### PR TITLE
feat: modificações de itens superiores do Heróis de Arton

### DIFF
--- a/src/components/SheetResult/BackpackModal/BackpackModal.tsx
+++ b/src/components/SheetResult/BackpackModal/BackpackModal.tsx
@@ -311,6 +311,7 @@ const BackpackModal: React.FC<BackpackModalProps> = ({
       offHandItemId: staged.offHandItemId,
       wornArmorId: staged.wornArmorId,
       backpackGroupByCategory: staged.groupByCategory,
+      sheetBonuses: recalculated.sheetBonuses ?? sheet.sheetBonuses,
       steps: [...sheet.steps, editStep],
     });
 

--- a/src/components/SheetResult/BackpackModal/ItemModificationsEditor.tsx
+++ b/src/components/SheetResult/BackpackModal/ItemModificationsEditor.tsx
@@ -24,6 +24,7 @@ import {
   addModificationWithPrerequisites,
   calculateModificationCost,
   formatPrerequisite,
+  removeModificationWithDependents,
   validateModificationRequirement,
 } from '../../../utils/superiorItemsValidation';
 
@@ -112,13 +113,29 @@ const ItemModificationsEditor: React.FC<ItemModificationsEditorProps> = ({
     _event: React.SyntheticEvent,
     value: ItemMod[]
   ) => {
-    const expanded = value.reduce<ItemMod[]>(
-      (acc, selectedMod) =>
-        addModificationWithPrerequisites(selectedMod, acc, allMods),
-      []
+    // Detect removal vs addition by comparing with the previous selection.
+    // For removal: cascata via removeModificationWithDependents to drop
+    // dependents that lose their prereqs. For addition: auto-add missing
+    // prereqs (or the first option of an OR-prereq) via
+    // addModificationWithPrerequisites.
+    const removed = selectedModifications.find(
+      (prev) => !value.some((v) => v.mod === prev.mod)
     );
+    let computed: ItemMod[];
+    if (removed) {
+      computed = removeModificationWithDependents(
+        removed,
+        selectedModifications
+      );
+    } else {
+      computed = value.reduce<ItemMod[]>(
+        (acc, selectedMod) =>
+          addModificationWithPrerequisites(selectedMod, acc, allMods),
+        []
+      );
+    }
 
-    const cost = calculateModificationCost(expanded);
+    const cost = calculateModificationCost(computed);
     if (cost > maxCost) {
       if (onError) {
         onError(
@@ -130,11 +147,11 @@ const ItemModificationsEditor: React.FC<ItemModificationsEditorProps> = ({
 
     if (onError) onError('');
 
-    if (!expanded.some((mod) => mod.mod === 'Material especial')) {
+    if (!computed.some((mod) => mod.mod === 'Material especial')) {
       if (selectedMaterial) onSelectedMaterialChange('');
     }
 
-    onChange(expanded);
+    onChange(computed);
   };
 
   const totalCost = calculateModificationCost(selectedModifications);

--- a/src/components/SheetResult/BackpackModal/ItemModificationsEditor.tsx
+++ b/src/components/SheetResult/BackpackModal/ItemModificationsEditor.tsx
@@ -23,6 +23,8 @@ import {
 import {
   addModificationWithPrerequisites,
   calculateModificationCost,
+  formatPrerequisite,
+  validateModificationRequirement,
 } from '../../../utils/superiorItemsValidation';
 
 export type ModificationItemType = 'weapon' | 'armor' | 'shield';
@@ -103,12 +105,8 @@ const ItemModificationsEditor: React.FC<ItemModificationsEditorProps> = ({
     [allMods, selectedModifications]
   );
 
-  const isOptionDisabled = (mod: ItemMod): boolean => {
-    if (!mod.prerequisite) return false;
-    return !selectedModifications.some(
-      (selected) => selected.mod === mod.prerequisite
-    );
-  };
+  const isOptionDisabled = (mod: ItemMod): boolean =>
+    !validateModificationRequirement(mod, selectedModifications);
 
   const handleSelectionChange = (
     _event: React.SyntheticEvent,
@@ -262,7 +260,7 @@ const ItemModificationsEditor: React.FC<ItemModificationsEditorProps> = ({
                       color={optionDisabled ? 'error.main' : 'warning.main'}
                       sx={{ display: 'block' }}
                     >
-                      Requer: {option.prerequisite}
+                      Requer: {formatPrerequisite(option.prerequisite)}
                     </Typography>
                   )}
                 </Box>

--- a/src/components/SheetResult/Result.tsx
+++ b/src/components/SheetResult/Result.tsx
@@ -1063,6 +1063,37 @@ const Result: React.FC<ResultProps> = (props) => {
       components.push(`${currentSheet.bonusDefense} (bônus manual)`);
     }
 
+    // SheetBonuses targeting Defense (Fixed modifiers — equipment mods like
+    // Guarda, condition bonuses, etc.). Aggregate by source label so multiple
+    // bonuses from the same source render as a single entry.
+    const labelForSource = (
+      s: (typeof currentSheet.sheetBonuses)[0]['source']
+    ) => {
+      if (s.type === 'equipment') return s.equipmentName;
+      if (s.type === 'power') return s.name;
+      if (s.type === 'condition') return s.conditionId;
+      if (s.type === 'levelUp') return `Nível ${s.level}`;
+      if (s.type === 'origin') return s.originName;
+      if (s.type === 'race') return s.raceName;
+      if (s.type === 'class') return s.className;
+      if (s.type === 'divinity') return s.divinityName;
+      return null;
+    };
+    const defenseBonusBySource = new Map<string, number>();
+    currentSheet.sheetBonuses.forEach((b) => {
+      if (b.target.type !== 'Defense') return;
+      if (b.modifier.type !== 'Fixed') return;
+      const label = labelForSource(b.source);
+      if (!label) return;
+      defenseBonusBySource.set(
+        label,
+        (defenseBonusBySource.get(label) ?? 0) + b.modifier.value
+      );
+    });
+    defenseBonusBySource.forEach((value, label) => {
+      if (value !== 0) components.push(`${value} (${label})`);
+    });
+
     return `${components.join(' + ')} = ${defesa}`;
   }, [
     currentSheet,

--- a/src/components/screens/SuperiorItems.tsx
+++ b/src/components/screens/SuperiorItems.tsx
@@ -48,7 +48,11 @@ import {
   GeneratedSuperiorItem,
   SuperiorItemsState,
 } from '../../interfaces/SuperiorItems';
-import { validateModificationCombination } from '../../utils/superiorItemsValidation';
+import {
+  formatPrerequisite,
+  validateModificationCombination,
+  validateModificationRequirement,
+} from '../../utils/superiorItemsValidation';
 import { getSpecialMaterialData } from '../../data/systems/tormenta20/specialMaterials';
 import { useAuth } from '../../hooks/useAuth';
 import { TORMENTA20_SYSTEM } from '../../data/systems/tormenta20';
@@ -159,9 +163,7 @@ const SuperiorItems: React.FC<{ isDarkMode: boolean }> = () => {
 
       // Check prerequisite
       if (mod.prerequisite) {
-        return selectedMods.some(
-          (selected) => selected.mod === mod.prerequisite
-        );
+        return validateModificationRequirement(mod, selectedMods);
       }
 
       // Check cost
@@ -198,14 +200,16 @@ const SuperiorItems: React.FC<{ isDarkMode: boolean }> = () => {
       let canAddMod = true;
       let totalCostNeeded = selectedMod.double ? 2 : 1;
 
-      // Add prerequisites if needed
+      // Add prerequisites if needed (para OR, escolhe o primeiro do array)
       if (
         selectedMod.prerequisite &&
-        !selectedMods.some((mod) => mod.mod === selectedMod.prerequisite)
+        !validateModificationRequirement(selectedMod, selectedMods)
       ) {
-        const prerequisite = allMods.find(
-          (mod) => mod.mod === selectedMod.prerequisite
-        );
+        const prereqList = Array.isArray(selectedMod.prerequisite)
+          ? selectedMod.prerequisite
+          : [selectedMod.prerequisite];
+        const [firstPrereq] = prereqList;
+        const prerequisite = allMods.find((mod) => mod.mod === firstPrereq);
         if (prerequisite) {
           const prereqCost = prerequisite.double ? 2 : 1;
           totalCostNeeded += prereqCost;
@@ -729,7 +733,8 @@ const SuperiorItems: React.FC<{ isDarkMode: boolean }> = () => {
                                       variant='caption'
                                       color='warning.main'
                                     >
-                                      Pré-requisito: {mod.prerequisite}
+                                      Pré-requisito:{' '}
+                                      {formatPrerequisite(mod.prerequisite)}
                                     </Typography>
                                   )}
                                 </AccordionDetails>

--- a/src/data/systems/tormenta20/herois-de-arton/improvements/index.ts
+++ b/src/data/systems/tormenta20/herois-de-arton/improvements/index.ts
@@ -81,7 +81,7 @@ export const armorImprovements: ItemMod[] = [
     mod: 'Deslumbrante',
     description:
       '+1 na CD para resistir às suas habilidades baseadas em Carisma. Apenas armaduras e vestuários.',
-    prerequisite: 'Banhada a ouro',
+    prerequisite: ['Banhada a ouro', 'Cravejada de gemas'],
     appliesTo: 'armor',
     supplementId: SupplementId.TORMENTA20_HEROIS_ARTON,
   },

--- a/src/data/systems/tormenta20/herois-de-arton/improvements/index.ts
+++ b/src/data/systems/tormenta20/herois-de-arton/improvements/index.ts
@@ -3,9 +3,10 @@ import { SupplementId } from '@/types/supplement.types';
 
 /**
  * Novas Melhorias do suplemento Heróis de Arton (cap. 3 - Arsenal dos Heróis,
- * pp. 239-240). Todas têm efeitos condicionais ou que dependem de subtipo de
- * item (munição, arma corpo a corpo, escudo) — por isso são marcadas como
- * text-only em modificationEffects.ts e a descrição informa o jogador.
+ * pp. 239-240). A maioria tem efeitos condicionais ou que dependem de subtipo
+ * de item (munição, arma corpo a corpo, escudo), então são text-only em
+ * modificationEffects.ts e a descrição informa o jogador. Exceção: Guarda
+ * aplica +1 de Defesa numericamente.
  *
  * Não inclui (por enquanto) melhorias específicas de categorias não
  * suportadas pelo editor: Potencializador (esotéricos), Brasonado e Usado
@@ -38,7 +39,7 @@ export const weaponImprovements: ItemMod[] = [
     max: 0,
     mod: 'Guarda',
     description:
-      '+1 na Defesa e em testes contra manobras. Apenas armas corpo a corpo.',
+      '+1 na Defesa (aplicado automaticamente) e em testes contra manobras. Apenas armas corpo a corpo.',
     appliesTo: 'weapon',
     supplementId: SupplementId.TORMENTA20_HEROIS_ARTON,
   },

--- a/src/data/systems/tormenta20/herois-de-arton/improvements/index.ts
+++ b/src/data/systems/tormenta20/herois-de-arton/improvements/index.ts
@@ -1,0 +1,112 @@
+import { ItemMod } from '@/interfaces/Rewards';
+import { SupplementId } from '@/types/supplement.types';
+
+/**
+ * Novas Melhorias do suplemento Heróis de Arton (cap. 3 - Arsenal dos Heróis,
+ * pp. 239-240). Todas têm efeitos condicionais ou que dependem de subtipo de
+ * item (munição, arma corpo a corpo, escudo) — por isso são marcadas como
+ * text-only em modificationEffects.ts e a descrição informa o jogador.
+ *
+ * Não inclui (por enquanto) melhorias específicas de categorias não
+ * suportadas pelo editor: Potencializador (esotéricos), Brasonado e Usado
+ * (ferramentas/vestuário).
+ */
+
+// Melhorias para armas
+export const weaponImprovements: ItemMod[] = [
+  {
+    min: 0,
+    max: 0,
+    mod: 'Farpada',
+    description:
+      'Acerto crítico provoca sangramento (-5 em Constituição para remover). Apenas armas de corte ou perfuração.',
+    prerequisite: 'Cruel',
+    appliesTo: 'weapon',
+    supplementId: SupplementId.TORMENTA20_HEROIS_ARTON,
+  },
+  {
+    min: 0,
+    max: 0,
+    mod: 'Fósforo',
+    description:
+      'Apenas munições. Dano diminui em um passo, mas alvo atingido fica ofuscado por 1 rodada.',
+    appliesTo: 'weapon',
+    supplementId: SupplementId.TORMENTA20_HEROIS_ARTON,
+  },
+  {
+    min: 0,
+    max: 0,
+    mod: 'Guarda',
+    description:
+      '+1 na Defesa e em testes contra manobras. Apenas armas corpo a corpo.',
+    appliesTo: 'weapon',
+    supplementId: SupplementId.TORMENTA20_HEROIS_ARTON,
+  },
+  {
+    min: 0,
+    max: 0,
+    mod: 'Incendiária',
+    description:
+      'Apenas munições. +1 de dano de fogo; se acertar por 5 ou mais, deixa o alvo em chamas.',
+    appliesTo: 'weapon',
+    supplementId: SupplementId.TORMENTA20_HEROIS_ARTON,
+  },
+  {
+    min: 0,
+    max: 0,
+    mod: 'Pressurizada',
+    description:
+      '+2 em ataque e dano ao acionar mecanismo (ação completa). Apenas armas corpo a corpo de impacto e armas de fogo.',
+    appliesTo: 'weapon',
+    supplementId: SupplementId.TORMENTA20_HEROIS_ARTON,
+  },
+];
+
+// Melhorias para armaduras e escudos
+export const armorImprovements: ItemMod[] = [
+  {
+    min: 0,
+    max: 0,
+    mod: 'Balístico',
+    description:
+      'Apenas escudos. Gasta uma bala (até 2 cargas) para aumentar o dano do escudo em +2d6.',
+    prerequisite: 'Reforçada',
+    appliesTo: 'shield',
+    supplementId: SupplementId.TORMENTA20_HEROIS_ARTON,
+  },
+  {
+    min: 0,
+    max: 0,
+    mod: 'Deslumbrante',
+    description:
+      '+1 na CD para resistir às suas habilidades baseadas em Carisma. Apenas armaduras e vestuários.',
+    prerequisite: 'Banhada a ouro',
+    appliesTo: 'armor',
+    supplementId: SupplementId.TORMENTA20_HEROIS_ARTON,
+  },
+  {
+    min: 0,
+    max: 0,
+    mod: 'Injetora',
+    description:
+      'Apenas armaduras. Mecanismo injetor com 1 dose de preparado ou poção, acionado por uma ação de movimento.',
+    appliesTo: 'armor',
+    supplementId: SupplementId.TORMENTA20_HEROIS_ARTON,
+  },
+  {
+    min: 0,
+    max: 0,
+    mod: 'Prudente',
+    description:
+      'Apenas armaduras. 1 vez/dia, ao usar Falhas Críticas, role duas vezes na Tabela 4-6 e escolha o resultado.',
+    appliesTo: 'armor',
+    supplementId: SupplementId.TORMENTA20_HEROIS_ARTON,
+  },
+];
+
+const HEROIS_ARTON_IMPROVEMENTS = {
+  weapons: weaponImprovements,
+  armors: armorImprovements,
+};
+
+export default HEROIS_ARTON_IMPROVEMENTS;

--- a/src/data/systems/tormenta20/herois-de-arton/index.ts
+++ b/src/data/systems/tormenta20/herois-de-arton/index.ts
@@ -8,6 +8,7 @@ import HEROIS_ARTON_RACES from './races';
 import HEROIS_ARTON_CLASSES from './classes';
 import HEROIS_ARTON_POWERS from './powers';
 import HEROIS_ARTON_EQUIPMENT from './equipment';
+import HEROIS_ARTON_IMPROVEMENTS from './improvements';
 import HEROIS_ARTON_ORIGINS from './origins';
 import HEROIS_ARTON_CLASS_POWERS from './classPowers';
 import HEROIS_ARTON_GOLPE_PESSOAL_EFFECTS from './golpePessoalEffects';
@@ -28,6 +29,7 @@ export const TORMENTA20_HEROIS_ARTON_SUPPLEMENT: SupplementData = {
     [GeneralPowerType.RACA]: HEROIS_ARTON_POWERS[GeneralPowerType.RACA],
   },
   equipment: HEROIS_ARTON_EQUIPMENT,
+  improvements: HEROIS_ARTON_IMPROVEMENTS,
   origins: HEROIS_ARTON_ORIGINS,
   classPowers: HEROIS_ARTON_CLASS_POWERS,
   golpePessoalEffects: HEROIS_ARTON_GOLPE_PESSOAL_EFFECTS,

--- a/src/functions/equipmentRewardGenerator.ts
+++ b/src/functions/equipmentRewardGenerator.ts
@@ -17,6 +17,7 @@ import Equipment, {
 } from '../interfaces/Equipment';
 
 import { rollDice } from './randomUtils';
+import { isPrereqMetByNames } from '../utils/superiorItemsValidation';
 import Bag from '../interfaces/Bag';
 
 /**
@@ -166,7 +167,10 @@ function applyWeaponModifications(
     // Filtrar modificações disponíveis (que não foram usadas e atendem pré-requisitos)
     const availableMods = weaponsModifications.filter((mod) => {
       if (takenMods.includes(mod.mod)) return false;
-      if (mod.prerequisite && !appliedMods.includes(mod.prerequisite))
+      if (
+        mod.prerequisite &&
+        !isPrereqMetByNames(mod.prerequisite, appliedMods)
+      )
         return false;
       return true;
     });
@@ -258,7 +262,10 @@ function applyArmorModifications(
     // Filtrar modificações disponíveis
     const availableMods = armorsModifications.filter((mod) => {
       if (takenMods.includes(mod.mod)) return false;
-      if (mod.prerequisite && !appliedMods.includes(mod.prerequisite))
+      if (
+        mod.prerequisite &&
+        !isPrereqMetByNames(mod.prerequisite, appliedMods)
+      )
         return false;
       return true;
     });

--- a/src/functions/modifications/__tests__/applyModifications.spec.ts
+++ b/src/functions/modifications/__tests__/applyModifications.spec.ts
@@ -228,4 +228,21 @@ describe('applyModificationsToEquipment', () => {
     expect(result.atkBonus).toBe(0);
     expect(result.critico).toBe('x2');
   });
+
+  test('Guarda emits a Defense SheetBonus on a weapon', () => {
+    const item: Equipment = {
+      ...baseSword,
+      modifications: [{ mod: 'Guarda' }],
+    };
+    const result = applyModificationsToEquipment(item);
+    const defenseBonus = (result.sheetBonuses ?? []).find(
+      (b) => b.target.type === 'Defense'
+    );
+    expect(defenseBonus).toBeDefined();
+    if (defenseBonus && defenseBonus.modifier.type === 'Fixed') {
+      expect(defenseBonus.modifier.value).toBe(1);
+    }
+    expect(result.atkBonus).toBe(0);
+    expect(result.dano).toBe('1d8');
+  });
 });

--- a/src/functions/modifications/__tests__/applyModifications.spec.ts
+++ b/src/functions/modifications/__tests__/applyModifications.spec.ts
@@ -245,4 +245,16 @@ describe('applyModificationsToEquipment', () => {
     expect(result.atkBonus).toBe(0);
     expect(result.dano).toBe('1d8');
   });
+
+  test('captures empty baseSheetBonuses on first apply when item had none', () => {
+    const item: Equipment = {
+      ...baseSword,
+      modifications: [{ mod: 'Guarda' }],
+    };
+    const result = applyModificationsToEquipment(item);
+    expect(result.baseSheetBonuses).toEqual([]);
+    // Re-running on the result must not promote modBonuses into baseSheetBonuses
+    const second = applyModificationsToEquipment(result);
+    expect(second.baseSheetBonuses).toEqual([]);
+  });
 });

--- a/src/functions/modifications/applyModifications.ts
+++ b/src/functions/modifications/applyModifications.ts
@@ -87,6 +87,8 @@ interface AggregatedDelta {
     skill: import('../../interfaces/Skills').default;
     value: number;
   }[];
+  /** Soma de bônus cross-cutting de Defesa (SheetBonus target Defense). */
+  defenseBonusFromSheetBonus: number;
 }
 
 function aggregate(modifications: AppliedModification[]): AggregatedDelta {
@@ -99,6 +101,7 @@ function aggregate(modifications: AppliedModification[]): AggregatedDelta {
     armorPenaltyDelta: 0,
     spacesDelta: 0,
     skillBonuses: [],
+    defenseBonusFromSheetBonus: 0,
   };
 
   modifications.forEach(({ mod }) => {
@@ -116,6 +119,7 @@ function aggregate(modifications: AppliedModification[]): AggregatedDelta {
     }
     acc.spacesDelta += effect.spacesDelta ?? 0;
     if (effect.skillBonuses) acc.skillBonuses.push(...effect.skillBonuses);
+    acc.defenseBonusFromSheetBonus += effect.defenseBonus ?? 0;
   });
 
   return acc;
@@ -227,6 +231,13 @@ export function applyModificationsToEquipment<T extends Equipment>(item: T): T {
     target: { type: 'Skill', name: sb.skill },
     modifier: { type: 'Fixed', value: sb.value },
   }));
+  if (delta.defenseBonusFromSheetBonus !== 0) {
+    modBonuses.push({
+      source: { type: 'equipment', equipmentName: result.nome },
+      target: { type: 'Defense' },
+      modifier: { type: 'Fixed', value: delta.defenseBonusFromSheetBonus },
+    });
+  }
   result.sheetBonuses = [...baseBonuses, ...modBonuses];
 
   return result;

--- a/src/functions/modifications/applyModifications.ts
+++ b/src/functions/modifications/applyModifications.ts
@@ -143,11 +143,8 @@ function captureBaseValues<T extends Equipment>(item: T): T {
   if (item.spaces !== undefined && result.baseSpaces === undefined) {
     result.baseSpaces = item.spaces;
   }
-  if (
-    item.sheetBonuses !== undefined &&
-    result.baseSheetBonuses === undefined
-  ) {
-    result.baseSheetBonuses = item.sheetBonuses;
+  if (result.baseSheetBonuses === undefined) {
+    result.baseSheetBonuses = item.sheetBonuses ?? [];
   }
   if (isDefenseEquipment(item)) {
     const defenseItem = item as unknown as DefenseEquipment;

--- a/src/functions/modifications/modificationEffects.ts
+++ b/src/functions/modifications/modificationEffects.ts
@@ -27,6 +27,13 @@ export interface ModificationEffect {
   };
   spacesDelta?: number;
   skillBonuses?: { skill: Skill; value: number }[];
+  /**
+   * Bônus de Defesa concedido pelo item a quem o porta (SheetBonus com target
+   * `Defense`). Diferente de `defenseStats.defenseBonusDelta`, que ajusta
+   * apenas o `defenseBonus` interno de armaduras/escudos. Útil para mods de
+   * arma que dão Defesa ao empunhador (ex.: Guarda).
+   */
+  defenseBonus?: number;
 }
 
 export const modificationEffects: Record<string, ModificationEffect> = {
@@ -65,6 +72,11 @@ export const modificationEffects: Record<string, ModificationEffect> = {
       { skill: Skill.DIPLOMACIA, value: 2 },
     ],
   },
+
+  // Heróis de Arton — armas
+  // O bônus em testes contra manobras não é representável no modelo atual
+  // (não há target "Maneuver"), então apenas a Defesa é aplicada.
+  Guarda: { defenseBonus: 1 },
 };
 
 /**
@@ -86,12 +98,12 @@ export const TEXT_ONLY_MODIFICATIONS: ReadonlySet<string> = new Set([
   'Selada',
   'Delicada',
   'Espinhosa',
-  // Heróis de Arton
+  // Heróis de Arton (todas com efeitos condicionais ou dependentes de subtipo
+  // de item, salvo Guarda que aplica +1 Defesa numericamente)
   'Balístico',
   'Deslumbrante',
   'Farpada',
   'Fósforo',
-  'Guarda',
   'Incendiária',
   'Injetora',
   'Pressurizada',

--- a/src/functions/modifications/modificationEffects.ts
+++ b/src/functions/modifications/modificationEffects.ts
@@ -70,6 +70,12 @@ export const modificationEffects: Record<string, ModificationEffect> = {
 /**
  * Mods recognized by the catalog but with no numeric effect — kept here purely
  * for documentation purposes (TODO: future iterations may model these).
+ *
+ * As entradas de Heróis de Arton (Farpada, Fósforo, Guarda, Incendiária,
+ * Pressurizada, Balístico, Deslumbrante, Injetora, Prudente) ficam aqui porque
+ * têm efeitos condicionais (ativação por ação, dano de tipo específico,
+ * limites por subtipo de item) que não são representáveis pelos deltas
+ * numéricos suportados por aplicação automática.
  */
 export const TEXT_ONLY_MODIFICATIONS: ReadonlySet<string> = new Set([
   'Harmonizada',
@@ -80,4 +86,14 @@ export const TEXT_ONLY_MODIFICATIONS: ReadonlySet<string> = new Set([
   'Selada',
   'Delicada',
   'Espinhosa',
+  // Heróis de Arton
+  'Balístico',
+  'Deslumbrante',
+  'Farpada',
+  'Fósforo',
+  'Guarda',
+  'Incendiária',
+  'Injetora',
+  'Pressurizada',
+  'Prudente',
 ]);

--- a/src/functions/rewards/rewardsGenerator.ts
+++ b/src/functions/rewards/rewardsGenerator.ts
@@ -30,6 +30,7 @@ import {
   Rych,
 } from '../../interfaces/Rewards';
 import { getRandomItemFromArray, rollDice } from '../randomUtils';
+import { validateModificationRequirement } from '../../utils/superiorItemsValidation';
 
 export interface RewardGenerated {
   moneyRoll: number;
@@ -177,7 +178,7 @@ export const getWeaponModification = (mods: number): string => {
       if (takenMods.some((taken) => taken.mod === mod.mod)) return false;
 
       if (mod.prerequisite) {
-        return takenMods.some((taken) => taken.mod === mod.prerequisite);
+        return validateModificationRequirement(mod, takenMods);
       }
 
       return true;
@@ -232,7 +233,7 @@ export const getArmorModification = (mods: number): string => {
       if (takenMods.some((taken) => taken.mod === mod.mod)) return false;
 
       if (mod.prerequisite) {
-        return takenMods.some((taken) => taken.mod === mod.prerequisite);
+        return validateModificationRequirement(mod, takenMods);
       }
 
       return true;

--- a/src/interfaces/Rewards.ts
+++ b/src/interfaces/Rewards.ts
@@ -120,7 +120,16 @@ export interface ItemMod {
   max: number;
   mod: string;
   description?: string;
-  prerequisite?: string;
+  /**
+   * Pré-requisito(s) para aplicar esta modificação.
+   *
+   * - `string`: requer exatamente essa modificação aplicada antes (AND único).
+   * - `string[]`: requer **qualquer uma** das modificações listadas (OR).
+   *   Quando o usuário escolhe a mod dependente sem ter um prereq, o helper
+   *   `addModificationWithPrerequisites` adiciona automaticamente o primeiro
+   *   item do array.
+   */
+  prerequisite?: string | string[];
   double?: boolean;
   /** What item types this modification applies to */
   appliesTo?: 'weapon' | 'armor' | 'shield' | 'all';

--- a/src/utils/__tests__/superiorItemsValidation.spec.ts
+++ b/src/utils/__tests__/superiorItemsValidation.spec.ts
@@ -1,0 +1,175 @@
+import {
+  addModificationWithPrerequisites,
+  formatPrerequisite,
+  isPrereqMetByNames,
+  removeModificationWithDependents,
+  validateModificationCombination,
+  validateModificationRequirement,
+} from '../superiorItemsValidation';
+import { ItemMod } from '../../interfaces/Rewards';
+
+const banhada: ItemMod = {
+  min: 0,
+  max: 0,
+  mod: 'Banhada a ouro',
+};
+const cravejada: ItemMod = {
+  min: 0,
+  max: 0,
+  mod: 'Cravejada de gemas',
+};
+const deslumbrante: ItemMod = {
+  min: 0,
+  max: 0,
+  mod: 'Deslumbrante',
+  prerequisite: ['Banhada a ouro', 'Cravejada de gemas'],
+};
+const cruel: ItemMod = { min: 0, max: 0, mod: 'Cruel' };
+const atroz: ItemMod = {
+  min: 0,
+  max: 0,
+  mod: 'Atroz',
+  prerequisite: 'Cruel',
+};
+
+describe('formatPrerequisite', () => {
+  test('returns empty string when prereq is undefined', () => {
+    expect(formatPrerequisite(undefined)).toBe('');
+  });
+
+  test('returns the string as-is for single prereq', () => {
+    expect(formatPrerequisite('Cruel')).toBe('Cruel');
+  });
+
+  test('joins array prereqs with " ou "', () => {
+    expect(formatPrerequisite(['Banhada a ouro', 'Cravejada de gemas'])).toBe(
+      'Banhada a ouro ou Cravejada de gemas'
+    );
+  });
+});
+
+describe('validateModificationRequirement', () => {
+  test('passes when mod has no prerequisite', () => {
+    expect(validateModificationRequirement(cruel, [])).toBe(true);
+  });
+
+  test('passes when single prerequisite is satisfied', () => {
+    expect(validateModificationRequirement(atroz, [cruel])).toBe(true);
+  });
+
+  test('fails when single prerequisite is missing', () => {
+    expect(validateModificationRequirement(atroz, [])).toBe(false);
+  });
+
+  test('passes when first OR prerequisite is present', () => {
+    expect(validateModificationRequirement(deslumbrante, [banhada])).toBe(true);
+  });
+
+  test('passes when second OR prerequisite is present', () => {
+    expect(validateModificationRequirement(deslumbrante, [cravejada])).toBe(
+      true
+    );
+  });
+
+  test('fails when no OR prerequisite is present', () => {
+    expect(validateModificationRequirement(deslumbrante, [cruel])).toBe(false);
+  });
+});
+
+describe('validateModificationCombination', () => {
+  test('reports error with " ou "-joined prereqs for OR mods', () => {
+    const result = validateModificationCombination([deslumbrante]);
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toEqual([
+      'Deslumbrante requer Banhada a ouro ou Cravejada de gemas',
+    ]);
+    expect(result.missingPrerequisites).toEqual([
+      'Banhada a ouro',
+      'Cravejada de gemas',
+    ]);
+  });
+
+  test('valid when any OR prereq is present', () => {
+    const result = validateModificationCombination([cravejada, deslumbrante]);
+    expect(result.isValid).toBe(true);
+  });
+});
+
+describe('addModificationWithPrerequisites', () => {
+  const allMods = [banhada, cravejada, deslumbrante, cruel, atroz];
+
+  test('auto-adds the FIRST prereq from an OR list', () => {
+    const result = addModificationWithPrerequisites(deslumbrante, [], allMods);
+    expect(result.map((m) => m.mod)).toEqual([
+      'Banhada a ouro',
+      'Deslumbrante',
+    ]);
+  });
+
+  test('does not add prereq when any OR option already present', () => {
+    const result = addModificationWithPrerequisites(
+      deslumbrante,
+      [cravejada],
+      allMods
+    );
+    expect(result.map((m) => m.mod)).toEqual([
+      'Cravejada de gemas',
+      'Deslumbrante',
+    ]);
+  });
+
+  test('still works for single-prereq mods', () => {
+    const result = addModificationWithPrerequisites(atroz, [], allMods);
+    expect(result.map((m) => m.mod)).toEqual(['Cruel', 'Atroz']);
+  });
+});
+
+describe('removeModificationWithDependents', () => {
+  test('removes dependent when single prereq is removed', () => {
+    const result = removeModificationWithDependents(cruel, [cruel, atroz]);
+    expect(result).toEqual([]);
+  });
+
+  test('keeps OR-dependent when alternate prereq remains', () => {
+    const result = removeModificationWithDependents(banhada, [
+      banhada,
+      cravejada,
+      deslumbrante,
+    ]);
+    expect(result.map((m) => m.mod)).toEqual([
+      'Cravejada de gemas',
+      'Deslumbrante',
+    ]);
+  });
+
+  test('removes OR-dependent when last prereq is removed', () => {
+    const result = removeModificationWithDependents(banhada, [
+      banhada,
+      deslumbrante,
+    ]);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('isPrereqMetByNames', () => {
+  test('returns true when no prereq', () => {
+    expect(isPrereqMetByNames(undefined, [])).toBe(true);
+  });
+
+  test('matches single string against name list', () => {
+    expect(isPrereqMetByNames('Cruel', ['Cruel'])).toBe(true);
+    expect(isPrereqMetByNames('Cruel', [])).toBe(false);
+  });
+
+  test('matches OR array against name list', () => {
+    expect(
+      isPrereqMetByNames(
+        ['Banhada a ouro', 'Cravejada de gemas'],
+        ['Cravejada de gemas']
+      )
+    ).toBe(true);
+    expect(
+      isPrereqMetByNames(['Banhada a ouro', 'Cravejada de gemas'], ['Cruel'])
+    ).toBe(false);
+  });
+});

--- a/src/utils/superiorItemsValidation.ts
+++ b/src/utils/superiorItemsValidation.ts
@@ -6,18 +6,50 @@ export interface ValidationResult {
   errors: string[];
 }
 
+/** Normaliza um pré-requisito para array (`undefined` → `[]`). */
+const prereqList = (
+  prereq: string | string[] | undefined
+): readonly string[] => {
+  if (!prereq) return [];
+  return Array.isArray(prereq) ? prereq : [prereq];
+};
+
+/** Junta uma lista de pré-requisitos para exibir ao usuário. */
+export const formatPrerequisite = (
+  prereq: string | string[] | undefined
+): string => prereqList(prereq).join(' ou ');
+
+/**
+ * Variante de checagem de pré-requisito que opera sobre uma lista de nomes
+ * (em vez de `ItemMod[]`). Útil para reward generators que rastreiam só o
+ * nome da modificação tomada.
+ */
+export const isPrereqMetByNames = (
+  prereq: string | string[] | undefined,
+  appliedNames: readonly string[]
+): boolean => {
+  const list = prereqList(prereq);
+  if (list.length === 0) return true;
+  return list.some((name) => appliedNames.includes(name));
+};
+
+/**
+ * Verifica se ao menos um dos pré-requisitos está presente nas modificações
+ * tomadas. Pré-requisito ausente sempre conta como satisfeito.
+ */
+const isPrereqMet = (
+  prereq: string | string[] | undefined,
+  taken: ItemMod[]
+): boolean => {
+  const list = prereqList(prereq);
+  if (list.length === 0) return true;
+  return list.some((name) => taken.some((t) => t.mod === name));
+};
+
 export const validateModificationRequirement = (
   modification: ItemMod,
   selectedModifications: ItemMod[]
-): boolean => {
-  if (!modification.prerequisite) {
-    return true;
-  }
-
-  return selectedModifications.some(
-    (mod) => mod.mod === modification.prerequisite
-  );
-};
+): boolean => isPrereqMet(modification.prerequisite, selectedModifications);
 
 export const validateModificationCombination = (
   modifications: ItemMod[]
@@ -29,16 +61,15 @@ export const validateModificationCombination = (
   };
 
   modifications.forEach((mod) => {
-    if (mod.prerequisite) {
-      const hasPrerequisite = modifications.some(
-        (m) => m.mod === mod.prerequisite
-      );
-      if (!hasPrerequisite) {
-        result.isValid = false;
-        result.missingPrerequisites.push(mod.prerequisite);
-        result.errors.push(`${mod.mod} requer ${mod.prerequisite}`);
-      }
-    }
+    if (!mod.prerequisite) return;
+    if (isPrereqMet(mod.prerequisite, modifications)) return;
+
+    const list = prereqList(mod.prerequisite);
+    result.isValid = false;
+    result.missingPrerequisites.push(...list);
+    result.errors.push(
+      `${mod.mod} requer ${formatPrerequisite(mod.prerequisite)}`
+    );
   });
 
   return result;
@@ -51,17 +82,18 @@ export const addModificationWithPrerequisites = (
 ): ItemMod[] => {
   const result = [...currentModifications];
 
-  if (modification.prerequisite) {
-    const hasPrerequisite = result.some(
-      (mod) => mod.mod === modification.prerequisite
+  if (
+    modification.prerequisite &&
+    !isPrereqMet(modification.prerequisite, result)
+  ) {
+    // Para OR, adiciona o primeiro do array como escolha padrão. O usuário
+    // pode trocar removendo e selecionando outro pré-requisito antes.
+    const [firstPrereq] = prereqList(modification.prerequisite);
+    const prerequisiteMod = allModifications.find(
+      (mod) => mod.mod === firstPrereq
     );
-    if (!hasPrerequisite) {
-      const prerequisiteMod = allModifications.find(
-        (mod) => mod.mod === modification.prerequisite
-      );
-      if (prerequisiteMod) {
-        result.push(prerequisiteMod);
-      }
+    if (prerequisiteMod) {
+      result.push(prerequisiteMod);
     }
   }
 
@@ -95,9 +127,13 @@ export const removeModificationWithDependents = (
     (mod) => mod.mod !== modificationToRemove.mod
   );
 
-  const dependents = result.filter(
-    (mod) => mod.prerequisite === modificationToRemove.mod
-  );
+  // Remove em cascata só se NENHUM dos pré-requisitos restantes ainda satisfizer.
+  const dependents = result.filter((mod) => {
+    const list = prereqList(mod.prerequisite);
+    if (list.length === 0) return false;
+    if (!list.includes(modificationToRemove.mod)) return false;
+    return !isPrereqMet(mod.prerequisite, result);
+  });
 
   if (dependents.length > 0) {
     return dependents.reduce(


### PR DESCRIPTION
## Summary

Adiciona 9 melhorias do **Heróis de Arton** (cap. 3 — Arsenal dos Heróis, pp. 239-240) ao catálogo de modificações da Mochila.

- **Armas:** Farpada (req: Cruel), Fósforo, Guarda, Incendiária, Pressurizada
- **Armaduras/escudos:** Balístico (escudo, req: Reforçada), Deslumbrante (req: Banhada a ouro **ou** Cravejada de gemas), Injetora, Prudente

## Infra

- **Guarda numérico** (paralelo a Reforçada): novo campo `defenseBonus` em `ModificationEffect` emite `SheetBonus { target: 'Defense' }` no item, propagado por `applyEquipmentBonuses`.
- **Pré-requisito OR:** `ItemMod.prerequisite` aceita `string | string[]`. Helpers em `superiorItemsValidation`: `isPrereqMet`, `isPrereqMetByNames`, `formatPrerequisite`. Auto-add escolhe o primeiro do array; `removeModificationWithDependents` só faz cascata se nenhuma opção restante satisfizer.
- Demais 8 mods em `TEXT_ONLY_MODIFICATIONS` (efeitos condicionais/textuais).

Não incluídas: Potencializador (\`Esotérico\`), Brasonado (\`Vestuário\`), Usado (\`Item Geral\`) — o editor da Mochila hoje só suporta modificações em \`Arma\`/\`Armadura\`/\`Escudo\`.

## Limitação herdada

\`applyEquipmentBonuses\` propaga \`sheetBonuses\` de todos os itens da bag sem filtrar por wielding/worn — Guarda dá +1 Defesa mesmo com a arma guardada (igual a Discreta, Banhada a ouro). Fora do escopo.

## Test plan

- [x] Prettier, ESLint e tsc clean
- [x] 120 testes vitest passando (20 novos em \`superiorItemsValidation\`, 2 em \`applyModifications\`)
- [x] QA Playwright: chip "HA" no autocomplete, prereqs simples e OR (auto-add + cascata), Guarda +1 Defesa numérico (apply/remove), breakdown da Defesa itemizado, mods text-only sem alteração de stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)