### PR TITLE
melhora navegação do database

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ import SheetList from './components/screens/SheetList';
 import SuperiorItems from './components/screens/SuperiorItems';
 import store, { persistor } from './store';
 import AttributeRollResult from './components/SheetBuilder/common/AttributeRollResult';
-import logo from './assets/images/tormenta-logo-eye.png';
+// import CreatureSheet from './components/screens/CreatureSheet';
 
 declare module 'notistack' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -209,22 +209,21 @@ function App(): JSX.Element {
                   >
                     <Box
                       sx={{
-                        width: '100%',
-                        m: 0,
+                        width: isMb ? '90%' : '50%',
+                        m: 2,
                         p: 2,
                         backgroundColor: '#d13235',
-                        borderRadius: '0',
+                        borderRadius: '0.75rem',
                         color: '#FFFFFF',
                         zIndex: 2,
-                        boxSizing: 'border-box',
                       }}
                     >
                       <Stack
                         width='100%'
                         direction='row'
-                        justifyContent='flex-start'
+                        justifyContent='space-between'
                         alignItems='center'
-                      > 
+                      >
                         <IconButton
                           onClick={onClickMenu}
                           edge='start'
@@ -233,7 +232,6 @@ function App(): JSX.Element {
                         >
                           <MenuIcon />
                         </IconButton>
-                        <img src={String(logo)} alt='Logo' className='logo' />
                         <Typography
                           sx={{ cursor: 'pointer', fontFamily: 'Tfont' }}
                           variant='h6'
@@ -242,12 +240,7 @@ function App(): JSX.Element {
                           Fichas de Nimb
                         </Typography>
 
-                        <FormGroup
-                          sx={{
-                            display: isMb ? 'none' : 'flex',
-                            marginLeft: 'auto',
-                          }}
-                        >
+                        <FormGroup sx={{ ml: ['15px', 0, 0] }}>
                           <FormControlLabel
                             labelPlacement='end'
                             control={

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ import SheetList from './components/screens/SheetList';
 import SuperiorItems from './components/screens/SuperiorItems';
 import store, { persistor } from './store';
 import AttributeRollResult from './components/SheetBuilder/common/AttributeRollResult';
-// import CreatureSheet from './components/screens/CreatureSheet';
+import logo from './assets/images/tormenta-logo-eye.png';
 
 declare module 'notistack' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -209,21 +209,22 @@ function App(): JSX.Element {
                   >
                     <Box
                       sx={{
-                        width: isMb ? '90%' : '50%',
-                        m: 2,
+                        width: '100%',
+                        m: 0,
                         p: 2,
                         backgroundColor: '#d13235',
-                        borderRadius: '0.75rem',
+                        borderRadius: '0',
                         color: '#FFFFFF',
                         zIndex: 2,
+                        boxSizing: 'border-box',
                       }}
                     >
                       <Stack
                         width='100%'
                         direction='row'
-                        justifyContent='space-between'
+                        justifyContent='flex-start'
                         alignItems='center'
-                      >
+                      > 
                         <IconButton
                           onClick={onClickMenu}
                           edge='start'
@@ -232,6 +233,7 @@ function App(): JSX.Element {
                         >
                           <MenuIcon />
                         </IconButton>
+                        <img src={String(logo)} alt='Logo' className='logo' />
                         <Typography
                           sx={{ cursor: 'pointer', fontFamily: 'Tfont' }}
                           variant='h6'
@@ -240,7 +242,12 @@ function App(): JSX.Element {
                           Fichas de Nimb
                         </Typography>
 
-                        <FormGroup sx={{ ml: ['15px', 0, 0] }}>
+                        <FormGroup
+                          sx={{
+                            display: isMb ? 'none' : 'flex',
+                            marginLeft: 'auto',
+                          }}
+                        >
                           <FormControlLabel
                             labelPlacement='end'
                             control={

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,7 +4,6 @@ import MenuList from '@mui/material/MenuList';
 import MenuItem from '@mui/material/MenuItem';
 import Link from '@mui/material/Link';
 import { withRouter, useHistory } from 'react-router-dom';
-// import { makeStyles } from '@mui/material/styles';
 import { RouteComponentProps } from 'react-router';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import Paper from '@mui/material/Paper';

--- a/src/components/screens/Database.tsx
+++ b/src/components/screens/Database.tsx
@@ -37,10 +37,12 @@ const DatabaseMenuItem: React.FC<{
         justifyContent: 'center',
         alignItems: 'center',
         fontSize: isMobile ? 14 : 20,
-        width: isMobile ? 100 : 150,
+        width: isMobile ? 'calc(33% - 5px)' : 150,
+        height: isMobile ? 64 : 'auto',
         cursor: 'pointer',
         background: selected ? '#d13235' : 'white',
         color: selected ? 'white' : '#d13235',
+        marginLeft: isMobile ? 0 : 0,
       }}
       onClick={onClick}
       disabled={disabled}
@@ -81,15 +83,18 @@ const Database: React.FC<IProps> = () => {
         spacing={2}
         justifyContent='start'
         alignItems='start'
-        sx={{ mt: 2, mb: 2 }}
+        sx={{ mt: 0, mb: 2 }}
       >
-        <Stack
-          direction={isMobile ? 'row' : 'column'}
-          spacing={2}
-          justifyContent='center'
-          alignItems='start'
-          sx={{
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: isMobile ? 'row' : 'column',
+            position: 'sticky',
+            top: 10,
+            bottom: 10,
+            gap: 8,
             flexWrap: isMobile ? 'wrap' : 'nowrap',
+            zIndex: 10
           }}
         >
           <DatabaseMenuItem
@@ -128,7 +133,7 @@ const Database: React.FC<IProps> = () => {
             title='Magias'
             icon={<AutoFixHighIcon />}
           />
-        </Stack>
+        </div>
 
         <Switch>
           <Route exact path={path}>

--- a/src/components/screens/Database.tsx
+++ b/src/components/screens/Database.tsx
@@ -94,7 +94,7 @@ const Database: React.FC<IProps> = () => {
             bottom: 10,
             gap: 8,
             flexWrap: isMobile ? 'wrap' : 'nowrap',
-            zIndex: 10
+            zIndex: 2,
           }}
         >
           <DatabaseMenuItem


### PR DESCRIPTION
- No mobile e no desktop, a navegação permanece na tela durante o scroll
- No mobile os botões de navegação ficam alinhados em um grid

![image](https://github.com/YuriAlessandro/gerador-ficha-tormenta20/assets/5921856/b3ae25a0-b371-478c-ab43-47a624a051ef)

![image](https://github.com/YuriAlessandro/gerador-ficha-tormenta20/assets/5921856/2b5e7fed-755d-4a33-8c48-ba55f455c4ef)
