### PR TITLE
fix: devotion rule for races and roles

### DIFF
--- a/src/components/SheetBuilder/SheetBuilderForm/SheetBuilderFormStep/SheetBuilderFormStepDevotionDefinition/DevotionSelect.tsx
+++ b/src/components/SheetBuilder/SheetBuilderForm/SheetBuilderFormStep/SheetBuilderFormStepDevotionDefinition/DevotionSelect.tsx
@@ -46,15 +46,11 @@ const DevotionSelect: React.FC<Props> = ({
           ? devotion.deity.allowedToDevote.roles.includes(roleName)
           : true;
 
-      if (!isRaceAllowedToDevote) {
+      if (!isRaceAllowedToDevote && !isRoleAllowedToDevote) {
         setNotAllowed(
-          `A raça selecionada (${raceName}) não permite essa devoção.`
-        );
-        return;
-      }
-      if (!isRoleAllowedToDevote) {
-        setNotAllowed(
-          `A classe selecionada (${roleName}) não permite essa devoção.`
+          `Essa divindade não aceita devotos da combinação ${Translator.getRaceTranslation(
+            raceName
+          )} e ${Translator.getRoleTranslation(roleName)}`
         );
         return;
       }


### PR DESCRIPTION
Para ser devoto, sua raça ou sua classe devem estar na lista. Da forma que estava, tinham que estar ambos.