### PR TITLE
fix: correct learnAnySpellFromHighestCircle spell selection handling

### DIFF
--- a/src/components/SidebarV2/SidebarV2.tsx
+++ b/src/components/SidebarV2/SidebarV2.tsx
@@ -45,7 +45,7 @@ import { useAuth } from '../../hooks/useAuth';
 import { useAuthContext } from '../../contexts/AuthContext';
 // import { useDice3D } from '../../contexts/Dice3DContext';
 
-const APP_VERSION = '4.0.1';
+const APP_VERSION = '4.0.1.1';
 
 interface SidebarV2Props {
   visible: boolean;

--- a/src/functions/general.ts
+++ b/src/functions/general.ts
@@ -1496,13 +1496,23 @@ export const applyPower = (
           sheet.classe.spellPath?.spellCircleAvailableAtLevel(sheet.nivel) || 1;
 
         let allSpellsOfCircle: Spell[] = [];
-        if (sheetAction.action.allowedType === 'Arcane') {
-          allSpellsOfCircle = getArcaneSpellsOfCircle(highestCircle);
-        } else if (sheetAction.action.allowedType === 'Divine') {
-          allSpellsOfCircle = getSpellsOfCircle(highestCircle);
-        } else {
-          allSpellsOfCircle = getSpellsOfCircle(highestCircle);
+        for (let circle = 1; circle <= highestCircle; circle += 1) {
+          if (sheetAction.action.allowedType === 'Arcane') {
+            allSpellsOfCircle.push(...getArcaneSpellsOfCircle(circle));
+          } else if (sheetAction.action.allowedType === 'Divine') {
+            allSpellsOfCircle.push(...getSpellsOfCircle(circle));
+          } else {
+            // Both - combina arcanas e divinas
+            allSpellsOfCircle.push(...getArcaneSpellsOfCircle(circle));
+            allSpellsOfCircle.push(...getSpellsOfCircle(circle));
+          }
         }
+
+        // Remove duplicatas
+        allSpellsOfCircle = allSpellsOfCircle.filter(
+          (spell, index, array) =>
+            array.findIndex((s) => s.nome === spell.nome) === index
+        );
 
         const allowedSchools = sheetAction.action.schools || [];
         const availableSpells = allSpellsOfCircle.filter((spell) => {
@@ -2853,7 +2863,7 @@ export function applyManualLevelUp(
       const [newSheet, newSubSteps] = applyPower(
         updatedSheet,
         newPower,
-        selections.powerEffectSelections
+        selections.powerEffectSelections?.[newPower.name]
       );
       nSubSteps.push(...newSubSteps);
       if (newSheet) updatedSheet = newSheet;
@@ -2895,7 +2905,7 @@ export function applyManualLevelUp(
     const [newSheet, newSubSteps] = applyPower(
       updatedSheet,
       newPower,
-      selections.powerEffectSelections
+      selections.powerEffectSelections?.[newPower.name]
     );
     nSubSteps.push(...newSubSteps);
     if (newSheet) updatedSheet = newSheet;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ import { VitePWA } from 'vite-plugin-pwa';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
 
 // Version used for cache naming - changing this invalidates all PWA caches
-const APP_VERSION = '4.0.1';
+const APP_VERSION = '4.0.1.1';
 
 // Plugin to handle SPA routing for paths with dots (e.g., /perfil/user.name)
 // This runs AFTER Vite's middleware to catch 404s on client-side routes


### PR DESCRIPTION
- Fix spell list generation for 'Both' type to include Arcane and Divine spells from all circles (1 to highest), not just Divine from highest
- Fix applyManualLevelUp to pass power-specific selections to applyPower instead of the entire ManualPowerSelections object
- Bump version to 4.0.1.1