### PR TITLE
Release v4.17 — redesenho da home, bestiário comunidade, efeitos ativos, role EDITOR

### DIFF
--- a/src/2foundry/threatExporter.ts
+++ b/src/2foundry/threatExporter.ts
@@ -5,6 +5,8 @@ import {
   ThreatSize,
   ThreatType,
   DEFAULT_RESISTANCE_ASSIGNMENTS,
+  getResistanceSave,
+  ResistanceType,
 } from '../interfaces/ThreatSheet';
 import { Atributo } from '../data/systems/tormenta20/atributos';
 import { DEFAULT_SKILLS } from './skills';
@@ -148,32 +150,30 @@ function getThreatSkills(threat: ThreatSheet) {
   const assignments =
     threat.resistanceAssignments || DEFAULT_RESISTANCE_ASSIGNMENTS;
 
-  // Set the save values based on resistance assignments and combat stats
+  // Os saves usam o valor efetivo da skill correspondente em threat.skills
+  // (inclui override do usuário). Fallback para a tabela de combate quando a
+  // skill não existe no array — caso de dados antigos não normalizados.
+  const getResistanceTotal = (
+    name: 'Fortitude' | 'Reflexos' | 'Vontade'
+  ): number => {
+    const skill = threat.skills.find((s) => s.name === name);
+    if (skill) return getEffectiveSkillTotal(skill);
+    return getResistanceSave(
+      assignments[name] as ResistanceType,
+      threat.combatStats
+    );
+  };
+
   if (skills.fort) {
-    skills.fort.outros = threat.combatStats.strongSave;
-    if (assignments.Fortitude === 'medium') {
-      skills.fort.outros = threat.combatStats.mediumSave;
-    } else if (assignments.Fortitude === 'weak') {
-      skills.fort.outros = threat.combatStats.weakSave;
-    }
+    skills.fort.outros = getResistanceTotal('Fortitude');
   }
 
   if (skills.refl) {
-    skills.refl.outros = threat.combatStats.strongSave;
-    if (assignments.Reflexos === 'medium') {
-      skills.refl.outros = threat.combatStats.mediumSave;
-    } else if (assignments.Reflexos === 'weak') {
-      skills.refl.outros = threat.combatStats.weakSave;
-    }
+    skills.refl.outros = getResistanceTotal('Reflexos');
   }
 
   if (skills.vont) {
-    skills.vont.outros = threat.combatStats.strongSave;
-    if (assignments.Vontade === 'medium') {
-      skills.vont.outros = threat.combatStats.mediumSave;
-    } else if (assignments.Vontade === 'weak') {
-      skills.vont.outros = threat.combatStats.weakSave;
-    }
+    skills.vont.outros = getResistanceTotal('Vontade');
   }
 
   // Set initiative and perception from threat skills if available

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,6 +91,7 @@ import {
   EditThreadPage,
   AdminPage,
   PushNotificationPrompt,
+  CosmeticsNudgeDialog,
   getFeatureFlags,
 } from './premium';
 import { Dice3DProvider } from './contexts/Dice3DContext';
@@ -293,6 +294,7 @@ function ThemedApp(): JSX.Element {
                         >
                           <PWAInstallPrompt />
                           <PushNotificationPrompt />
+                          <CosmeticsNudgeDialog />
                           <div className='mainApp'>
                             <header className='App-header'>
                               <SidebarV2

--- a/src/assets/css/landing-page-v2.css
+++ b/src/assets/css/landing-page-v2.css
@@ -100,13 +100,46 @@
 
 .hero-section {
   position: relative;
-  min-height: 50vh;
+  min-height: 35vh;
   display: flex;
   align-items: center;
   justify-content: center;
   overflow: hidden;
   border-radius: 16px;
   margin-bottom: 2rem;
+}
+
+/* ================================
+   HORIZONTAL SCROLLERS (mobile)
+   ================================ */
+
+.h-scroller {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 0.5rem;
+  scrollbar-width: thin;
+}
+
+.h-scroller > * {
+  scroll-snap-align: start;
+  flex: 0 0 auto;
+}
+
+.h-scroller::-webkit-scrollbar {
+  height: 6px;
+}
+
+.h-scroller::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.h-scroller::-webkit-scrollbar-thumb {
+  background: rgba(var(--primary-main-rgb), 0.3);
+  border-radius: 3px;
 }
 
 .hero-background {
@@ -546,7 +579,7 @@
 
 @media (max-width: 900px) {
   .hero-section {
-    min-height: 40vh;
+    min-height: 32vh;
   }
 
   .hero-content {
@@ -573,7 +606,7 @@
 
 @media (max-width: 600px) {
   .hero-section {
-    min-height: 35vh;
+    min-height: 30vh;
     border-radius: 12px;
   }
 

--- a/src/components/LandingPageV2/ActiveSessionBanner.tsx
+++ b/src/components/LandingPageV2/ActiveSessionBanner.tsx
@@ -1,112 +1,114 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { Box, Typography, Button, Stack, Chip, useTheme } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
-import { useGameTable } from '../../premium/hooks/useGameTable';
-import { GameTableStatus } from '../../premium/services/gameTable.service';
+import PeopleAltIcon from '@mui/icons-material/PeopleAlt';
+import { GameTable } from '../../premium/services/gameTable.service';
 
 interface ActiveSessionBannerProps {
   onClickButton: (link: string) => void;
-  isAuthenticated: boolean;
+  table: GameTable;
 }
 
 const ActiveSessionBanner: React.FC<ActiveSessionBannerProps> = ({
   onClickButton,
-  isAuthenticated,
+  table,
 }) => {
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
-
-  const gameTableContext = isAuthenticated ? useGameTable() : null;
-  const tables = gameTableContext?.tables ?? [];
-
-  const activeSession = useMemo(() => {
-    if (!isAuthenticated || !tables.length) return null;
-    return tables.find(
-      (t) =>
-        t.status === GameTableStatus.ACTIVE ||
-        t.status === GameTableStatus.PAUSED
-    );
-  }, [tables, isAuthenticated]);
-
-  if (!isAuthenticated || !activeSession) {
-    return null;
-  }
 
   return (
     <Box
       className='session-card active'
       sx={{
         background: isDark
-          ? 'linear-gradient(135deg, rgba(76, 175, 80, 0.12) 0%, rgba(76, 175, 80, 0.18) 100%)'
-          : 'linear-gradient(135deg, rgba(76, 175, 80, 0.08) 0%, rgba(76, 175, 80, 0.14) 100%)',
+          ? 'linear-gradient(135deg, rgba(76, 175, 80, 0.15) 0%, rgba(76, 175, 80, 0.22) 100%)'
+          : 'linear-gradient(135deg, rgba(76, 175, 80, 0.08) 0%, rgba(76, 175, 80, 0.18) 100%)',
         color: isDark ? '#ffffff' : 'inherit',
+        border: '2px solid rgba(76, 175, 80, 0.45)',
+        p: { xs: 2, md: 3 },
       }}
     >
       <Stack
-        direction={{ xs: 'column', sm: 'row' }}
-        alignItems={{ xs: 'flex-start', sm: 'center' }}
+        direction={{ xs: 'column', md: 'row' }}
+        alignItems={{ xs: 'flex-start', md: 'center' }}
         justifyContent='space-between'
         spacing={2}
       >
         <Box sx={{ flex: 1, minWidth: 0 }}>
-          <Stack direction='row' alignItems='center' spacing={1} mb={1}>
-            <Chip
-              label={
-                activeSession.status === GameTableStatus.ACTIVE
-                  ? 'Sessão Ativa'
-                  : 'Sessão Pausada'
-              }
-              color={
-                activeSession.status === GameTableStatus.ACTIVE
-                  ? 'success'
-                  : 'warning'
-              }
-              size='small'
-            />
+          <Stack
+            direction='row'
+            alignItems='center'
+            spacing={1}
+            mb={1}
+            flexWrap='wrap'
+            sx={{ rowGap: 0.5 }}
+          >
+            <Chip label='Sessão Ativa' color='success' size='small' />
+            <Stack direction='row' alignItems='center' spacing={0.5}>
+              <PeopleAltIcon sx={{ fontSize: 14, color: 'text.secondary' }} />
+              <Typography
+                variant='caption'
+                color='text.secondary'
+                sx={{ fontSize: '0.75rem' }}
+              >
+                {table.members.length}{' '}
+                {table.members.length === 1 ? 'jogador' : 'jogadores'}
+              </Typography>
+            </Stack>
           </Stack>
           <Typography
-            variant='h6'
+            variant='h5'
             sx={{
               fontFamily: 'Tfont, serif',
+              fontWeight: 700,
               mb: 0.5,
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
             }}
           >
-            {activeSession.name}
+            {table.name}
           </Typography>
-          {activeSession.description && (
+          {table.description && (
             <Typography
               variant='body2'
               color='text.secondary'
               sx={{
                 display: '-webkit-box',
-                WebkitLineClamp: 1,
+                WebkitLineClamp: 2,
                 WebkitBoxOrient: 'vertical',
                 overflow: 'hidden',
               }}
             >
-              {activeSession.description}
+              {table.description}
             </Typography>
           )}
         </Box>
-        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={1}
+          sx={{ flexShrink: 0 }}
+        >
           <Button
             variant='contained'
             color='success'
+            size='large'
             startIcon={<PlayArrowIcon />}
-            onClick={() => onClickButton(`/sessao/${activeSession.id}`)}
+            onClick={() => onClickButton(`/sessao/${table.id}`)}
             sx={{
               whiteSpace: 'nowrap',
+              fontWeight: 700,
               '&:hover': { transform: 'scale(1.05)' },
               transition: 'transform 0.2s ease',
             }}
           >
-            Continuar sessão
+            Entrar na sessão
           </Button>
-          <Button variant='outlined' onClick={() => onClickButton('/mesas')}>
-            Ver todas
+          <Button
+            variant='outlined'
+            onClick={() => onClickButton(`/mesa/${table.id}`)}
+          >
+            Gerenciar mesa
           </Button>
         </Stack>
       </Stack>

--- a/src/components/LandingPageV2/ActiveSessionBanner.tsx
+++ b/src/components/LandingPageV2/ActiveSessionBanner.tsx
@@ -1,0 +1,117 @@
+import React, { useMemo } from 'react';
+import { Box, Typography, Button, Stack, Chip, useTheme } from '@mui/material';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import { useGameTable } from '../../premium/hooks/useGameTable';
+import { GameTableStatus } from '../../premium/services/gameTable.service';
+
+interface ActiveSessionBannerProps {
+  onClickButton: (link: string) => void;
+  isAuthenticated: boolean;
+}
+
+const ActiveSessionBanner: React.FC<ActiveSessionBannerProps> = ({
+  onClickButton,
+  isAuthenticated,
+}) => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === 'dark';
+
+  const gameTableContext = isAuthenticated ? useGameTable() : null;
+  const tables = gameTableContext?.tables ?? [];
+
+  const activeSession = useMemo(() => {
+    if (!isAuthenticated || !tables.length) return null;
+    return tables.find(
+      (t) =>
+        t.status === GameTableStatus.ACTIVE ||
+        t.status === GameTableStatus.PAUSED
+    );
+  }, [tables, isAuthenticated]);
+
+  if (!isAuthenticated || !activeSession) {
+    return null;
+  }
+
+  return (
+    <Box
+      className='session-card active'
+      sx={{
+        background: isDark
+          ? 'linear-gradient(135deg, rgba(76, 175, 80, 0.12) 0%, rgba(76, 175, 80, 0.18) 100%)'
+          : 'linear-gradient(135deg, rgba(76, 175, 80, 0.08) 0%, rgba(76, 175, 80, 0.14) 100%)',
+        color: isDark ? '#ffffff' : 'inherit',
+      }}
+    >
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        alignItems={{ xs: 'flex-start', sm: 'center' }}
+        justifyContent='space-between'
+        spacing={2}
+      >
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Stack direction='row' alignItems='center' spacing={1} mb={1}>
+            <Chip
+              label={
+                activeSession.status === GameTableStatus.ACTIVE
+                  ? 'Sessão Ativa'
+                  : 'Sessão Pausada'
+              }
+              color={
+                activeSession.status === GameTableStatus.ACTIVE
+                  ? 'success'
+                  : 'warning'
+              }
+              size='small'
+            />
+          </Stack>
+          <Typography
+            variant='h6'
+            sx={{
+              fontFamily: 'Tfont, serif',
+              mb: 0.5,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {activeSession.name}
+          </Typography>
+          {activeSession.description && (
+            <Typography
+              variant='body2'
+              color='text.secondary'
+              sx={{
+                display: '-webkit-box',
+                WebkitLineClamp: 1,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              {activeSession.description}
+            </Typography>
+          )}
+        </Box>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
+          <Button
+            variant='contained'
+            color='success'
+            startIcon={<PlayArrowIcon />}
+            onClick={() => onClickButton(`/sessao/${activeSession.id}`)}
+            sx={{
+              whiteSpace: 'nowrap',
+              '&:hover': { transform: 'scale(1.05)' },
+              transition: 'transform 0.2s ease',
+            }}
+          >
+            Continuar sessão
+          </Button>
+          <Button variant='outlined' onClick={() => onClickButton('/mesas')}>
+            Ver todas
+          </Button>
+        </Stack>
+      </Stack>
+    </Box>
+  );
+};
+
+export default ActiveSessionBanner;

--- a/src/components/LandingPageV2/BlogHighlights.tsx
+++ b/src/components/LandingPageV2/BlogHighlights.tsx
@@ -1,0 +1,346 @@
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  Stack,
+  Skeleton,
+  Chip,
+  useTheme,
+} from '@mui/material';
+import ArticleIcon from '@mui/icons-material/Article';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import PersonIcon from '@mui/icons-material/Person';
+import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import { BlogPost } from '../../premium/interfaces/blog.types';
+
+interface BlogHighlightsProps {
+  onClickButton: (link: string) => void;
+  posts: BlogPost[];
+  loading: boolean;
+}
+
+const formatDate = (dateString?: string): string => {
+  if (!dateString) return '';
+  return new Date(dateString).toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: 'short',
+  });
+};
+
+const BlogHighlights: React.FC<BlogHighlightsProps> = ({
+  onClickButton,
+  posts,
+  loading,
+}) => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === 'dark';
+
+  const cardBg = isDark
+    ? 'linear-gradient(135deg, #2d2d2d 0%, #1a1a1a 100%)'
+    : 'linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%)';
+  const cardBorder = isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)';
+
+  const renderHeader = () => (
+    <Stack
+      direction='row'
+      justifyContent='space-between'
+      alignItems='center'
+      sx={{ mb: 1.5 }}
+    >
+      <Typography variant='h5' className='section-title' sx={{ mb: 0 }}>
+        Blog
+      </Typography>
+      <Button
+        size='small'
+        endIcon={<ArrowForwardIcon sx={{ fontSize: 14 }} />}
+        onClick={() => onClickButton('/blog')}
+        sx={{ textTransform: 'none', fontSize: '0.75rem' }}
+      >
+        Ver todos
+      </Button>
+    </Stack>
+  );
+
+  if (loading) {
+    return (
+      <Box>
+        {renderHeader()}
+        <Stack spacing={1.25}>
+          <Skeleton
+            variant='rectangular'
+            height={260}
+            sx={{ borderRadius: 2 }}
+          />
+          {[1, 2, 3].map((i) => (
+            <Skeleton
+              key={i}
+              variant='rectangular'
+              height={70}
+              sx={{ borderRadius: 2 }}
+            />
+          ))}
+        </Stack>
+      </Box>
+    );
+  }
+
+  if (posts.length === 0) {
+    return null;
+  }
+
+  const [featured, ...rest] = posts;
+  const sidePosts = rest.slice(0, 3);
+
+  return (
+    <Box>
+      {renderHeader()}
+
+      <Stack spacing={1.25}>
+        {/* Featured post — full-width inside column */}
+        <Box
+          onClick={() => onClickButton(`/blog/${featured.slug}`)}
+          sx={{
+            background: cardBg,
+            color: isDark ? '#ffffff' : 'inherit',
+            borderRadius: 2,
+            cursor: 'pointer',
+            border: `1px solid ${cardBorder}`,
+            overflow: 'hidden',
+            display: 'flex',
+            flexDirection: 'column',
+            transition: 'all 0.2s ease',
+            animation: 'scaleIn 0.4s ease-out 0.1s both',
+            '&:hover': {
+              transform: 'translateY(-3px)',
+              borderColor: theme.palette.primary.main,
+              boxShadow: `0 8px 20px ${
+                isDark ? 'rgba(0,0,0,0.4)' : 'rgba(0,0,0,0.12)'
+              }`,
+            },
+          }}
+        >
+          <Box
+            sx={{
+              position: 'relative',
+              width: '100%',
+              aspectRatio: '16 / 9',
+              backgroundColor: isDark
+                ? 'rgba(255,255,255,0.05)'
+                : 'rgba(0,0,0,0.05)',
+              overflow: 'hidden',
+            }}
+          >
+            {featured.coverImage ? (
+              <Box
+                component='img'
+                src={featured.coverImage}
+                alt={featured.title}
+                sx={{
+                  width: '100%',
+                  height: '100%',
+                  objectFit: 'cover',
+                  display: 'block',
+                }}
+              />
+            ) : (
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: '100%',
+                  height: '100%',
+                }}
+              >
+                <ArticleIcon
+                  sx={{
+                    fontSize: 56,
+                    color: theme.palette.primary.main,
+                    opacity: 0.5,
+                  }}
+                />
+              </Box>
+            )}
+            <Chip
+              label='Destaque'
+              size='small'
+              sx={{
+                position: 'absolute',
+                top: 12,
+                left: 12,
+                backgroundColor: theme.palette.primary.main,
+                color: '#ffffff',
+                fontWeight: 700,
+                fontSize: '0.65rem',
+                height: 20,
+              }}
+            />
+          </Box>
+          <Box sx={{ p: 2 }}>
+            <Typography
+              variant='subtitle1'
+              sx={{
+                fontFamily: 'Tfont, serif',
+                fontWeight: 700,
+                lineHeight: 1.25,
+                mb: 0.75,
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              {featured.title}
+            </Typography>
+            {featured.description && (
+              <Typography
+                variant='body2'
+                color='text.secondary'
+                sx={{
+                  fontSize: '0.825rem',
+                  mb: 1,
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                }}
+              >
+                {featured.description}
+              </Typography>
+            )}
+            <Stack direction='row' spacing={1.5} alignItems='center'>
+              <Stack direction='row' spacing={0.5} alignItems='center'>
+                <PersonIcon sx={{ fontSize: 13, color: 'text.secondary' }} />
+                <Typography
+                  variant='caption'
+                  color='text.secondary'
+                  sx={{ fontSize: '0.7rem' }}
+                >
+                  {featured.authorName}
+                </Typography>
+              </Stack>
+              <Stack direction='row' spacing={0.5} alignItems='center'>
+                <CalendarTodayIcon
+                  sx={{ fontSize: 12, color: 'text.secondary' }}
+                />
+                <Typography
+                  variant='caption'
+                  color='text.secondary'
+                  sx={{ fontSize: '0.7rem' }}
+                >
+                  {formatDate(featured.publishedAt || featured.createdAt)}
+                </Typography>
+              </Stack>
+            </Stack>
+          </Box>
+        </Box>
+
+        {/* Smaller posts below featured (compact list) */}
+        {sidePosts.map((post, index) => (
+          <Box
+            key={post.id}
+            onClick={() => onClickButton(`/blog/${post.slug}`)}
+            sx={{
+              animation: `scaleIn 0.4s ease-out ${0.08 * (index + 2)}s both`,
+              background: cardBg,
+              color: isDark ? '#ffffff' : 'inherit',
+              borderRadius: 2,
+              cursor: 'pointer',
+              border: `1px solid ${cardBorder}`,
+              borderLeft: `4px solid ${theme.palette.primary.main}`,
+              p: 1.25,
+              display: 'flex',
+              gap: 1.25,
+              transition: 'all 0.18s ease',
+              '&:hover': {
+                transform: 'translateX(3px)',
+                borderColor: theme.palette.primary.main,
+                borderLeftColor: theme.palette.primary.main,
+              },
+            }}
+          >
+            <Box
+              sx={{
+                width: 72,
+                height: 56,
+                borderRadius: 1,
+                overflow: 'hidden',
+                flexShrink: 0,
+                backgroundColor: isDark
+                  ? 'rgba(255,255,255,0.05)'
+                  : 'rgba(0,0,0,0.05)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              {post.coverImage ? (
+                <Box
+                  component='img'
+                  src={post.coverImage}
+                  alt={post.title}
+                  sx={{
+                    width: '100%',
+                    height: '100%',
+                    objectFit: 'cover',
+                  }}
+                />
+              ) : (
+                <ArticleIcon
+                  sx={{
+                    fontSize: 24,
+                    color: theme.palette.primary.main,
+                    opacity: 0.4,
+                  }}
+                />
+              )}
+            </Box>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography
+                variant='subtitle2'
+                sx={{
+                  fontWeight: 600,
+                  lineHeight: 1.25,
+                  fontSize: '0.825rem',
+                  mb: 0.4,
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                }}
+              >
+                {post.title}
+              </Typography>
+              <Stack direction='row' spacing={0.75} alignItems='center'>
+                <Typography
+                  variant='caption'
+                  color='text.secondary'
+                  sx={{ fontSize: '0.65rem' }}
+                >
+                  {post.authorName}
+                </Typography>
+                <Typography
+                  variant='caption'
+                  color='text.secondary'
+                  sx={{ fontSize: '0.65rem' }}
+                >
+                  ·
+                </Typography>
+                <Typography
+                  variant='caption'
+                  color='text.secondary'
+                  sx={{ fontSize: '0.65rem' }}
+                >
+                  {formatDate(post.publishedAt || post.createdAt)}
+                </Typography>
+              </Stack>
+            </Box>
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  );
+};
+
+export default BlogHighlights;

--- a/src/components/LandingPageV2/BuildsShowcase.tsx
+++ b/src/components/LandingPageV2/BuildsShowcase.tsx
@@ -1,0 +1,221 @@
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  Stack,
+  Skeleton,
+  Chip,
+  useTheme,
+} from '@mui/material';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import ConstructionIcon from '@mui/icons-material/Construction';
+import StarIcon from '@mui/icons-material/Star';
+import { BuildData } from '../../premium/services/builds.service';
+import { getSupporterGlowColor } from '../../types/subscription.types';
+
+interface BuildsShowcaseProps {
+  onClickButton: (link: string) => void;
+  builds: BuildData[];
+  loading: boolean;
+}
+
+const BuildsShowcase: React.FC<BuildsShowcaseProps> = ({
+  onClickButton,
+  builds,
+  loading,
+}) => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === 'dark';
+
+  const renderHeader = () => (
+    <Stack
+      direction='row'
+      justifyContent='space-between'
+      alignItems='center'
+      sx={{ mb: 2 }}
+    >
+      <Typography variant='h5' className='section-title' sx={{ mb: 0 }}>
+        Builds em destaque
+      </Typography>
+      <Button
+        size='small'
+        endIcon={<ArrowForwardIcon />}
+        onClick={() => onClickButton('/builds')}
+        sx={{ textTransform: 'none' }}
+      >
+        Explorar builds
+      </Button>
+    </Stack>
+  );
+
+  if (loading) {
+    return (
+      <Box>
+        {renderHeader()}
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: {
+              xs: '1fr',
+              sm: 'repeat(2, 1fr)',
+              md: 'repeat(4, 1fr)',
+            },
+            gap: 2,
+          }}
+        >
+          {[1, 2, 3, 4].map((i) => (
+            <Skeleton
+              key={i}
+              variant='rectangular'
+              height={160}
+              sx={{ borderRadius: 2 }}
+            />
+          ))}
+        </Box>
+      </Box>
+    );
+  }
+
+  if (builds.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box>
+      {renderHeader()}
+
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: {
+            xs: '1fr',
+            sm: 'repeat(2, 1fr)',
+            md: 'repeat(4, 1fr)',
+          },
+          gap: 2,
+        }}
+      >
+        {builds.slice(0, 4).map((build, index) => {
+          const shadowColor = getSupporterGlowColor(build.ownerSupportLevel);
+          return (
+            <Box
+              key={build.id}
+              onClick={() => onClickButton(`/build/${build.id}`)}
+              sx={{
+                animation: `scaleIn 0.4s ease-out ${0.1 * (index + 1)}s both`,
+                background: isDark
+                  ? 'linear-gradient(135deg, #2d2d2d 0%, #1a1a1a 100%)'
+                  : 'linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%)',
+                color: isDark ? '#ffffff' : 'inherit',
+                borderRadius: 2,
+                p: 2,
+                cursor: 'pointer',
+                border: `1px solid ${
+                  isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)'
+                }`,
+                borderTop: '4px solid #7c4dff',
+                borderBottom: shadowColor ? `3px solid ${shadowColor}` : 'none',
+                display: 'flex',
+                flexDirection: 'column',
+                minHeight: 160,
+                transition: 'all 0.2s ease',
+                '&:hover': {
+                  transform: 'translateY(-4px)',
+                  borderColor: theme.palette.primary.main,
+                  borderTopColor: '#7c4dff',
+                  boxShadow: `0 8px 20px ${
+                    isDark ? 'rgba(0,0,0,0.4)' : 'rgba(0,0,0,0.12)'
+                  }`,
+                },
+              }}
+            >
+              <Stack
+                direction='row'
+                justifyContent='space-between'
+                alignItems='flex-start'
+                spacing={1}
+                sx={{ mb: 1 }}
+              >
+                <ConstructionIcon
+                  sx={{ fontSize: 20, color: '#7c4dff', flexShrink: 0 }}
+                />
+                {build.ratings && build.ratings.count > 0 && (
+                  <Stack direction='row' alignItems='center' spacing={0.3}>
+                    <StarIcon sx={{ fontSize: 14, color: 'warning.main' }} />
+                    <Typography
+                      variant='caption'
+                      color='text.secondary'
+                      sx={{ fontSize: '0.7rem' }}
+                    >
+                      {build.ratings.average.toFixed(1)}
+                    </Typography>
+                  </Stack>
+                )}
+              </Stack>
+
+              <Typography
+                variant='subtitle2'
+                sx={{
+                  fontFamily: 'Tfont, serif',
+                  fontWeight: 700,
+                  lineHeight: 1.25,
+                  mb: 1,
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                  minHeight: '2.6em',
+                }}
+              >
+                {build.name}
+              </Typography>
+
+              <Stack
+                direction='row'
+                spacing={0.5}
+                flexWrap='wrap'
+                gap={0.5}
+                sx={{ mb: 1 }}
+              >
+                <Chip
+                  label={build.isMulticlass ? 'Multiclasse' : build.classe}
+                  size='small'
+                  color='primary'
+                  sx={{ fontSize: '0.65rem', height: 20 }}
+                />
+                {build.raca && (
+                  <Chip
+                    label={build.raca}
+                    size='small'
+                    variant='outlined'
+                    sx={{ fontSize: '0.65rem', height: 20 }}
+                  />
+                )}
+              </Stack>
+
+              {build.description && (
+                <Typography
+                  variant='caption'
+                  color='text.secondary'
+                  sx={{
+                    fontSize: '0.7rem',
+                    display: '-webkit-box',
+                    WebkitLineClamp: 2,
+                    WebkitBoxOrient: 'vertical',
+                    overflow: 'hidden',
+                    mt: 'auto',
+                  }}
+                >
+                  {build.description}
+                </Typography>
+              )}
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+};
+
+export default BuildsShowcase;

--- a/src/components/LandingPageV2/CommunityFeedSection.tsx
+++ b/src/components/LandingPageV2/CommunityFeedSection.tsx
@@ -165,6 +165,7 @@ const CommunityFeedSection: React.FC<CommunityFeedSectionProps> = ({
   const isDark = theme.palette.mode === 'dark';
   const { user } = useAuth();
   const isAdmin = user?.email === ADMIN_EMAIL;
+  const canCreateBlogPost = isAdmin || user?.isEditor === true;
 
   const [feedItems, setFeedItems] = useState<FeedItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -474,7 +475,7 @@ const CommunityFeedSection: React.FC<CommunityFeedSectionProps> = ({
           </ListItemIcon>
           <ListItemText>Nova Build</ListItemText>
         </MenuItem>
-        {isAdmin && (
+        {canCreateBlogPost && (
           <MenuItem onClick={() => handleMenuClick('/blog/novo')}>
             <ListItemIcon>
               <ArticleIcon fontSize='small' />

--- a/src/components/LandingPageV2/ContinueAndTablesSection.tsx
+++ b/src/components/LandingPageV2/ContinueAndTablesSection.tsx
@@ -1,0 +1,63 @@
+import React, { useMemo } from 'react';
+import { Box } from '@mui/material';
+import { useGameTable } from '../../premium/hooks/useGameTable';
+import { GameTableStatus } from '../../premium/services/gameTable.service';
+import ContinueJourneySection from './ContinueJourneySection';
+import VirtualTablesColumn from './VirtualTablesColumn';
+import ActiveSessionBanner from './ActiveSessionBanner';
+
+interface ContinueAndTablesSectionProps {
+  onClickButton: (link: string) => void;
+  isAuthenticated: boolean;
+}
+
+const ContinueAndTablesSection: React.FC<ContinueAndTablesSectionProps> = ({
+  onClickButton,
+  isAuthenticated,
+}) => {
+  // useGameTable always runs (React rules of hooks); we ignore its data
+  // when the user is not authenticated.
+  const { tables } = useGameTable();
+
+  const activeTable = useMemo(() => {
+    if (!isAuthenticated) return null;
+    return tables.find((t) => t.status === GameTableStatus.ACTIVE) ?? null;
+  }, [tables, isAuthenticated]);
+
+  // 1. Unauthenticated → start-your-journey CTAs (handled inside ContinueJourneySection)
+  if (!isAuthenticated) {
+    return (
+      <ContinueJourneySection
+        onClickButton={onClickButton}
+        isAuthenticated={isAuthenticated}
+      />
+    );
+  }
+
+  // 2. Active table → full-width spotlight
+  if (activeTable) {
+    return (
+      <ActiveSessionBanner onClickButton={onClickButton} table={activeTable} />
+    );
+  }
+
+  // 3. Default → two columns: recent sheets + tables
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, minmax(0, 1fr))' },
+        gap: { xs: 3, sm: 3 },
+        alignItems: 'start',
+      }}
+    >
+      <ContinueJourneySection
+        onClickButton={onClickButton}
+        isAuthenticated={isAuthenticated}
+      />
+      <VirtualTablesColumn onClickButton={onClickButton} tables={tables} />
+    </Box>
+  );
+};
+
+export default ContinueAndTablesSection;

--- a/src/components/LandingPageV2/ContinueJourneySection.tsx
+++ b/src/components/LandingPageV2/ContinueJourneySection.tsx
@@ -1,0 +1,472 @@
+import React, { useMemo } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  Stack,
+  Skeleton,
+  Chip,
+  useTheme,
+} from '@mui/material';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import AddIcon from '@mui/icons-material/Add';
+import LoginIcon from '@mui/icons-material/Login';
+import PersonAddIcon from '@mui/icons-material/PersonAdd';
+import CasinoIcon from '@mui/icons-material/Casino';
+import tormenta20 from '@/assets/images/tormenta20.jpg';
+import { useSheets } from '../../hooks/useSheets';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { SheetListData } from '../../services/sheets.service';
+
+interface ContinueJourneySectionProps {
+  onClickButton: (link: string) => void;
+  isAuthenticated: boolean;
+}
+
+interface SheetDataContent {
+  raca?: { name: string };
+  classe?: { name: string };
+  classLevels?: { className: string }[];
+  nivel?: number;
+  isThreat?: boolean;
+}
+
+const MAX_SHEETS = 2;
+
+const ContinueJourneySection: React.FC<ContinueJourneySectionProps> = ({
+  onClickButton,
+  isAuthenticated,
+}) => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === 'dark';
+  const { openLoginModal } = useAuthContext();
+
+  const { sheets, loading } = useSheets();
+
+  const recentSheets = useMemo(() => {
+    if (!isAuthenticated || !sheets || sheets.length === 0) return [];
+    return sheets
+      .filter((sheet) => !(sheet.sheetData as SheetDataContent)?.isThreat)
+      .sort(
+        (a, b) =>
+          new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+      )
+      .slice(0, MAX_SHEETS);
+  }, [isAuthenticated, sheets]);
+
+  const getSheetData = (sheet: SheetListData): SheetDataContent =>
+    (sheet.sheetData as SheetDataContent) || {};
+
+  const getCtaBackground = (isPrimary: boolean): string => {
+    if (isPrimary) {
+      return `linear-gradient(135deg, ${theme.palette.primary.main} 0%, ${theme.palette.primary.dark} 100%)`;
+    }
+    return isDark
+      ? 'linear-gradient(135deg, #2d2d2d 0%, #1a1a1a 100%)'
+      : 'linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%)';
+  };
+
+  const getCtaBorderColor = (isPrimary: boolean): string => {
+    if (isPrimary) return theme.palette.primary.dark;
+    return isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)';
+  };
+
+  const getCtaHoverShadow = (isPrimary: boolean): string => {
+    if (isPrimary) return 'rgba(0,0,0,0.25)';
+    return isDark ? 'rgba(0,0,0,0.4)' : 'rgba(0,0,0,0.12)';
+  };
+
+  // ============== Not authenticated ==============
+  if (!isAuthenticated) {
+    const ctas = [
+      {
+        key: 'create',
+        title: 'Criar Personagem',
+        description: 'Gere uma ficha completa em minutos',
+        icon: <PersonAddIcon sx={{ fontSize: 32 }} />,
+        onClick: () => onClickButton('/criar-ficha'),
+        isPrimary: true,
+      },
+      {
+        key: 'random',
+        title: 'Ficha Aleatória',
+        description: 'Sem ideia? Gere uma pronta',
+        icon: <CasinoIcon sx={{ fontSize: 32 }} />,
+        onClick: () => onClickButton('/ficha-aleatoria'),
+        isPrimary: false,
+      },
+      {
+        key: 'login',
+        title: 'Faça Login',
+        description: 'Salve fichas e participe',
+        icon: <LoginIcon sx={{ fontSize: 32 }} />,
+        onClick: openLoginModal,
+        isPrimary: false,
+      },
+    ];
+
+    return (
+      <Box>
+        <Typography
+          variant='subtitle1'
+          sx={{
+            fontFamily: 'Tfont, serif',
+            fontWeight: 700,
+            color: theme.palette.primary.main,
+            mb: 1.5,
+          }}
+        >
+          Comece sua jornada
+        </Typography>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', sm: 'repeat(3, 1fr)' },
+            gap: 1.5,
+          }}
+        >
+          {ctas.map((cta, index) => (
+            <Box
+              key={cta.key}
+              onClick={cta.onClick}
+              sx={{
+                animation: `scaleIn 0.4s ease-out ${0.1 * (index + 1)}s both`,
+                background: getCtaBackground(cta.isPrimary),
+                color: cta.isPrimary || isDark ? '#ffffff' : 'inherit',
+                borderRadius: 2,
+                p: 2,
+                cursor: 'pointer',
+                border: `2px solid ${getCtaBorderColor(cta.isPrimary)}`,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1.5,
+                minHeight: 80,
+                transition: 'all 0.18s ease',
+                '&:hover': {
+                  transform: 'translateY(-2px)',
+                  borderColor: theme.palette.primary.main,
+                  boxShadow: `0 6px 16px ${getCtaHoverShadow(cta.isPrimary)}`,
+                },
+              }}
+            >
+              <Box
+                sx={{
+                  color: cta.isPrimary
+                    ? 'rgba(255,255,255,0.95)'
+                    : theme.palette.primary.main,
+                  display: 'flex',
+                  flexShrink: 0,
+                }}
+              >
+                {cta.icon}
+              </Box>
+              <Box sx={{ minWidth: 0 }}>
+                <Typography
+                  variant='subtitle2'
+                  sx={{
+                    fontFamily: 'Tfont, serif',
+                    fontWeight: 700,
+                    mb: 0.25,
+                    lineHeight: 1.2,
+                  }}
+                >
+                  {cta.title}
+                </Typography>
+                <Typography
+                  variant='caption'
+                  sx={{
+                    fontSize: '0.75rem',
+                    opacity: cta.isPrimary ? 0.95 : 0.7,
+                    color: cta.isPrimary ? 'rgba(255,255,255,0.9)' : 'inherit',
+                    display: 'block',
+                  }}
+                >
+                  {cta.description}
+                </Typography>
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    );
+  }
+
+  // ============== Authenticated, loading ==============
+  if (loading) {
+    return (
+      <Box>
+        <Stack
+          direction='row'
+          alignItems='center'
+          justifyContent='space-between'
+          sx={{ mb: 1.5 }}
+        >
+          <Typography
+            variant='subtitle1'
+            sx={{
+              fontFamily: 'Tfont, serif',
+              fontWeight: 700,
+              color: theme.palette.primary.main,
+            }}
+          >
+            Continue jogando
+          </Typography>
+        </Stack>
+        <Stack direction='row' spacing={1.5}>
+          {[1, 2, 3].map((i) => (
+            <Skeleton
+              key={i}
+              variant='rectangular'
+              height={68}
+              sx={{ borderRadius: 2, flex: 1 }}
+            />
+          ))}
+          <Skeleton
+            variant='rectangular'
+            height={68}
+            width={120}
+            sx={{ borderRadius: 2 }}
+          />
+        </Stack>
+      </Box>
+    );
+  }
+
+  // ============== Authenticated, no sheets ==============
+  if (recentSheets.length === 0) {
+    return (
+      <Box
+        onClick={() => onClickButton('/criar-ficha')}
+        sx={{
+          background: `linear-gradient(135deg, ${theme.palette.primary.main} 0%, ${theme.palette.primary.dark} 100%)`,
+          color: '#ffffff',
+          borderRadius: 2,
+          p: 2,
+          cursor: 'pointer',
+          border: `2px solid ${theme.palette.primary.dark}`,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+          transition: 'all 0.2s ease',
+          '&:hover': {
+            transform: 'translateY(-2px)',
+            boxShadow: '0 8px 20px rgba(0,0,0,0.25)',
+          },
+        }}
+      >
+        <PersonAddIcon sx={{ fontSize: 36, opacity: 0.95, flexShrink: 0 }} />
+        <Box sx={{ flex: 1 }}>
+          <Typography
+            variant='subtitle1'
+            sx={{ fontFamily: 'Tfont, serif', fontWeight: 700, mb: 0.25 }}
+          >
+            Crie seu primeiro personagem
+          </Typography>
+          <Typography
+            variant='caption'
+            sx={{ opacity: 0.9, fontSize: '0.8rem' }}
+          >
+            Comece sua aventura em Arton em poucos minutos
+          </Typography>
+        </Box>
+        <ArrowForwardIcon sx={{ flexShrink: 0 }} />
+      </Box>
+    );
+  }
+
+  // ============== Authenticated, with sheets ==============
+  // Compact horizontal row: small thumbnail + name + level chip
+  return (
+    <Box>
+      <Stack
+        direction='row'
+        alignItems='center'
+        justifyContent='space-between'
+        sx={{ mb: 1.5 }}
+      >
+        <Typography
+          variant='subtitle1'
+          sx={{
+            fontFamily: 'Tfont, serif',
+            fontWeight: 700,
+            color: theme.palette.primary.main,
+          }}
+        >
+          Continue jogando
+        </Typography>
+        <Button
+          size='small'
+          endIcon={<ArrowForwardIcon sx={{ fontSize: 14 }} />}
+          onClick={() => onClickButton('/meus-personagens')}
+          sx={{ textTransform: 'none', fontSize: '0.75rem' }}
+        >
+          Ver todas
+        </Button>
+      </Stack>
+
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: {
+            xs: '1fr',
+            sm: 'repeat(2, 1fr)',
+            md: `repeat(${recentSheets.length + 1}, minmax(0, 1fr))`,
+          },
+          gap: 1.25,
+        }}
+      >
+        {recentSheets.map((sheet, index) => {
+          const data = getSheetData(sheet);
+          let classLabel = data.classe?.name;
+          if (
+            data.classLevels &&
+            Array.isArray(data.classLevels) &&
+            data.classLevels.length > 0
+          ) {
+            const classMap = new Map<string, number>();
+            data.classLevels.forEach((cl) => {
+              classMap.set(cl.className, (classMap.get(cl.className) ?? 0) + 1);
+            });
+            if (classMap.size > 1) {
+              classLabel = Array.from(classMap.entries())
+                .map(([name, level]) => `${name} ${level}`)
+                .join(' / ');
+            }
+          }
+
+          return (
+            <Box
+              key={sheet.id}
+              onClick={() => onClickButton(`/ficha/${sheet.id}`)}
+              sx={{
+                animation: `scaleIn 0.4s ease-out ${0.08 * (index + 1)}s both`,
+                background: isDark
+                  ? 'rgba(45, 45, 45, 0.85)'
+                  : 'rgba(255, 255, 255, 0.9)',
+                color: isDark ? '#ffffff' : 'inherit',
+                borderRadius: 2,
+                cursor: 'pointer',
+                border: `1px solid ${
+                  isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)'
+                }`,
+                p: 1,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1.25,
+                minWidth: 0,
+                transition: 'all 0.18s ease',
+                '&:hover': {
+                  transform: 'translateY(-2px)',
+                  borderColor: theme.palette.primary.main,
+                  boxShadow: `0 4px 12px ${
+                    isDark ? 'rgba(0,0,0,0.4)' : 'rgba(0,0,0,0.12)'
+                  }`,
+                },
+              }}
+            >
+              <Box
+                component='img'
+                src={sheet.image || tormenta20}
+                alt={sheet.name}
+                sx={{
+                  width: 44,
+                  height: 44,
+                  objectFit: 'cover',
+                  borderRadius: 1,
+                  flexShrink: 0,
+                }}
+              />
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography
+                  variant='subtitle2'
+                  sx={{
+                    fontFamily: 'Tfont, serif',
+                    fontWeight: 700,
+                    lineHeight: 1.15,
+                    fontSize: '0.85rem',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {sheet.name}
+                </Typography>
+                <Stack
+                  direction='row'
+                  spacing={0.5}
+                  alignItems='center'
+                  sx={{ mt: 0.25, minWidth: 0 }}
+                >
+                  {classLabel && (
+                    <Typography
+                      variant='caption'
+                      sx={{
+                        fontSize: '0.65rem',
+                        color: 'text.secondary',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                        minWidth: 0,
+                      }}
+                    >
+                      {classLabel}
+                    </Typography>
+                  )}
+                  {data.nivel && (
+                    <Chip
+                      label={`Nv${data.nivel}`}
+                      size='small'
+                      sx={{
+                        fontSize: '0.6rem',
+                        height: 16,
+                        flexShrink: 0,
+                        '& .MuiChip-label': { px: 0.75 },
+                      }}
+                    />
+                  )}
+                </Stack>
+              </Box>
+            </Box>
+          );
+        })}
+
+        {/* "New sheet" compact slot */}
+        <Box
+          onClick={() => onClickButton('/criar-ficha')}
+          sx={{
+            background: 'transparent',
+            border: `1.5px dashed ${theme.palette.primary.main}`,
+            borderRadius: 2,
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 0.75,
+            color: theme.palette.primary.main,
+            minHeight: 60,
+            p: 1,
+            transition: 'all 0.18s ease',
+            '&:hover': {
+              backgroundColor: `${theme.palette.primary.main}10`,
+              transform: 'translateY(-2px)',
+            },
+          }}
+        >
+          <AddIcon sx={{ fontSize: 18 }} />
+          <Typography
+            variant='subtitle2'
+            sx={{
+              fontFamily: 'Tfont, serif',
+              fontWeight: 700,
+              fontSize: '0.8rem',
+            }}
+          >
+            Nova ficha
+          </Typography>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default ContinueJourneySection;

--- a/src/components/LandingPageV2/ForumActivity.tsx
+++ b/src/components/LandingPageV2/ForumActivity.tsx
@@ -1,0 +1,277 @@
+import React, { useMemo } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  Stack,
+  Skeleton,
+  Chip,
+  useTheme,
+} from '@mui/material';
+import ForumIcon from '@mui/icons-material/Forum';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import AddIcon from '@mui/icons-material/Add';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import PersonIcon from '@mui/icons-material/Person';
+import { ForumThread } from '../../premium/interfaces/forum.types';
+import {
+  SupportLevel,
+  getSupporterGlowColor,
+} from '../../types/subscription.types';
+
+interface ForumActivityProps {
+  onClickButton: (link: string) => void;
+  threads: ForumThread[];
+  loading: boolean;
+  isAuthenticated: boolean;
+  maxItems?: number;
+}
+
+const getBodyPreview = (body: string, maxLength = 160): string => {
+  const plainText = body
+    .replace(/#{1,6}\s/g, '')
+    .replace(/\*\*|__/g, '')
+    .replace(/\*|_/g, '')
+    .replace(/`{1,3}[^`]*`{1,3}/g, '')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, '')
+    .replace(/>\s/g, '')
+    .replace(/\n/g, ' ')
+    .trim();
+
+  if (plainText.length <= maxLength) return plainText;
+  return `${plainText.substring(0, maxLength)}...`;
+};
+
+const formatDate = (dateString?: string): string => {
+  if (!dateString) return '';
+  return new Date(dateString).toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: 'short',
+  });
+};
+
+const isSupporter = (thread: ForumThread) =>
+  thread.authorSupportLevel && thread.authorSupportLevel !== SupportLevel.FREE;
+
+/**
+ * Ordering rule: top 3 prioritize supporters (most-recently-active first),
+ * then the remaining slots are filled by overall activity order.
+ */
+const orderThreads = (threads: ForumThread[]): ForumThread[] => {
+  if (threads.length === 0) return [];
+
+  const supporterPool = threads.filter(isSupporter).slice(0, 3);
+
+  const supporterIds = new Set(supporterPool.map((t) => t.id));
+  const rest = threads.filter((t) => !supporterIds.has(t.id));
+
+  return [...supporterPool, ...rest];
+};
+
+const ForumActivity: React.FC<ForumActivityProps> = ({
+  onClickButton,
+  threads,
+  loading,
+  isAuthenticated,
+  maxItems = 8,
+}) => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === 'dark';
+
+  const ordered = useMemo(
+    () => orderThreads(threads).slice(0, maxItems),
+    [threads, maxItems]
+  );
+
+  const renderHeader = () => (
+    <Stack
+      direction='row'
+      justifyContent='space-between'
+      alignItems='center'
+      sx={{ mb: 1.5, flexWrap: 'wrap', gap: 1 }}
+    >
+      <Typography variant='h5' className='section-title' sx={{ mb: 0 }}>
+        Fórum
+      </Typography>
+      {isAuthenticated && (
+        <Button
+          size='small'
+          startIcon={<AddIcon sx={{ fontSize: 16 }} />}
+          onClick={() => onClickButton('/forum/novo')}
+          sx={{ textTransform: 'none', fontSize: '0.75rem' }}
+        >
+          Criar post
+        </Button>
+      )}
+    </Stack>
+  );
+
+  if (loading) {
+    return (
+      <Box>
+        {renderHeader()}
+        <Stack spacing={1}>
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <Skeleton
+              key={i}
+              variant='rectangular'
+              height={70}
+              sx={{ borderRadius: 2 }}
+            />
+          ))}
+        </Stack>
+      </Box>
+    );
+  }
+
+  if (ordered.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box>
+      {renderHeader()}
+
+      <Stack spacing={1}>
+        {ordered.map((thread, index) => {
+          const shadowColor = getSupporterGlowColor(thread.authorSupportLevel);
+          return (
+            <Box
+              key={thread.id}
+              onClick={() => onClickButton(`/forum/${thread.slug}`)}
+              sx={{
+                animation: `scaleIn 0.4s ease-out ${0.04 * (index + 1)}s both`,
+                background: isDark
+                  ? 'linear-gradient(135deg, #2d2d2d 0%, #1a1a1a 100%)'
+                  : 'linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%)',
+                color: isDark ? '#ffffff' : 'inherit',
+                borderRadius: 2,
+                p: 1.25,
+                cursor: 'pointer',
+                border: `1px solid ${
+                  isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)'
+                }`,
+                borderLeft: '4px solid #66bb6a',
+                borderBottom: shadowColor ? `3px solid ${shadowColor}` : 'none',
+                transition: 'all 0.18s ease',
+                '&:hover': {
+                  transform: 'translateX(3px)',
+                  borderColor: theme.palette.primary.main,
+                  borderLeftColor: '#66bb6a',
+                },
+              }}
+            >
+              <Typography
+                variant='subtitle2'
+                sx={{
+                  fontWeight: 600,
+                  lineHeight: 1.25,
+                  fontSize: '0.85rem',
+                  mb: 0.5,
+                  display: '-webkit-box',
+                  WebkitLineClamp: 1,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                }}
+              >
+                {thread.title}
+              </Typography>
+
+              <Typography
+                variant='caption'
+                color='text.secondary'
+                sx={{
+                  fontSize: '0.7rem',
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                  mb: 0.5,
+                }}
+              >
+                {getBodyPreview(thread.body)}
+              </Typography>
+
+              <Stack
+                direction='row'
+                spacing={1}
+                alignItems='center'
+                flexWrap='wrap'
+                sx={{ rowGap: 0.25 }}
+              >
+                {thread.category?.name && (
+                  <Chip
+                    label={thread.category.name}
+                    size='small'
+                    variant='outlined'
+                    sx={{
+                      fontSize: '0.55rem',
+                      height: 16,
+                      borderColor: thread.category.color || undefined,
+                      color: thread.category.color || undefined,
+                      '& .MuiChip-label': { px: 0.75 },
+                    }}
+                  />
+                )}
+                <Stack direction='row' spacing={0.4} alignItems='center'>
+                  <PersonIcon sx={{ fontSize: 11, color: 'text.secondary' }} />
+                  <Typography
+                    variant='caption'
+                    color='text.secondary'
+                    sx={{ fontSize: '0.65rem' }}
+                  >
+                    {thread.authorUsername}
+                  </Typography>
+                </Stack>
+                <Stack direction='row' spacing={0.4} alignItems='center'>
+                  <ChatBubbleOutlineIcon
+                    sx={{ fontSize: 11, color: 'text.secondary' }}
+                  />
+                  <Typography
+                    variant='caption'
+                    color='text.secondary'
+                    sx={{ fontSize: '0.65rem' }}
+                  >
+                    {thread.commentCount}
+                  </Typography>
+                </Stack>
+                <Typography
+                  variant='caption'
+                  color='text.secondary'
+                  sx={{ fontSize: '0.65rem', ml: 'auto' }}
+                >
+                  {formatDate(thread.lastActivityAt || thread.createdAt)}
+                </Typography>
+              </Stack>
+            </Box>
+          );
+        })}
+      </Stack>
+
+      <Button
+        variant='outlined'
+        size='small'
+        fullWidth
+        startIcon={<ForumIcon sx={{ fontSize: 14 }} />}
+        endIcon={<ArrowForwardIcon sx={{ fontSize: 14 }} />}
+        onClick={() => onClickButton('/forum')}
+        sx={{
+          mt: 1.5,
+          textTransform: 'none',
+          fontSize: '0.75rem',
+          borderColor: '#66bb6a',
+          color: '#66bb6a',
+          '&:hover': {
+            borderColor: '#66bb6a',
+            backgroundColor: 'rgba(102, 187, 106, 0.08)',
+          },
+        }}
+      >
+        Ir ao fórum
+      </Button>
+    </Box>
+  );
+};
+
+export default ForumActivity;

--- a/src/components/LandingPageV2/HeroCarousel.tsx
+++ b/src/components/LandingPageV2/HeroCarousel.tsx
@@ -299,7 +299,7 @@ const HeroCarousel: React.FC<HeroCarouselProps> = ({
     <Box
       className='hero-section'
       sx={{
-        minHeight: { xs: '35vh', sm: '40vh', md: '50vh' },
+        minHeight: { xs: '30vh', sm: '32vh', md: '35vh' },
         position: 'relative',
         zIndex: 1,
       }}

--- a/src/components/LandingPageV2/JamboFooter.tsx
+++ b/src/components/LandingPageV2/JamboFooter.tsx
@@ -11,7 +11,7 @@ import {
 } from '@mui/material';
 import { useHistory } from 'react-router-dom';
 
-const APP_VERSION = '4.16';
+const APP_VERSION = '4.17';
 
 // Image credits - add more as needed
 const imageCredits = [

--- a/src/components/LandingPageV2/LandingPageV2.tsx
+++ b/src/components/LandingPageV2/LandingPageV2.tsx
@@ -9,8 +9,7 @@ import background from '../../assets/images/fantasybg.png';
 import HeroCarousel from './HeroCarousel';
 import SupportBanner from './SupportBanner';
 import BestiaryBanner from './BestiaryBanner';
-import ActiveSessionBanner from './ActiveSessionBanner';
-import ContinueJourneySection from './ContinueJourneySection';
+import ContinueAndTablesSection from './ContinueAndTablesSection';
 import BlogHighlights from './BlogHighlights';
 import ForumActivity from './ForumActivity';
 import BuildsShowcase from './BuildsShowcase';
@@ -114,14 +113,18 @@ const LandingPageV2: React.FC<LandingPageV2Props> = ({ onClickButton }) => {
                 <HeroCarousel onClickButton={onClickButton} />
               </Box>
 
-              {/* Active session banner (conditional) */}
-              <ActiveSessionBanner
-                onClickButton={onClickButton}
-                isAuthenticated={isAuthenticated}
-              />
+              {/* Continue jogando + Mesas virtuais — full width.
+                  Switches between: anon CTAs / active session highlight /
+                  2-column (recent sheets + tables). */}
+              <Box className='landing-section'>
+                <ContinueAndTablesSection
+                  onClickButton={onClickButton}
+                  isAuthenticated={isAuthenticated}
+                />
+              </Box>
 
-              {/* Inner grid: desktop = Forum left + Continue/Blog right;
-                  mobile = Continue → Forum → Blog stacked */}
+              {/* Inner grid: desktop = Forum left + Blog right;
+                  mobile = Forum → Blog stacked */}
               <Box
                 sx={{
                   display: 'grid',
@@ -133,32 +136,8 @@ const LandingPageV2: React.FC<LandingPageV2Props> = ({ onClickButton }) => {
                   alignItems: 'start',
                 }}
               >
-                {/* Continue jogando — desktop: col 2 row 1; mobile: 1st */}
-                <Box
-                  className='landing-section'
-                  sx={{
-                    minWidth: 0,
-                    order: { xs: 1, md: 0 },
-                    gridColumn: { md: '2' },
-                    gridRow: { md: '1' },
-                  }}
-                >
-                  <ContinueJourneySection
-                    onClickButton={onClickButton}
-                    isAuthenticated={isAuthenticated}
-                  />
-                </Box>
-
-                {/* Forum activity — desktop: col 1 spans 2 rows; mobile: 2nd */}
-                <Box
-                  className='landing-section'
-                  sx={{
-                    minWidth: 0,
-                    order: { xs: 2, md: 0 },
-                    gridColumn: { md: '1' },
-                    gridRow: { md: '1 / span 2' },
-                  }}
-                >
+                {/* Forum activity */}
+                <Box className='landing-section' sx={{ minWidth: 0 }}>
                   <ForumActivity
                     onClickButton={onClickButton}
                     threads={forumThreads}
@@ -167,16 +146,8 @@ const LandingPageV2: React.FC<LandingPageV2Props> = ({ onClickButton }) => {
                   />
                 </Box>
 
-                {/* Blog highlights — desktop: col 2 row 2; mobile: 3rd */}
-                <Box
-                  className='landing-section'
-                  sx={{
-                    minWidth: 0,
-                    order: { xs: 3, md: 0 },
-                    gridColumn: { md: '2' },
-                    gridRow: { md: '2' },
-                  }}
-                >
+                {/* Blog highlights */}
+                <Box className='landing-section' sx={{ minWidth: 0 }}>
                   <BlogHighlights
                     onClickButton={onClickButton}
                     posts={blogPosts}

--- a/src/components/LandingPageV2/LandingPageV2.tsx
+++ b/src/components/LandingPageV2/LandingPageV2.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Box, Stack } from '@mui/material';
+import { Box, Stack, useTheme } from '@mui/material';
 import { useAuth } from '../../hooks/useAuth';
 import { useFeatureAccess } from '../../hooks/useFeatureAccess';
 import { SEO, getPageSEO } from '../SEO';
 import '../../assets/css/landing-page-v2.css';
+import background from '../../assets/images/fantasybg.png';
 
 import HeroCarousel from './HeroCarousel';
 import SupportBanner from './SupportBanner';
@@ -23,6 +24,8 @@ interface LandingPageV2Props {
 const LandingPageV2: React.FC<LandingPageV2Props> = ({ onClickButton }) => {
   const { isAuthenticated } = useAuth();
   const bestiaryEnabled = useFeatureAccess('bestiary').isEnabled;
+  const theme = useTheme();
+  const isDarkTheme = theme.palette.mode === 'dark';
 
   const homeSEO = getPageSEO('home');
 
@@ -36,11 +39,42 @@ const LandingPageV2: React.FC<LandingPageV2Props> = ({ onClickButton }) => {
   return (
     <>
       <SEO title={homeSEO.title} description={homeSEO.description} url='/' />
+
+      {/* Full-width backdrop behind the hero — sits at the top of the page,
+          extends upward behind the navbar, and does NOT follow the scroll
+          (position: absolute, not fixed). Once the user scrolls past the
+          hero area, the rest of the page has its normal background. */}
+      <Box
+        sx={{
+          backgroundImage: `linear-gradient(
+              to bottom,
+              rgba(0, 0, 0, 0) 35%,
+              ${isDarkTheme ? '#212121' : '#f3f2f1'}
+            ), url(${background})`,
+          backgroundSize: 'cover',
+          backgroundRepeat: 'no-repeat',
+          backgroundPosition: { xs: 'center top', sm: 'center center' },
+          position: 'absolute',
+          top: -120,
+          left: 0,
+          right: 0,
+          width: '100%',
+          height: {
+            xs: 'calc(38vh + 120px)',
+            sm: 'calc(42vh + 120px)',
+            md: 'calc(45vh + 120px)',
+          },
+          zIndex: 0,
+          pointerEvents: 'none',
+        }}
+      />
+
       <Stack
         direction='row'
         alignItems='center'
         justifyContent='center'
         spacing={2}
+        sx={{ position: 'relative', zIndex: 1 }}
       >
         <Box
           sx={{

--- a/src/components/LandingPageV2/LandingPageV2.tsx
+++ b/src/components/LandingPageV2/LandingPageV2.tsx
@@ -9,11 +9,13 @@ import background from '../../assets/images/fantasybg.png';
 import HeroCarousel from './HeroCarousel';
 import SupportBanner from './SupportBanner';
 import BestiaryBanner from './BestiaryBanner';
-import RecentSheetsSection from './RecentSheetsSection';
-import MainToolsSection from './MainToolsSection';
-import SecondaryToolsSection from './SecondaryToolsSection';
-import GameSessionsSection from './GameSessionsSection';
-import CommunityFeedSection from './CommunityFeedSection';
+import ActiveSessionBanner from './ActiveSessionBanner';
+import ContinueJourneySection from './ContinueJourneySection';
+import BlogHighlights from './BlogHighlights';
+import ForumActivity from './ForumActivity';
+import BuildsShowcase from './BuildsShowcase';
+import ToolsSidebar from './ToolsSidebar';
+import useCommunityHighlights from './hooks/useCommunityHighlights';
 
 interface LandingPageV2Props {
   onClickButton: (link: string) => void;
@@ -26,6 +28,13 @@ const LandingPageV2: React.FC<LandingPageV2Props> = ({ onClickButton }) => {
   const isDarkTheme = theme.palette.mode === 'dark';
 
   const homeSEO = getPageSEO('home');
+
+  const {
+    blogPosts,
+    forumThreads,
+    builds,
+    loading: highlightsLoading,
+  } = useCommunityHighlights();
 
   return (
     <>
@@ -44,14 +53,14 @@ const LandingPageV2: React.FC<LandingPageV2Props> = ({ onClickButton }) => {
               xs: '100%',
               sm: '95%',
               md: '95%',
-              lg: '90%',
-              xl: '80%',
+              lg: '92%',
+              xl: '85%',
             },
             width: '100%',
             boxSizing: 'border-box',
           }}
         >
-          {/* Hero Background with Fade - Fixed to viewport */}
+          {/* Fixed hero background */}
           <Box
             sx={{
               backgroundImage: `linear-gradient(
@@ -67,106 +76,115 @@ const LandingPageV2: React.FC<LandingPageV2Props> = ({ onClickButton }) => {
               left: 0,
               right: 0,
               width: '100%',
-              height: { xs: '50vh', sm: '60vh', md: '65vh' },
+              height: { xs: '35vh', sm: '40vh', md: '45vh' },
               zIndex: 0,
               pointerEvents: 'none',
             }}
           />
+
+          {/* Two-column layout: main content (with hero on top) + tools sidebar */}
           <Box
             sx={{
               display: 'grid',
               gridTemplateColumns: {
                 xs: 'minmax(0, 1fr)',
-                md: 'minmax(0, 1fr) 30%',
+                md: 'minmax(0, 1fr) 280px',
+                lg: 'minmax(0, 1fr) 320px',
               },
-              gridTemplateRows: { md: 'repeat(5, auto)' },
-              gap: 2,
+              gap: { xs: 2, md: 3 },
               alignItems: 'start',
-              minHeight: '100vh',
-              pb: 4,
               position: 'relative',
+              pt: 1,
+              pb: 4,
             }}
           >
-            {/* Hero Carousel */}
-            <Box sx={{ order: 1, gridColumn: '1' }}>
-              <HeroCarousel onClickButton={onClickButton} />
-            </Box>
+            {/* MAIN COLUMN */}
+            <Stack spacing={{ xs: 3, md: 4 }} sx={{ minWidth: 0 }}>
+              {/* Hero carousel — shares row with sidebar */}
+              <Box className='landing-section'>
+                <HeroCarousel onClickButton={onClickButton} />
+              </Box>
 
-            {/* Sidebar - appears after hero on mobile, right column on desktop */}
+              {/* Active session banner (conditional) */}
+              <ActiveSessionBanner
+                onClickButton={onClickButton}
+                isAuthenticated={isAuthenticated}
+              />
+
+              {/* Two-column inner grid: Continue+Blog (left) + Forum (right/center) */}
+              <Box
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: {
+                    xs: 'minmax(0, 1fr)',
+                    md: 'minmax(0, 5fr) minmax(0, 7fr)',
+                  },
+                  gap: { xs: 3, md: 3 },
+                  alignItems: 'start',
+                }}
+              >
+                {/* Left inner column: continue jogando + blog */}
+                <Stack spacing={{ xs: 3, md: 4 }} sx={{ minWidth: 0 }}>
+                  <Box className='landing-section'>
+                    <ContinueJourneySection
+                      onClickButton={onClickButton}
+                      isAuthenticated={isAuthenticated}
+                    />
+                  </Box>
+                  <Box className='landing-section'>
+                    <BlogHighlights
+                      onClickButton={onClickButton}
+                      posts={blogPosts}
+                      loading={highlightsLoading}
+                    />
+                  </Box>
+                </Stack>
+
+                {/* Right (center) inner column: forum activity — main focus */}
+                <Box className='landing-section'>
+                  <ForumActivity
+                    onClickButton={onClickButton}
+                    threads={forumThreads}
+                    loading={highlightsLoading}
+                    isAuthenticated={isAuthenticated}
+                  />
+                </Box>
+              </Box>
+
+              {/* Bestiary banner — full width below the 2-col section */}
+              {bestiaryEnabled && (
+                <Box className='landing-section'>
+                  <BestiaryBanner onClickButton={onClickButton} />
+                </Box>
+              )}
+
+              {/* Builds showcase (grid 4-col) */}
+              <Box className='landing-section'>
+                <BuildsShowcase
+                  onClickButton={onClickButton}
+                  builds={builds}
+                  loading={highlightsLoading}
+                />
+              </Box>
+
+              {/* Support banner */}
+              <Box className='landing-section'>
+                <SupportBanner onClickButton={onClickButton} />
+              </Box>
+            </Stack>
+
+            {/* SIDEBAR (sticky on desktop) */}
             <Box
               sx={{
-                order: { xs: 2, md: 2 },
-                gridColumn: { xs: '1', md: '2' },
-                gridRow: { md: '1 / -1' },
                 position: { md: 'sticky' },
                 top: { md: 80 },
-                maxWidth: '100%',
-                boxSizing: 'border-box',
-                overflow: 'hidden',
-                background: isDarkTheme
-                  ? 'rgba(33, 33, 33, 0.85)'
-                  : 'rgba(243, 242, 241, 0.85)',
-                backdropFilter: 'blur(10px)',
-                borderRadius: 3,
-                p: 2,
-                border: `1px solid ${
-                  isDarkTheme
-                    ? 'rgba(255, 255, 255, 0.1)'
-                    : 'rgba(0, 0, 0, 0.1)'
-                }`,
+                minWidth: 0,
               }}
             >
-              <Box className='landing-section'>
-                <CommunityFeedSection
-                  onClickButton={onClickButton}
-                  isAuthenticated={isAuthenticated}
-                />
-              </Box>
-              <Box className='landing-section'>
-                <RecentSheetsSection
-                  onClickButton={onClickButton}
-                  isAuthenticated={isAuthenticated}
-                />
-              </Box>
-            </Box>
-
-            {/* Bestiary Highlight Banner */}
-            {bestiaryEnabled && (
-              <Box
-                className='landing-section'
-                sx={{ order: 3, gridColumn: '1', mt: 1 }}
-              >
-                <BestiaryBanner onClickButton={onClickButton} />
-              </Box>
-            )}
-
-            {/* Support Banner */}
-            <Box
-              className='landing-section'
-              sx={{ order: 4, gridColumn: '1', mt: 1 }}
-            >
-              <SupportBanner onClickButton={onClickButton} />
-            </Box>
-
-            {/* Main Tools Section */}
-            <Box className='landing-section' sx={{ order: 5, gridColumn: '1' }}>
-              <MainToolsSection
+              <ToolsSidebar
                 onClickButton={onClickButton}
                 isAuthenticated={isAuthenticated}
               />
-            </Box>
-
-            {/* Game Sessions Section */}
-            <Box className='landing-section' sx={{ order: 6, gridColumn: '1' }}>
-              <GameSessionsSection
-                onClickButton={onClickButton}
-                isAuthenticated={isAuthenticated}
-              />
-            </Box>
-
-            {/* Secondary Tools Section */}
-            <Box className='landing-section' sx={{ order: 7, gridColumn: '1' }}>
-              <SecondaryToolsSection onClickButton={onClickButton} />
             </Box>
           </Box>
         </Box>

--- a/src/components/LandingPageV2/LandingPageV2.tsx
+++ b/src/components/LandingPageV2/LandingPageV2.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { Box, Stack, useTheme } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import { useAuth } from '../../hooks/useAuth';
 import { useFeatureAccess } from '../../hooks/useFeatureAccess';
 import { SEO, getPageSEO } from '../SEO';
 import '../../assets/css/landing-page-v2.css';
-import background from '../../assets/images/fantasybg.png';
 
 import HeroCarousel from './HeroCarousel';
 import SupportBanner from './SupportBanner';
@@ -24,8 +23,6 @@ interface LandingPageV2Props {
 const LandingPageV2: React.FC<LandingPageV2Props> = ({ onClickButton }) => {
   const { isAuthenticated } = useAuth();
   const bestiaryEnabled = useFeatureAccess('bestiary').isEnabled;
-  const theme = useTheme();
-  const isDarkTheme = theme.palette.mode === 'dark';
 
   const homeSEO = getPageSEO('home');
 
@@ -60,28 +57,6 @@ const LandingPageV2: React.FC<LandingPageV2Props> = ({ onClickButton }) => {
             boxSizing: 'border-box',
           }}
         >
-          {/* Fixed hero background */}
-          <Box
-            sx={{
-              backgroundImage: `linear-gradient(
-            to bottom,
-            rgba(255, 255, 255, 0) 20%,
-            ${isDarkTheme ? '#212121' : '#f3f2f1'}
-          ), url(${background})`,
-              backgroundSize: 'cover',
-              backgroundRepeat: 'no-repeat',
-              backgroundPosition: { xs: 'center top', sm: 'center center' },
-              position: 'fixed',
-              top: 0,
-              left: 0,
-              right: 0,
-              width: '100%',
-              height: { xs: '35vh', sm: '40vh', md: '45vh' },
-              zIndex: 0,
-              pointerEvents: 'none',
-            }}
-          />
-
           {/* Two-column layout: main content (with hero on top) + tools sidebar */}
           <Box
             sx={{
@@ -111,42 +86,67 @@ const LandingPageV2: React.FC<LandingPageV2Props> = ({ onClickButton }) => {
                 isAuthenticated={isAuthenticated}
               />
 
-              {/* Two-column inner grid: Continue+Blog (left) + Forum (right/center) */}
+              {/* Inner grid: desktop = Forum left + Continue/Blog right;
+                  mobile = Continue → Forum → Blog stacked */}
               <Box
                 sx={{
                   display: 'grid',
                   gridTemplateColumns: {
                     xs: 'minmax(0, 1fr)',
-                    md: 'minmax(0, 5fr) minmax(0, 7fr)',
+                    md: 'minmax(0, 7fr) minmax(0, 5fr)',
                   },
-                  gap: { xs: 3, md: 3 },
+                  gap: 3,
                   alignItems: 'start',
                 }}
               >
-                {/* Left inner column: continue jogando + blog */}
-                <Stack spacing={{ xs: 3, md: 4 }} sx={{ minWidth: 0 }}>
-                  <Box className='landing-section'>
-                    <ContinueJourneySection
-                      onClickButton={onClickButton}
-                      isAuthenticated={isAuthenticated}
-                    />
-                  </Box>
-                  <Box className='landing-section'>
-                    <BlogHighlights
-                      onClickButton={onClickButton}
-                      posts={blogPosts}
-                      loading={highlightsLoading}
-                    />
-                  </Box>
-                </Stack>
+                {/* Continue jogando — desktop: col 2 row 1; mobile: 1st */}
+                <Box
+                  className='landing-section'
+                  sx={{
+                    minWidth: 0,
+                    order: { xs: 1, md: 0 },
+                    gridColumn: { md: '2' },
+                    gridRow: { md: '1' },
+                  }}
+                >
+                  <ContinueJourneySection
+                    onClickButton={onClickButton}
+                    isAuthenticated={isAuthenticated}
+                  />
+                </Box>
 
-                {/* Right (center) inner column: forum activity — main focus */}
-                <Box className='landing-section'>
+                {/* Forum activity — desktop: col 1 spans 2 rows; mobile: 2nd */}
+                <Box
+                  className='landing-section'
+                  sx={{
+                    minWidth: 0,
+                    order: { xs: 2, md: 0 },
+                    gridColumn: { md: '1' },
+                    gridRow: { md: '1 / span 2' },
+                  }}
+                >
                   <ForumActivity
                     onClickButton={onClickButton}
                     threads={forumThreads}
                     loading={highlightsLoading}
                     isAuthenticated={isAuthenticated}
+                  />
+                </Box>
+
+                {/* Blog highlights — desktop: col 2 row 2; mobile: 3rd */}
+                <Box
+                  className='landing-section'
+                  sx={{
+                    minWidth: 0,
+                    order: { xs: 3, md: 0 },
+                    gridColumn: { md: '2' },
+                    gridRow: { md: '2' },
+                  }}
+                >
+                  <BlogHighlights
+                    onClickButton={onClickButton}
+                    posts={blogPosts}
+                    loading={highlightsLoading}
                   />
                 </Box>
               </Box>

--- a/src/components/LandingPageV2/LandingPageV2.tsx
+++ b/src/components/LandingPageV2/LandingPageV2.tsx
@@ -97,8 +97,8 @@ const LandingPageV2: React.FC<LandingPageV2Props> = ({ onClickButton }) => {
               display: 'grid',
               gridTemplateColumns: {
                 xs: 'minmax(0, 1fr)',
-                md: 'minmax(0, 1fr) 280px',
-                lg: 'minmax(0, 1fr) 320px',
+                md: 'minmax(0, 1fr) 320px',
+                lg: 'minmax(0, 1fr) 360px',
               },
               gap: { xs: 2, md: 3 },
               alignItems: 'start',

--- a/src/components/LandingPageV2/MainToolsSection.tsx
+++ b/src/components/LandingPageV2/MainToolsSection.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { Box, Grid } from '@mui/material';
+import { Box, Typography, Grid } from '@mui/material';
 import GroupIcon from '@mui/icons-material/Group';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
 import MapIcon from '@mui/icons-material/Map';
 import StorageIcon from '@mui/icons-material/Storage';
+import TableRestaurantIcon from '@mui/icons-material/TableRestaurant';
+import { useAuthContext } from '../../contexts/AuthContext';
 import ToolCard from './ToolCard';
 
 interface MainToolsSectionProps {
@@ -15,8 +17,18 @@ const MainToolsSection: React.FC<MainToolsSectionProps> = ({
   onClickButton,
   isAuthenticated,
 }) => {
+  const { openLoginModal } = useAuthContext();
+
   const handleExternalLink = (url: string) => {
     window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  const handleMesaVirtual = () => {
+    if (isAuthenticated) {
+      onClickButton('/mesas');
+    } else {
+      openLoginModal();
+    }
   };
 
   const mainTools = [
@@ -30,15 +42,27 @@ const MainToolsSection: React.FC<MainToolsSectionProps> = ({
       ) : (
         <PersonAddIcon sx={{ fontSize: 'inherit' }} />
       ),
-      link: isAuthenticated ? '/meus-personagens' : '/criar-ficha',
+      onClick: () =>
+        onClickButton(isAuthenticated ? '/meus-personagens' : '/criar-ficha'),
       isPrimary: true,
+      isExternal: false,
+    },
+    {
+      title: 'Mesa Virtual',
+      description: isAuthenticated
+        ? 'Crie e gerencie mesas para jogar com seus amigos'
+        : 'Jogue Tormenta 20 online em tempo real',
+      icon: <TableRestaurantIcon sx={{ fontSize: 'inherit' }} />,
+      onClick: handleMesaVirtual,
+      isPrimary: false,
       isExternal: false,
     },
     {
       title: 'Mapa de Arton',
       description: 'Explore o mundo de Arton de forma interativa',
       icon: <MapIcon sx={{ fontSize: 'inherit' }} />,
-      link: 'https://mapadearton.fichasdenimb.com.br/',
+      onClick: () =>
+        handleExternalLink('https://mapadearton.fichasdenimb.com.br/'),
       isPrimary: false,
       isExternal: true,
     },
@@ -46,7 +70,7 @@ const MainToolsSection: React.FC<MainToolsSectionProps> = ({
       title: 'Enciclopédia de Tanah-Toh',
       description: 'Consulte raças, classes, magias e muito mais',
       icon: <StorageIcon sx={{ fontSize: 'inherit' }} />,
-      link: '/database',
+      onClick: () => onClickButton('/database'),
       isPrimary: false,
       isExternal: false,
     },
@@ -54,12 +78,12 @@ const MainToolsSection: React.FC<MainToolsSectionProps> = ({
 
   return (
     <Box>
+      <Typography variant='h5' className='section-title' sx={{ mb: 2 }}>
+        Ações rápidas
+      </Typography>
       <Grid container spacing={{ xs: 2, md: 3 }}>
         {mainTools.map((tool, index) => (
-          <Grid
-            size={{ xs: 12, sm: tool.isPrimary ? 12 : 6, md: 4 }}
-            key={tool.title}
-          >
+          <Grid size={{ xs: 12, sm: 6, md: 3 }} key={tool.title}>
             <ToolCard
               title={tool.title}
               description={tool.description}
@@ -67,11 +91,7 @@ const MainToolsSection: React.FC<MainToolsSectionProps> = ({
               isPrimary={tool.isPrimary}
               isExternal={tool.isExternal}
               delay={0.1 * (index + 1)}
-              onClick={() =>
-                tool.isExternal
-                  ? handleExternalLink(tool.link)
-                  : onClickButton(tool.link)
-              }
+              onClick={tool.onClick}
             />
           </Grid>
         ))}

--- a/src/components/LandingPageV2/ToolsSidebar.tsx
+++ b/src/components/LandingPageV2/ToolsSidebar.tsx
@@ -111,7 +111,9 @@ const ToolsSidebar: React.FC<ToolsSidebarProps> = ({
           key: 'my-threats',
           title: 'Minhas Ameaças',
           icon: <PetsIcon />,
-          onClick: requireAuth(() => onClickButton('/meu-bestiario')),
+          onClick: requireAuth(() =>
+            onClickButton('/meus-personagens?tab=ameacas')
+          ),
         },
       ],
     },

--- a/src/components/LandingPageV2/ToolsSidebar.tsx
+++ b/src/components/LandingPageV2/ToolsSidebar.tsx
@@ -12,8 +12,12 @@ import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
 import ArchitectureIcon from '@mui/icons-material/Architecture';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import ConstructionIcon from '@mui/icons-material/Construction';
+import EditNoteIcon from '@mui/icons-material/EditNote';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { useAuthContext } from '../../contexts/AuthContext';
+import { useAuth } from '../../hooks/useAuth';
+
+const ADMIN_EMAIL = 'yuri.alessandro.m@gmail.com';
 
 interface ToolsSidebarProps {
   onClickButton: (link: string) => void;
@@ -41,6 +45,9 @@ const ToolsSidebar: React.FC<ToolsSidebarProps> = ({
   const theme = useTheme();
   const isDark = theme.palette.mode === 'dark';
   const { openLoginModal } = useAuthContext();
+  const { user, isEditor } = useAuth();
+  const isAdmin = user?.email === ADMIN_EMAIL;
+  const canCreateBlogPost = isAdmin || isEditor;
 
   const openExternal = (url: string) => {
     window.open(url, '_blank', 'noopener,noreferrer');
@@ -72,6 +79,21 @@ const ToolsSidebar: React.FC<ToolsSidebarProps> = ({
   };
 
   const groups: ToolGroup[] = [
+    ...(canCreateBlogPost
+      ? [
+          {
+            title: 'Editor',
+            items: [
+              {
+                key: 'new-blog-post',
+                title: 'Novo Post',
+                icon: <EditNoteIcon />,
+                onClick: () => onClickButton('/blog/novo'),
+              },
+            ],
+          },
+        ]
+      : []),
     {
       title: 'Personagens',
       items: [

--- a/src/components/LandingPageV2/ToolsSidebar.tsx
+++ b/src/components/LandingPageV2/ToolsSidebar.tsx
@@ -237,8 +237,11 @@ const ToolsSidebar: React.FC<ToolsSidebarProps> = ({
             <Box
               sx={{
                 display: 'grid',
-                gridTemplateColumns: 'repeat(2, 1fr)',
-                gap: 1,
+                gridTemplateColumns: {
+                  xs: 'repeat(2, 1fr)',
+                  md: 'repeat(3, 1fr)',
+                },
+                gap: { xs: 1.25, md: 0.75 },
               }}
             >
               {group.items.map((item) => (
@@ -250,13 +253,13 @@ const ToolsSidebar: React.FC<ToolsSidebarProps> = ({
                     color: getItemColor(item.isPrimary),
                     border: `1px solid ${getItemBorderColor(item.isPrimary)}`,
                     borderRadius: 1.5,
-                    p: 1.25,
+                    p: { xs: 1.5, md: 1 },
                     cursor: 'pointer',
                     display: 'flex',
                     flexDirection: 'column',
                     alignItems: 'flex-start',
-                    gap: 0.5,
-                    minHeight: 72,
+                    gap: { xs: 0.75, md: 0.5 },
+                    minHeight: { xs: 96, md: 76 },
                     position: 'relative',
                     transition: 'all 0.18s ease',
                     '&:hover': {
@@ -281,7 +284,7 @@ const ToolsSidebar: React.FC<ToolsSidebarProps> = ({
                   )}
                   <Box
                     sx={{
-                      fontSize: 20,
+                      fontSize: { xs: 26, md: 20 },
                       color: item.isPrimary
                         ? 'rgba(255,255,255,0.95)'
                         : theme.palette.primary.main,
@@ -293,7 +296,7 @@ const ToolsSidebar: React.FC<ToolsSidebarProps> = ({
                   <Typography
                     variant='caption'
                     sx={{
-                      fontSize: '0.75rem',
+                      fontSize: { xs: '0.85rem', md: '0.7rem' },
                       fontWeight: 600,
                       lineHeight: 1.2,
                       display: '-webkit-box',

--- a/src/components/LandingPageV2/ToolsSidebar.tsx
+++ b/src/components/LandingPageV2/ToolsSidebar.tsx
@@ -1,0 +1,293 @@
+import React from 'react';
+import { Box, Typography, Stack, useTheme } from '@mui/material';
+import GroupIcon from '@mui/icons-material/Group';
+import PersonAddIcon from '@mui/icons-material/PersonAdd';
+import MapIcon from '@mui/icons-material/Map';
+import StorageIcon from '@mui/icons-material/Storage';
+import TableRestaurantIcon from '@mui/icons-material/TableRestaurant';
+import AutoStoriesIcon from '@mui/icons-material/AutoStories';
+import PetsIcon from '@mui/icons-material/Pets';
+import BookIcon from '@mui/icons-material/Book';
+import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
+import ArchitectureIcon from '@mui/icons-material/Architecture';
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import ConstructionIcon from '@mui/icons-material/Construction';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { useAuthContext } from '../../contexts/AuthContext';
+
+interface ToolsSidebarProps {
+  onClickButton: (link: string) => void;
+  isAuthenticated: boolean;
+}
+
+interface ToolItem {
+  key: string;
+  title: string;
+  icon: React.ReactNode;
+  onClick: () => void;
+  isExternal?: boolean;
+  isPrimary?: boolean;
+}
+
+interface ToolGroup {
+  title: string;
+  items: ToolItem[];
+}
+
+const ToolsSidebar: React.FC<ToolsSidebarProps> = ({
+  onClickButton,
+  isAuthenticated,
+}) => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === 'dark';
+  const { openLoginModal } = useAuthContext();
+
+  const openExternal = (url: string) => {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  const requireAuth = (action: () => void) => () => {
+    if (isAuthenticated) {
+      action();
+    } else {
+      openLoginModal();
+    }
+  };
+
+  const getItemBackground = (isPrimary?: boolean): string => {
+    if (isPrimary) {
+      return `linear-gradient(135deg, ${theme.palette.primary.main} 0%, ${theme.palette.primary.dark} 100%)`;
+    }
+    return isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.03)';
+  };
+
+  const getItemColor = (isPrimary?: boolean): string => {
+    if (isPrimary || isDark) return '#ffffff';
+    return 'inherit';
+  };
+
+  const getItemBorderColor = (isPrimary?: boolean): string => {
+    if (isPrimary) return theme.palette.primary.dark;
+    return isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
+  };
+
+  const groups: ToolGroup[] = [
+    {
+      title: 'Personagens',
+      items: [
+        {
+          key: 'characters',
+          title: isAuthenticated ? 'Meus Personagens' : 'Criar Personagem',
+          icon: isAuthenticated ? <GroupIcon /> : <PersonAddIcon />,
+          onClick: () =>
+            onClickButton(
+              isAuthenticated ? '/meus-personagens' : '/criar-ficha'
+            ),
+          isPrimary: true,
+        },
+        {
+          key: 'my-threats',
+          title: 'Minhas Ameaças',
+          icon: <PetsIcon />,
+          onClick: requireAuth(() => onClickButton('/meu-bestiario')),
+        },
+      ],
+    },
+    {
+      title: 'Comunidade',
+      items: [
+        {
+          key: 'tables',
+          title: 'Mesa Virtual',
+          icon: <TableRestaurantIcon />,
+          onClick: requireAuth(() => onClickButton('/mesas')),
+        },
+        {
+          key: 'builds',
+          title: 'Builds',
+          icon: <ConstructionIcon />,
+          onClick: () => onClickButton('/builds'),
+        },
+        {
+          key: 'bestiary',
+          title: 'Bestiário',
+          icon: <AutoStoriesIcon />,
+          onClick: () => onClickButton('/bestiario'),
+        },
+      ],
+    },
+    {
+      title: 'Consulta',
+      items: [
+        {
+          key: 'encyclopedia',
+          title: 'Enciclopédia',
+          icon: <StorageIcon />,
+          onClick: () => onClickButton('/database'),
+        },
+        {
+          key: 'map',
+          title: 'Mapa de Arton',
+          icon: <MapIcon />,
+          onClick: () =>
+            openExternal('https://mapadearton.fichasdenimb.com.br/'),
+          isExternal: true,
+        },
+        {
+          key: 'cave',
+          title: 'Caverna do Saber',
+          icon: <BookIcon />,
+          onClick: () => onClickButton('/caverna-do-saber'),
+        },
+      ],
+    },
+    {
+      title: 'Gerar',
+      items: [
+        {
+          key: 'rewards',
+          title: 'Recompensas',
+          icon: <AttachMoneyIcon />,
+          onClick: () => onClickButton('/recompensas'),
+        },
+        {
+          key: 'superior-items',
+          title: 'Itens Superiores',
+          icon: <ArchitectureIcon />,
+          onClick: () => onClickButton('/itens-superiores'),
+        },
+        {
+          key: 'magic-items',
+          title: 'Itens Mágicos',
+          icon: <AutoFixHighIcon />,
+          onClick: () => onClickButton('/itens-magicos'),
+        },
+      ],
+    },
+  ];
+
+  return (
+    <Box
+      sx={{
+        background: isDark
+          ? 'rgba(33, 33, 33, 0.92)'
+          : 'rgba(243, 242, 241, 0.92)',
+        backdropFilter: 'blur(10px)',
+        borderRadius: 3,
+        p: 2,
+        border: `1px solid ${
+          isDark ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)'
+        }`,
+      }}
+    >
+      <Typography
+        variant='h6'
+        sx={{
+          fontFamily: 'Tfont, serif',
+          fontWeight: 700,
+          mb: 2,
+          color: theme.palette.primary.main,
+        }}
+      >
+        Ferramentas
+      </Typography>
+
+      <Stack spacing={2.5}>
+        {groups.map((group) => (
+          <Box key={group.title}>
+            <Typography
+              variant='caption'
+              sx={{
+                textTransform: 'uppercase',
+                fontSize: '0.65rem',
+                letterSpacing: 1,
+                fontWeight: 700,
+                color: 'text.secondary',
+                display: 'block',
+                mb: 1,
+              }}
+            >
+              {group.title}
+            </Typography>
+
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(2, 1fr)',
+                gap: 1,
+              }}
+            >
+              {group.items.map((item) => (
+                <Box
+                  key={item.key}
+                  onClick={item.onClick}
+                  sx={{
+                    background: getItemBackground(item.isPrimary),
+                    color: getItemColor(item.isPrimary),
+                    border: `1px solid ${getItemBorderColor(item.isPrimary)}`,
+                    borderRadius: 1.5,
+                    p: 1.25,
+                    cursor: 'pointer',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'flex-start',
+                    gap: 0.5,
+                    minHeight: 72,
+                    position: 'relative',
+                    transition: 'all 0.18s ease',
+                    '&:hover': {
+                      transform: 'translateY(-2px)',
+                      borderColor: theme.palette.primary.main,
+                      boxShadow: `0 4px 12px ${
+                        item.isPrimary ? 'rgba(0,0,0,0.3)' : 'rgba(0,0,0,0.12)'
+                      }`,
+                    },
+                  }}
+                >
+                  {item.isExternal && (
+                    <OpenInNewIcon
+                      sx={{
+                        position: 'absolute',
+                        top: 6,
+                        right: 6,
+                        fontSize: 12,
+                        opacity: 0.5,
+                      }}
+                    />
+                  )}
+                  <Box
+                    sx={{
+                      fontSize: 20,
+                      color: item.isPrimary
+                        ? 'rgba(255,255,255,0.95)'
+                        : theme.palette.primary.main,
+                      display: 'flex',
+                    }}
+                  >
+                    {item.icon}
+                  </Box>
+                  <Typography
+                    variant='caption'
+                    sx={{
+                      fontSize: '0.75rem',
+                      fontWeight: 600,
+                      lineHeight: 1.2,
+                      display: '-webkit-box',
+                      WebkitLineClamp: 2,
+                      WebkitBoxOrient: 'vertical',
+                      overflow: 'hidden',
+                    }}
+                  >
+                    {item.title}
+                  </Typography>
+                </Box>
+              ))}
+            </Box>
+          </Box>
+        ))}
+      </Stack>
+    </Box>
+  );
+};
+
+export default ToolsSidebar;

--- a/src/components/LandingPageV2/VirtualTablesColumn.tsx
+++ b/src/components/LandingPageV2/VirtualTablesColumn.tsx
@@ -1,0 +1,295 @@
+import React from 'react';
+import { Box, Typography, Button, Stack, Chip, useTheme } from '@mui/material';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import AddIcon from '@mui/icons-material/Add';
+import TableRestaurantIcon from '@mui/icons-material/TableRestaurant';
+import PeopleAltIcon from '@mui/icons-material/PeopleAlt';
+import {
+  GameTable,
+  GameTableStatus,
+} from '../../premium/services/gameTable.service';
+
+interface VirtualTablesColumnProps {
+  onClickButton: (link: string) => void;
+  tables: GameTable[];
+}
+
+const MAX_TABLES = 2;
+
+const statusLabel = (status: GameTableStatus): string => {
+  switch (status) {
+    case GameTableStatus.ACTIVE:
+      return 'Ativa';
+    case GameTableStatus.PAUSED:
+      return 'Pausada';
+    case GameTableStatus.ARCHIVED:
+      return 'Arquivada';
+    default:
+      return 'Preparando';
+  }
+};
+
+const statusColor = (
+  status: GameTableStatus
+): 'success' | 'warning' | 'default' | 'info' => {
+  switch (status) {
+    case GameTableStatus.ACTIVE:
+      return 'success';
+    case GameTableStatus.PAUSED:
+      return 'warning';
+    case GameTableStatus.ARCHIVED:
+      return 'default';
+    default:
+      return 'info';
+  }
+};
+
+const formatDate = (dateString?: string): string => {
+  if (!dateString) return '';
+  return new Date(dateString).toLocaleDateString('pt-BR');
+};
+
+const VirtualTablesColumn: React.FC<VirtualTablesColumnProps> = ({
+  onClickButton,
+  tables,
+}) => {
+  const theme = useTheme();
+  const isDark = theme.palette.mode === 'dark';
+
+  const sectionHeader = (action?: React.ReactNode) => (
+    <Stack
+      direction='row'
+      alignItems='center'
+      justifyContent='space-between'
+      sx={{ mb: 1.5 }}
+    >
+      <Typography
+        variant='subtitle1'
+        sx={{
+          fontFamily: 'Tfont, serif',
+          fontWeight: 700,
+          color: theme.palette.primary.main,
+        }}
+      >
+        Suas mesas
+      </Typography>
+      {action}
+    </Stack>
+  );
+
+  // No tables yet — empty state
+  if (tables.length === 0) {
+    return (
+      <Box>
+        {sectionHeader()}
+        <Box
+          onClick={() => onClickButton('/mesas')}
+          sx={{
+            background: `linear-gradient(135deg, ${theme.palette.primary.main} 0%, ${theme.palette.primary.dark} 100%)`,
+            color: '#ffffff',
+            borderRadius: 2,
+            p: 2,
+            cursor: 'pointer',
+            border: `2px solid ${theme.palette.primary.dark}`,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 2,
+            transition: 'all 0.2s ease',
+            '&:hover': {
+              transform: 'translateY(-2px)',
+              boxShadow: '0 8px 20px rgba(0,0,0,0.25)',
+            },
+          }}
+        >
+          <TableRestaurantIcon
+            sx={{ fontSize: 36, opacity: 0.95, flexShrink: 0 }}
+          />
+          <Box sx={{ flex: 1 }}>
+            <Typography
+              variant='subtitle1'
+              sx={{ fontFamily: 'Tfont, serif', fontWeight: 700, mb: 0.25 }}
+            >
+              Crie sua primeira mesa
+            </Typography>
+            <Typography
+              variant='caption'
+              sx={{ opacity: 0.9, fontSize: '0.8rem' }}
+            >
+              Jogue Tormenta 20 online com seus amigos
+            </Typography>
+          </Box>
+          <ArrowForwardIcon sx={{ flexShrink: 0 }} />
+        </Box>
+      </Box>
+    );
+  }
+
+  const visibleTables = tables.slice(0, MAX_TABLES);
+
+  return (
+    <Box>
+      {sectionHeader(
+        <Button
+          size='small'
+          endIcon={<ArrowForwardIcon sx={{ fontSize: 14 }} />}
+          onClick={() => onClickButton('/mesas')}
+          sx={{ textTransform: 'none', fontSize: '0.75rem' }}
+        >
+          Ver todas
+        </Button>
+      )}
+
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: {
+            xs: '1fr',
+            sm: 'repeat(2, 1fr)',
+            md: `repeat(${visibleTables.length + 1}, minmax(0, 1fr))`,
+          },
+          gap: 1.25,
+        }}
+      >
+        {visibleTables.map((table, index) => (
+          <Box
+            key={table.id}
+            onClick={() => onClickButton(`/mesa/${table.id}`)}
+            sx={{
+              animation: `scaleIn 0.4s ease-out ${0.08 * (index + 1)}s both`,
+              background: isDark
+                ? 'rgba(45, 45, 45, 0.85)'
+                : 'rgba(255, 255, 255, 0.9)',
+              color: isDark ? '#ffffff' : 'inherit',
+              borderRadius: 2,
+              cursor: 'pointer',
+              border: `1px solid ${
+                isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)'
+              }`,
+              p: 1,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1.25,
+              minWidth: 0,
+              transition: 'all 0.18s ease',
+              '&:hover': {
+                transform: 'translateY(-2px)',
+                borderColor: theme.palette.primary.main,
+                boxShadow: `0 4px 12px ${
+                  isDark ? 'rgba(0,0,0,0.4)' : 'rgba(0,0,0,0.12)'
+                }`,
+              },
+            }}
+          >
+            <Box
+              sx={{
+                width: 44,
+                height: 44,
+                borderRadius: 1,
+                flexShrink: 0,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                background: `linear-gradient(135deg, ${theme.palette.primary.main} 0%, ${theme.palette.primary.dark} 100%)`,
+                color: '#ffffff',
+              }}
+            >
+              <TableRestaurantIcon sx={{ fontSize: 22 }} />
+            </Box>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography
+                variant='subtitle2'
+                sx={{
+                  fontFamily: 'Tfont, serif',
+                  fontWeight: 700,
+                  lineHeight: 1.15,
+                  fontSize: '0.85rem',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {table.name}
+              </Typography>
+              <Stack
+                direction='row'
+                spacing={0.75}
+                alignItems='center'
+                sx={{ mt: 0.25, minWidth: 0 }}
+              >
+                <Chip
+                  label={statusLabel(table.status)}
+                  size='small'
+                  color={statusColor(table.status)}
+                  sx={{
+                    fontSize: '0.6rem',
+                    height: 16,
+                    '& .MuiChip-label': { px: 0.75 },
+                  }}
+                />
+                <Stack
+                  direction='row'
+                  spacing={0.3}
+                  alignItems='center'
+                  sx={{ color: 'text.secondary' }}
+                >
+                  <PeopleAltIcon sx={{ fontSize: 11 }} />
+                  <Typography
+                    variant='caption'
+                    color='text.secondary'
+                    sx={{ fontSize: '0.65rem' }}
+                  >
+                    {table.members.length}
+                  </Typography>
+                </Stack>
+                <Typography
+                  variant='caption'
+                  color='text.secondary'
+                  sx={{ fontSize: '0.65rem' }}
+                >
+                  {formatDate(table.updatedAt)}
+                </Typography>
+              </Stack>
+            </Box>
+          </Box>
+        ))}
+
+        {/* "New table" compact slot */}
+        <Box
+          onClick={() => onClickButton('/mesas')}
+          sx={{
+            background: 'transparent',
+            border: `1.5px dashed ${theme.palette.primary.main}`,
+            borderRadius: 2,
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 0.75,
+            color: theme.palette.primary.main,
+            minHeight: 60,
+            p: 1,
+            transition: 'all 0.18s ease',
+            '&:hover': {
+              backgroundColor: `${theme.palette.primary.main}10`,
+              transform: 'translateY(-2px)',
+            },
+          }}
+        >
+          <AddIcon sx={{ fontSize: 18 }} />
+          <Typography
+            variant='subtitle2'
+            sx={{
+              fontFamily: 'Tfont, serif',
+              fontWeight: 700,
+              fontSize: '0.8rem',
+            }}
+          >
+            Nova mesa
+          </Typography>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default VirtualTablesColumn;

--- a/src/components/LandingPageV2/hooks/useCommunityHighlights.ts
+++ b/src/components/LandingPageV2/hooks/useCommunityHighlights.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import BlogService from '../../../premium/services/blog.service';
+import BuildsService, {
+  BuildData,
+} from '../../../premium/services/builds.service';
+import ForumService from '../../../premium/services/forum.service';
+import { BlogPost } from '../../../premium/interfaces/blog.types';
+import { ForumThread } from '../../../premium/interfaces/forum.types';
+
+interface UseCommunityHighlightsResult {
+  blogPosts: BlogPost[];
+  forumThreads: ForumThread[];
+  builds: BuildData[];
+  loading: boolean;
+}
+
+const BLOG_LIMIT = 5;
+const FORUM_LIMIT = 14;
+const BUILDS_LIMIT = 4;
+
+const useCommunityHighlights = (): UseCommunityHighlightsResult => {
+  const [blogPosts, setBlogPosts] = useState<BlogPost[]>([]);
+  const [forumThreads, setForumThreads] = useState<ForumThread[]>([]);
+  const [builds, setBuilds] = useState<BuildData[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchAll = async () => {
+      const [blogResult, forumResult, buildsResult] = await Promise.allSettled([
+        BlogService.getRecentPosts(BLOG_LIMIT),
+        ForumService.getThreads({
+          page: 1,
+          limit: FORUM_LIMIT,
+          sortBy: 'recent',
+        }),
+        BuildsService.getAllPublicBuilds(
+          { sortBy: 'createdAt', sortOrder: 'desc' },
+          1,
+          BUILDS_LIMIT
+        ),
+      ]);
+
+      if (cancelled) return;
+
+      if (blogResult.status === 'fulfilled') {
+        setBlogPosts(blogResult.value);
+      }
+      if (forumResult.status === 'fulfilled') {
+        setForumThreads(forumResult.value.data);
+      }
+      if (buildsResult.status === 'fulfilled') {
+        setBuilds(buildsResult.value.data);
+      }
+
+      setLoading(false);
+    };
+
+    fetchAll();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { blogPosts, forumThreads, builds, loading };
+};
+
+export default useCommunityHighlights;

--- a/src/components/NavbarV2/NavbarV2.tsx
+++ b/src/components/NavbarV2/NavbarV2.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   Box,
   Stack,
@@ -16,7 +16,6 @@ import {
 } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import PersonAddIcon from '@mui/icons-material/PersonAdd';
 import ArchitectureIcon from '@mui/icons-material/Architecture';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import AttachMoneyIcon from '@mui/icons-material/AttachMoney';
@@ -24,7 +23,8 @@ import BookIcon from '@mui/icons-material/Book';
 import MapIcon from '@mui/icons-material/Map';
 import AccountTreeIcon from '@mui/icons-material/AccountTree';
 import TableRestaurantIcon from '@mui/icons-material/TableRestaurant';
-import SecurityIcon from '@mui/icons-material/Security';
+import AutoStoriesIcon from '@mui/icons-material/AutoStories';
+import PetsIcon from '@mui/icons-material/Pets';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import GroupIcon from '@mui/icons-material/Group';
 import WhatshotIcon from '@mui/icons-material/Whatshot';
@@ -53,6 +53,7 @@ interface NavMenuItem {
   link: string;
   icon: React.ReactNode;
   isExternal?: boolean;
+  requireAuth?: boolean;
 }
 
 interface NavCategory {
@@ -62,125 +63,138 @@ interface NavCategory {
   requireAuth?: boolean;
 }
 
-const navCategories: NavCategory[] = [
-  {
-    label: 'Meus Personagens',
-    link: '/meus-personagens',
-    requireAuth: true,
-  },
-  {
-    label: 'Minhas Ameaças',
-    link: '/meus-personagens?tab=ameacas',
-    requireAuth: true,
-  },
-  {
-    label: 'Ferramentas',
-    items: [
+const buildNavCategories = (isAuthenticated: boolean): NavCategory[] => {
+  const jogarItems: NavMenuItem[] = [];
+  if (isAuthenticated) {
+    jogarItems.push(
       {
-        label: 'Criar Ficha',
-        link: '/criar-ficha',
-        icon: <PersonAddIcon fontSize='small' />,
-      },
-      {
-        label: 'Gerador de Ameaças',
-        link: '/gerador-ameacas',
-        icon: <SecurityIcon fontSize='small' />,
-      },
-      {
-        label: 'Item Superior',
-        link: '/itens-superiores',
-        icon: <ArchitectureIcon fontSize='small' />,
-      },
-      {
-        label: 'Item Mágico',
-        link: '/itens-magicos',
-        icon: <AutoFixHighIcon fontSize='small' />,
-      },
-      {
-        label: 'Recompensas',
-        link: '/recompensas',
-        icon: <AttachMoneyIcon fontSize='small' />,
-      },
-    ],
-  },
-  {
-    label: 'Enciclopédia',
-    items: [
-      {
-        label: 'Raças',
-        link: '/database/raças',
+        label: 'Personagens',
+        link: '/meus-personagens',
         icon: <GroupIcon fontSize='small' />,
       },
       {
-        label: 'Classes',
-        link: '/database/classes',
-        icon: <WhatshotIcon fontSize='small' />,
-      },
-      {
-        label: 'Origens',
-        link: '/database/origens',
-        icon: <BrowseGalleryIcon fontSize='small' />,
-      },
-      {
-        label: 'Divindades',
-        link: '/database/divindades',
-        icon: <FilterDramaIcon fontSize='small' />,
-      },
-      {
-        label: 'Poderes',
-        link: '/database/poderes',
-        icon: <LocalFireDepartmentIcon fontSize='small' />,
-      },
-      {
-        label: 'Magias',
-        link: '/database/magias',
-        icon: <AutoFixHighIcon fontSize='small' />,
-      },
-    ],
-  },
-  {
-    label: 'Consulta',
-    items: [
-      {
-        label: 'Caverna do Saber',
-        link: '/caverna-do-saber',
-        icon: <BookIcon fontSize='small' />,
-      },
-      {
-        label: 'Mapa de Arton',
-        link: 'https://mapadearton.fichasdenimb.com.br/',
-        icon: <MapIcon fontSize='small' />,
-        isExternal: true,
-      },
-    ],
-  },
-  {
-    label: 'Comunidade',
-    items: [
-      {
-        label: 'Wyrt',
-        link: '/wyrt',
-        icon: <DynamicFeedIcon fontSize='small' />,
-      },
-      {
-        label: 'Mesas Virtuais',
-        link: '/mesas',
-        icon: <TableRestaurantIcon fontSize='small' />,
-      },
-      {
-        label: 'Explorar Builds',
-        link: '/builds',
-        icon: <AccountTreeIcon fontSize='small' />,
-      },
-    ],
-  },
-];
+        label: 'Ameaças',
+        link: '/meus-personagens?tab=ameacas',
+        icon: <PetsIcon fontSize='small' />,
+      }
+    );
+  }
+  jogarItems.push(
+    {
+      label: 'Mesa Virtual',
+      link: '/mesas',
+      icon: <TableRestaurantIcon fontSize='small' />,
+    },
+    {
+      label: 'Wyrt',
+      link: '/wyrt',
+      icon: <DynamicFeedIcon fontSize='small' />,
+    }
+  );
+
+  return [
+    {
+      label: 'Jogar',
+      items: jogarItems,
+    },
+    {
+      label: 'Ferramentas',
+      items: [
+        {
+          label: 'Rolador de Recompensas',
+          link: '/recompensas',
+          icon: <AttachMoneyIcon fontSize='small' />,
+        },
+        {
+          label: 'Criar Item Superior',
+          link: '/itens-superiores',
+          icon: <ArchitectureIcon fontSize='small' />,
+        },
+        {
+          label: 'Criar Item Mágico',
+          link: '/itens-magicos',
+          icon: <AutoFixHighIcon fontSize='small' />,
+        },
+      ],
+    },
+    {
+      label: 'Comunidade',
+      items: [
+        {
+          label: 'Bestiário',
+          link: '/bestiario',
+          icon: <AutoStoriesIcon fontSize='small' />,
+        },
+        {
+          label: 'Builds',
+          link: '/builds',
+          icon: <AccountTreeIcon fontSize='small' />,
+        },
+      ],
+    },
+    {
+      label: 'Enciclopédia',
+      items: [
+        {
+          label: 'Raças',
+          link: '/database/raças',
+          icon: <GroupIcon fontSize='small' />,
+        },
+        {
+          label: 'Classes',
+          link: '/database/classes',
+          icon: <WhatshotIcon fontSize='small' />,
+        },
+        {
+          label: 'Origens',
+          link: '/database/origens',
+          icon: <BrowseGalleryIcon fontSize='small' />,
+        },
+        {
+          label: 'Divindades',
+          link: '/database/divindades',
+          icon: <FilterDramaIcon fontSize='small' />,
+        },
+        {
+          label: 'Poderes',
+          link: '/database/poderes',
+          icon: <LocalFireDepartmentIcon fontSize='small' />,
+        },
+        {
+          label: 'Magias',
+          link: '/database/magias',
+          icon: <AutoFixHighIcon fontSize='small' />,
+        },
+      ],
+    },
+    {
+      label: 'Consulta',
+      items: [
+        {
+          label: 'Caverna do Saber',
+          link: '/caverna-do-saber',
+          icon: <BookIcon fontSize='small' />,
+        },
+        {
+          label: 'Mapa de Arton',
+          link: 'https://mapadearton.fichasdenimb.com.br/',
+          icon: <MapIcon fontSize='small' />,
+          isExternal: true,
+        },
+      ],
+    },
+  ];
+};
 
 const NavbarV2: React.FC<NavbarV2Props> = ({ onClickMenu, onClickToLink }) => {
   const theme = useTheme();
   const { isAuthenticated } = useAuth();
   const { isSupporter } = useSubscription();
   const isMobile = useMediaQuery(theme.breakpoints.down('xl'));
+  const navCategories = useMemo(
+    () => buildNavCategories(isAuthenticated),
+    [isAuthenticated]
+  );
   const [anchorEls, setAnchorEls] = useState<{
     [key: string]: HTMLElement | null;
   }>({});

--- a/src/components/RollsEditDialog.tsx
+++ b/src/components/RollsEditDialog.tsx
@@ -1,26 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Dialog,
-  DialogTitle,
-  DialogContent,
   DialogActions,
+  DialogContent,
+  DialogTitle,
   Button,
-  TextField,
-  List,
-  ListItem,
-  ListItemText,
-  ListItemSecondaryAction,
-  IconButton,
-  Stack,
-  Typography,
-  Box,
 } from '@mui/material';
-import DeleteIcon from '@mui/icons-material/Delete';
-import EditIcon from '@mui/icons-material/Edit';
-import AddIcon from '@mui/icons-material/Add';
-import { v4 as uuid } from 'uuid';
 import { DiceRoll } from '@/interfaces/DiceRoll';
-import { isValidDiceString } from '@/utils/diceRoller';
+import RollsEditorPanel from './RollsEditorPanel';
 
 interface RollsEditDialogProps {
   open: boolean;
@@ -30,6 +17,13 @@ interface RollsEditDialogProps {
   title?: string;
 }
 
+/**
+ * Dialog que envolve `RollsEditorPanel` com semântica de Salvar/Cancelar:
+ * mudanças no painel só são persistidas quando o usuário confirma. Continua
+ * sendo usado por consumidores que querem o fluxo modal clássico
+ * (ItemEditorDialog, SpellCastDialog). Para casos em que o estado é
+ * persistido on-change (ex.: `PowerSettingsDialog`), use o painel direto.
+ */
 const RollsEditDialog: React.FC<RollsEditDialogProps> = ({
   open,
   onClose,
@@ -38,214 +32,26 @@ const RollsEditDialog: React.FC<RollsEditDialogProps> = ({
   title = 'Editar Rolagens',
 }) => {
   const [localRolls, setLocalRolls] = useState<DiceRoll[]>([]);
-  const [editingRoll, setEditingRoll] = useState<DiceRoll | null>(null);
-  const [editingIndex, setEditingIndex] = useState<number | null>(null);
-
-  // Form states
-  const [label, setLabel] = useState('');
-  const [dice, setDice] = useState('');
-  const [description, setDescription] = useState('');
-  const [labelError, setLabelError] = useState('');
-  const [diceError, setDiceError] = useState('');
 
   useEffect(() => {
-    setLocalRolls([...rolls]);
+    if (open) {
+      setLocalRolls([...rolls]);
+    }
   }, [rolls, open]);
-
-  const resetForm = () => {
-    setLabel('');
-    setDice('');
-    setDescription('');
-    setLabelError('');
-    setDiceError('');
-    setEditingRoll(null);
-    setEditingIndex(null);
-  };
-
-  const validateForm = (): boolean => {
-    let isValid = true;
-
-    if (label.trim().length < 3) {
-      setLabelError('Nome deve ter pelo menos 3 caracteres');
-      isValid = false;
-    } else {
-      setLabelError('');
-    }
-
-    if (!isValidDiceString(dice)) {
-      setDiceError('Formato inválido. Use: XdY, XdY+Z ou XdY-Z (ex: 3d6+2)');
-      isValid = false;
-    } else {
-      setDiceError('');
-    }
-
-    return isValid;
-  };
-
-  const handleAddRoll = () => {
-    if (!validateForm()) return;
-
-    const newRoll: DiceRoll = {
-      id: uuid(),
-      label: label.trim(),
-      dice: dice.trim(),
-      description: description.trim() || undefined,
-    };
-
-    setLocalRolls([...localRolls, newRoll]);
-    resetForm();
-  };
-
-  const handleEditRoll = (roll: DiceRoll, index: number) => {
-    setEditingRoll(roll);
-    setEditingIndex(index);
-    setLabel(roll.label);
-    setDice(roll.dice);
-    setDescription(roll.description || '');
-  };
-
-  const handleUpdateRoll = () => {
-    if (!validateForm() || editingIndex === null) return;
-
-    const updatedRoll: DiceRoll = {
-      ...editingRoll,
-      label: label.trim(),
-      dice: dice.trim(),
-      description: description.trim() || undefined,
-    };
-
-    const newRolls = [...localRolls];
-    newRolls[editingIndex] = updatedRoll;
-    setLocalRolls(newRolls);
-    resetForm();
-  };
-
-  const handleDeleteRoll = (index: number) => {
-    setLocalRolls(localRolls.filter((_, i) => i !== index));
-  };
 
   const handleSave = () => {
     onSave(localRolls);
     onClose();
   };
 
-  const handleCancel = () => {
-    resetForm();
-    onClose();
-  };
-
   return (
-    <Dialog open={open} onClose={handleCancel} maxWidth='md' fullWidth>
+    <Dialog open={open} onClose={onClose} maxWidth='md' fullWidth>
       <DialogTitle>{title}</DialogTitle>
       <DialogContent>
-        <Stack spacing={3} sx={{ mt: 1 }}>
-          {/* Lista de rolagens existentes */}
-          <Box>
-            <Typography variant='subtitle1' fontWeight='bold' sx={{ mb: 1 }}>
-              Rolagens Configuradas
-            </Typography>
-            {localRolls.length > 0 ? (
-              <List dense>
-                {localRolls.map((roll, index) => (
-                  // eslint-disable-next-line react/no-array-index-key
-                  <ListItem key={index}>
-                    <ListItemText
-                      primary={`${roll.label} - ${roll.dice}`}
-                      secondary={roll.description}
-                    />
-                    <ListItemSecondaryAction>
-                      <IconButton
-                        size='small'
-                        onClick={() => handleEditRoll(roll, index)}
-                        sx={{ mr: 1 }}
-                      >
-                        <EditIcon />
-                      </IconButton>
-                      <IconButton
-                        edge='end'
-                        size='small'
-                        onClick={() => handleDeleteRoll(index)}
-                        color='error'
-                      >
-                        <DeleteIcon />
-                      </IconButton>
-                    </ListItemSecondaryAction>
-                  </ListItem>
-                ))}
-              </List>
-            ) : (
-              <Typography variant='body2' color='text.secondary'>
-                Nenhuma rolagem configurada
-              </Typography>
-            )}
-          </Box>
-
-          {/* Formulário para adicionar/editar */}
-          <Box>
-            <Typography variant='subtitle1' fontWeight='bold' sx={{ mb: 2 }}>
-              {editingRoll ? 'Editar Rolagem' : 'Adicionar Rolagem'}
-            </Typography>
-            <Stack spacing={2}>
-              <TextField
-                label='Nome da Rolagem'
-                value={label}
-                onChange={(e) => setLabel(e.target.value)}
-                fullWidth
-                required
-                error={!!labelError}
-                helperText={
-                  labelError || 'Ex: "Dano de Fogo", "Cura", "Ataque"'
-                }
-              />
-              <TextField
-                label='Dado'
-                value={dice}
-                onChange={(e) => setDice(e.target.value)}
-                fullWidth
-                required
-                error={!!diceError}
-                helperText={diceError || 'Ex: "3d6", "1d20+5", "2d10-2"'}
-              />
-              <TextField
-                label='Descrição (Opcional)'
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                fullWidth
-                multiline
-                rows={2}
-                helperText='Descrição adicional sobre esta rolagem'
-              />
-              <Box>
-                {editingRoll ? (
-                  <Stack direction='row' spacing={1}>
-                    <Button
-                      variant='contained'
-                      onClick={handleUpdateRoll}
-                      fullWidth
-                    >
-                      Atualizar
-                    </Button>
-                    <Button variant='outlined' onClick={resetForm} fullWidth>
-                      Cancelar Edição
-                    </Button>
-                  </Stack>
-                ) : (
-                  <Button
-                    variant='contained'
-                    startIcon={<AddIcon />}
-                    onClick={handleAddRoll}
-                    fullWidth
-                  >
-                    Adicionar Rolagem
-                  </Button>
-                )}
-              </Box>
-            </Stack>
-          </Box>
-        </Stack>
+        <RollsEditorPanel rolls={localRolls} onChange={setLocalRolls} />
       </DialogContent>
       <DialogActions>
-        <Button onClick={handleCancel}>Cancelar</Button>
+        <Button onClick={onClose}>Cancelar</Button>
         <Button onClick={handleSave} variant='contained'>
           Salvar
         </Button>

--- a/src/components/RollsEditorPanel.tsx
+++ b/src/components/RollsEditorPanel.tsx
@@ -1,0 +1,225 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  IconButton,
+  List,
+  ListItem,
+  ListItemSecondaryAction,
+  ListItemText,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import { v4 as uuid } from 'uuid';
+import { DiceRoll } from '@/interfaces/DiceRoll';
+import { isValidDiceString } from '@/utils/diceRoller';
+
+interface RollsEditorPanelProps {
+  rolls: DiceRoll[];
+  onChange: (rolls: DiceRoll[]) => void;
+}
+
+/**
+ * Conteúdo do editor de rolagens — extraído de `RollsEditDialog` para que
+ * possa ser usado dentro de outras estruturas (ex.: abas em
+ * `PowerSettingsDialog`) sem aninhar Dialogs. O Dialog em si fica em
+ * `RollsEditDialog`, que é apenas um wrapper sobre este painel.
+ */
+const RollsEditorPanel: React.FC<RollsEditorPanelProps> = ({
+  rolls,
+  onChange,
+}) => {
+  const [editingRoll, setEditingRoll] = useState<DiceRoll | null>(null);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+
+  const [label, setLabel] = useState('');
+  const [dice, setDice] = useState('');
+  const [description, setDescription] = useState('');
+  const [labelError, setLabelError] = useState('');
+  const [diceError, setDiceError] = useState('');
+
+  useEffect(() => {
+    setEditingRoll(null);
+    setEditingIndex(null);
+    setLabel('');
+    setDice('');
+    setDescription('');
+    setLabelError('');
+    setDiceError('');
+  }, [rolls.length === 0]);
+
+  const resetForm = () => {
+    setLabel('');
+    setDice('');
+    setDescription('');
+    setLabelError('');
+    setDiceError('');
+    setEditingRoll(null);
+    setEditingIndex(null);
+  };
+
+  const validateForm = (): boolean => {
+    let isValid = true;
+    if (label.trim().length < 3) {
+      setLabelError('Nome deve ter pelo menos 3 caracteres');
+      isValid = false;
+    } else {
+      setLabelError('');
+    }
+    if (!isValidDiceString(dice)) {
+      setDiceError('Formato inválido. Use: XdY, XdY+Z ou XdY-Z (ex: 3d6+2)');
+      isValid = false;
+    } else {
+      setDiceError('');
+    }
+    return isValid;
+  };
+
+  const handleAddRoll = () => {
+    if (!validateForm()) return;
+    const newRoll: DiceRoll = {
+      id: uuid(),
+      label: label.trim(),
+      dice: dice.trim(),
+      description: description.trim() || undefined,
+    };
+    onChange([...rolls, newRoll]);
+    resetForm();
+  };
+
+  const handleEditRoll = (roll: DiceRoll, index: number) => {
+    setEditingRoll(roll);
+    setEditingIndex(index);
+    setLabel(roll.label);
+    setDice(roll.dice);
+    setDescription(roll.description || '');
+  };
+
+  const handleUpdateRoll = () => {
+    if (!validateForm() || editingIndex === null) return;
+    const updatedRoll: DiceRoll = {
+      ...editingRoll,
+      label: label.trim(),
+      dice: dice.trim(),
+      description: description.trim() || undefined,
+    };
+    const newRolls = [...rolls];
+    newRolls[editingIndex] = updatedRoll;
+    onChange(newRolls);
+    resetForm();
+  };
+
+  const handleDeleteRoll = (index: number) => {
+    onChange(rolls.filter((_, i) => i !== index));
+  };
+
+  return (
+    <Stack spacing={3} sx={{ mt: 1 }}>
+      <Box>
+        <Typography variant='subtitle1' fontWeight='bold' sx={{ mb: 1 }}>
+          Rolagens Configuradas
+        </Typography>
+        {rolls.length > 0 ? (
+          <List dense>
+            {rolls.map((roll, index) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <ListItem key={index}>
+                <ListItemText
+                  primary={`${roll.label} - ${roll.dice}`}
+                  secondary={roll.description}
+                />
+                <ListItemSecondaryAction>
+                  <IconButton
+                    size='small'
+                    onClick={() => handleEditRoll(roll, index)}
+                    sx={{ mr: 1 }}
+                  >
+                    <EditIcon />
+                  </IconButton>
+                  <IconButton
+                    edge='end'
+                    size='small'
+                    onClick={() => handleDeleteRoll(index)}
+                    color='error'
+                  >
+                    <DeleteIcon />
+                  </IconButton>
+                </ListItemSecondaryAction>
+              </ListItem>
+            ))}
+          </List>
+        ) : (
+          <Typography variant='body2' color='text.secondary'>
+            Nenhuma rolagem configurada
+          </Typography>
+        )}
+      </Box>
+
+      <Box>
+        <Typography variant='subtitle1' fontWeight='bold' sx={{ mb: 2 }}>
+          {editingRoll ? 'Editar Rolagem' : 'Adicionar Rolagem'}
+        </Typography>
+        <Stack spacing={2}>
+          <TextField
+            label='Nome da Rolagem'
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            fullWidth
+            required
+            error={!!labelError}
+            helperText={labelError || 'Ex: "Dano de Fogo", "Cura", "Ataque"'}
+          />
+          <TextField
+            label='Dado'
+            value={dice}
+            onChange={(e) => setDice(e.target.value)}
+            fullWidth
+            required
+            error={!!diceError}
+            helperText={diceError || 'Ex: "3d6", "1d20+5", "2d10-2"'}
+          />
+          <TextField
+            label='Descrição (Opcional)'
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            fullWidth
+            multiline
+            rows={2}
+            helperText='Descrição adicional sobre esta rolagem'
+          />
+          <Box>
+            {editingRoll ? (
+              <Stack direction='row' spacing={1}>
+                <Button
+                  variant='contained'
+                  onClick={handleUpdateRoll}
+                  fullWidth
+                >
+                  Atualizar
+                </Button>
+                <Button variant='outlined' onClick={resetForm} fullWidth>
+                  Cancelar Edição
+                </Button>
+              </Stack>
+            ) : (
+              <Button
+                variant='contained'
+                startIcon={<AddIcon />}
+                onClick={handleAddRoll}
+                fullWidth
+              >
+                Adicionar Rolagem
+              </Button>
+            )}
+          </Box>
+        </Stack>
+      </Box>
+    </Stack>
+  );
+};
+
+export default RollsEditorPanel;

--- a/src/components/SheetResult/EditDrawers/CustomPowerDialog.tsx
+++ b/src/components/SheetResult/EditDrawers/CustomPowerDialog.tsx
@@ -175,6 +175,7 @@ const CustomPowerDialog: React.FC<CustomPowerDialogProps> = ({
       name: name.trim(),
       description: description.trim(),
       rolls: localRolls.length > 0 ? localRolls : undefined,
+      customEffects: power?.customEffects,
     };
 
     onSave(customPower);

--- a/src/components/SheetResult/PowerCustomEffectsAction.tsx
+++ b/src/components/SheetResult/PowerCustomEffectsAction.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+import { IconButton, Menu, MenuItem, Tooltip } from '@mui/material';
+import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
+import CharacterSheet from '@/interfaces/CharacterSheet';
+import { ActivePowerUseDialog } from '@/premium/components/ActiveEffects';
+import { ACTIVE_EFFECT_COLOR } from '@/premium/functions/activeEffectHighlights';
+import type {
+  ActivePowerDefinition,
+  ActiveEffectUsageOption,
+} from '@/premium/interfaces/ActiveEffect';
+import type { CustomEffect } from '@/premium/interfaces/CustomEffect';
+import { buildVirtualDefinitionFromCustomEffect } from '@/premium/data/activePowers/customEffectAdapter';
+
+interface PowerCustomEffectsActionProps {
+  powerName: string;
+  customEffects: CustomEffect[];
+  sheet: CharacterSheet;
+  onActivate: (
+    definition: ActivePowerDefinition,
+    option: ActiveEffectUsageOption
+  ) => void;
+}
+
+/**
+ * Botão "Usar" para efeitos customizados criados pelo usuário num poder.
+ * - 1 efeito: abre o diálogo de tiers direto.
+ * - >1 efeitos: abre um menu para o usuário escolher qual efeito ativar; o
+ *   diálogo de tiers abre em seguida.
+ */
+export default function PowerCustomEffectsAction({
+  powerName,
+  customEffects,
+  sheet,
+  onActivate,
+}: PowerCustomEffectsActionProps) {
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+  const [activeDefinition, setActiveDefinition] =
+    useState<ActivePowerDefinition | null>(null);
+
+  if (customEffects.length === 0) return null;
+
+  const closeAll = () => {
+    setActiveDefinition(null);
+    setMenuAnchor(null);
+  };
+
+  const handleClick = (e: React.MouseEvent<HTMLElement>) => {
+    if (customEffects.length === 1) {
+      setActiveDefinition(
+        buildVirtualDefinitionFromCustomEffect(powerName, customEffects[0])
+      );
+      return;
+    }
+    setMenuAnchor(e.currentTarget);
+  };
+
+  const handlePickFromMenu = (effect: CustomEffect) => {
+    setMenuAnchor(null);
+    setActiveDefinition(
+      buildVirtualDefinitionFromCustomEffect(powerName, effect)
+    );
+  };
+
+  const tooltipLabel =
+    customEffects.length === 1
+      ? `Usar ${customEffects[0].name}`
+      : 'Usar efeito customizado';
+
+  return (
+    <>
+      <Tooltip title={tooltipLabel}>
+        <IconButton
+          size='small'
+          onClick={handleClick}
+          sx={{ color: ACTIVE_EFFECT_COLOR }}
+        >
+          <AutoAwesomeIcon fontSize='small' />
+        </IconButton>
+      </Tooltip>
+      <Menu
+        anchorEl={menuAnchor}
+        open={Boolean(menuAnchor)}
+        onClose={() => setMenuAnchor(null)}
+      >
+        {customEffects.map((effect) => (
+          <MenuItem key={effect.id} onClick={() => handlePickFromMenu(effect)}>
+            {effect.name}
+          </MenuItem>
+        ))}
+      </Menu>
+      <ActivePowerUseDialog
+        open={activeDefinition !== null}
+        definition={activeDefinition}
+        sheet={sheet}
+        onClose={closeAll}
+        onConfirm={(option) => {
+          if (activeDefinition) {
+            onActivate(activeDefinition, option);
+          }
+          closeAll();
+        }}
+      />
+    </>
+  );
+}

--- a/src/components/SheetResult/PowerDisplay.tsx
+++ b/src/components/SheetResult/PowerDisplay.tsx
@@ -18,9 +18,12 @@ import {
   useMediaQuery,
 } from '@mui/material';
 import { DiceRoll } from '@/interfaces/DiceRoll';
-import { SheetActionHistoryEntry } from '@/interfaces/CharacterSheet';
+import CharacterSheet, {
+  SheetActionHistoryEntry,
+} from '@/interfaces/CharacterSheet';
+import type { CustomEffect } from '@/premium/interfaces/CustomEffect';
 import RollButton from '../RollButton';
-import RollsEditDialog from '../RollsEditDialog';
+import PowerSettingsDialog from './PowerSettingsDialog';
 
 const getText = (text: string) => <div>{text}</div>;
 
@@ -44,6 +47,12 @@ interface PowerDisplayProps {
     power: ClassPower | RaceAbility | ClassAbility | OriginPower,
     newRolls: DiceRoll[]
   ) => void;
+  onUpdateCustomEffects?: (
+    power: ClassPower | RaceAbility | ClassAbility | OriginPower,
+    newEffects: CustomEffect[]
+  ) => void;
+  sheet?: CharacterSheet;
+  className?: string;
   characterName?: string;
   onCompanionClick?: () => void;
   headerActionSlot?: React.ReactNode;
@@ -56,12 +65,15 @@ const PowerDisplay: React.FC<PowerDisplayProps> = React.memo(
     type,
     count,
     onUpdateRolls,
+    onUpdateCustomEffects,
+    sheet,
+    className,
     characterName,
     onCompanionClick,
     headerActionSlot,
   }) => {
     const [isExpanded, setIsExpanded] = React.useState(false);
-    const [rollsDialogOpen, setRollsDialogOpen] = useState(false);
+    const [settingsDialogOpen, setSettingsDialogOpen] = useState(false);
     const theme = useTheme();
     const isDesktop = useMediaQuery(theme.breakpoints.up('sm'));
 
@@ -122,13 +134,13 @@ const PowerDisplay: React.FC<PowerDisplayProps> = React.memo(
       setIsExpanded((prev) => !prev);
     }, []);
 
-    const handleOpenRollsDialog = useCallback((e: React.MouseEvent) => {
+    const handleOpenSettingsDialog = useCallback((e: React.MouseEvent) => {
       e.stopPropagation();
-      setRollsDialogOpen(true);
+      setSettingsDialogOpen(true);
     }, []);
 
-    const handleCloseRollsDialog = useCallback(() => {
-      setRollsDialogOpen(false);
+    const handleCloseSettingsDialog = useCallback(() => {
+      setSettingsDialogOpen(false);
     }, []);
 
     const handleSaveRolls = useCallback(
@@ -138,6 +150,15 @@ const PowerDisplay: React.FC<PowerDisplayProps> = React.memo(
         }
       },
       [power, onUpdateRolls]
+    );
+
+    const handleSaveCustomEffects = useCallback(
+      (newEffects: CustomEffect[]) => {
+        if (onUpdateCustomEffects) {
+          onUpdateCustomEffects(power, newEffects);
+        }
+      },
+      [power, onUpdateCustomEffects]
     );
 
     // Check if this is a general power that was added manually
@@ -151,6 +172,14 @@ const PowerDisplay: React.FC<PowerDisplayProps> = React.memo(
     // Get rolls from power if it has them
     const powerRolls =
       'rolls' in power && power.rolls ? power.rolls : ([] as DiceRoll[]);
+
+    // Get custom effects from power if it has them
+    const powerCustomEffects =
+      'customEffects' in power && power.customEffects
+        ? power.customEffects
+        : ([] as CustomEffect[]);
+
+    const settingsBadgeCount = powerRolls.length + powerCustomEffects.length;
 
     return (
       <Accordion expanded={isExpanded} onChange={handleToggle}>
@@ -214,13 +243,13 @@ const PowerDisplay: React.FC<PowerDisplayProps> = React.memo(
             <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2 }}>
               <IconButton
                 size='small'
-                onClick={handleOpenRollsDialog}
-                title='Configurar rolagens'
+                onClick={handleOpenSettingsDialog}
+                title='Configurar rolagens e efeitos'
               >
                 <Badge
-                  badgeContent={powerRolls.length}
+                  badgeContent={settingsBadgeCount}
                   color='primary'
-                  invisible={powerRolls.length === 0}
+                  invisible={settingsBadgeCount === 0}
                 >
                   <SettingsIcon fontSize='small' />
                 </Badge>
@@ -247,13 +276,18 @@ const PowerDisplay: React.FC<PowerDisplayProps> = React.memo(
             </Typography>
           </div>
         </AccordionDetails>
-        {onUpdateRolls && (
-          <RollsEditDialog
-            open={rollsDialogOpen}
-            onClose={handleCloseRollsDialog}
+        {onUpdateRolls && sheet && (
+          <PowerSettingsDialog
+            open={settingsDialogOpen}
+            onClose={handleCloseSettingsDialog}
+            title={`Configurações: ${power.name}`}
+            powerName={power.name}
+            className={className}
             rolls={powerRolls}
-            onSave={handleSaveRolls}
-            title={`Rolagens: ${power.name}`}
+            customEffects={powerCustomEffects}
+            sheet={sheet}
+            onRollsChange={handleSaveRolls}
+            onCustomEffectsChange={handleSaveCustomEffects}
           />
         )}
       </Accordion>

--- a/src/components/SheetResult/PowerSettingsDialog.tsx
+++ b/src/components/SheetResult/PowerSettingsDialog.tsx
@@ -1,0 +1,110 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Tab,
+  Tabs,
+} from '@mui/material';
+import { DiceRoll } from '@/interfaces/DiceRoll';
+import type CharacterSheet from '@/interfaces/CharacterSheet';
+import type { CustomEffect } from '@/premium/interfaces/CustomEffect';
+import { getActivePowerForSheetEntry } from '@/premium/data/activePowers';
+import {
+  CustomEffectsList,
+  PrecannedEffectView,
+} from '@/premium/components/CustomEffectsEditor';
+import RollsEditorPanel from '../RollsEditorPanel';
+
+interface PowerSettingsDialogProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  powerName: string;
+  className?: string;
+  rolls: DiceRoll[];
+  customEffects: CustomEffect[];
+  sheet: CharacterSheet;
+  onRollsChange: (rolls: DiceRoll[]) => void;
+  onCustomEffectsChange: (effects: CustomEffect[]) => void;
+}
+
+/**
+ * Dialog de configurações do poder expandido. Substitui o uso direto de
+ * `RollsEditDialog` no `PowerDisplay`, oferecendo duas abas:
+ *
+ * - "Rolagens": configura rolagens de dados do poder (label + notação).
+ * - "Efeitos": configura efeitos customizados (tiers + bônus) que aparecem
+ *   no gerenciador de Efeitos Ativos. Quando o poder tem efeito pré-canned
+ *   no registry `ACTIVE_POWERS`, exibe apenas o efeito read-only.
+ *
+ * Ambas as abas persistem on-change — não há botão de Salvar.
+ */
+const PowerSettingsDialog: React.FC<PowerSettingsDialogProps> = ({
+  open,
+  onClose,
+  title,
+  powerName,
+  className,
+  rolls,
+  customEffects,
+  sheet,
+  onRollsChange,
+  onCustomEffectsChange,
+}) => {
+  const [tab, setTab] = useState<0 | 1>(0);
+
+  const precannedDef = useMemo(
+    () => getActivePowerForSheetEntry(className, powerName),
+    [className, powerName]
+  );
+
+  let effectsBadgeSuffix = '';
+  if (precannedDef) {
+    effectsBadgeSuffix = ' (auto)';
+  } else if (customEffects.length > 0) {
+    effectsBadgeSuffix = ` (${customEffects.length})`;
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth='md' fullWidth>
+      <DialogTitle>{title}</DialogTitle>
+      <Tabs
+        value={tab}
+        onChange={(_e, v: 0 | 1) => setTab(v)}
+        variant='fullWidth'
+        sx={{ borderBottom: 1, borderColor: 'divider' }}
+      >
+        <Tab label={`Rolagens${rolls.length ? ` (${rolls.length})` : ''}`} />
+        <Tab label={`Efeitos${effectsBadgeSuffix}`} />
+      </Tabs>
+      <DialogContent dividers>
+        {tab === 0 && (
+          <RollsEditorPanel rolls={rolls} onChange={onRollsChange} />
+        )}
+        {tab === 1 && (
+          <Box>
+            {precannedDef ? (
+              <PrecannedEffectView definition={precannedDef} sheet={sheet} />
+            ) : (
+              <CustomEffectsList
+                effects={customEffects}
+                onChange={onCustomEffectsChange}
+              />
+            )}
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} variant='contained'>
+          Fechar
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default PowerSettingsDialog;

--- a/src/components/SheetResult/PowersDisplay.tsx
+++ b/src/components/SheetResult/PowersDisplay.tsx
@@ -28,6 +28,7 @@ import type { CustomEffect } from '@/premium/interfaces/CustomEffect';
 import PowerDisplay from './PowerDisplay';
 import PowerWeaponSelectionAction from './PowerWeaponSelectionAction';
 import PowerActiveEffectAction from './PowerActiveEffectAction';
+import PowerCustomEffectsAction from './PowerCustomEffectsAction';
 
 function filterUniqueByName<T extends { name: string }>(array: T[]): T[] {
   const seen = new Set<string>();
@@ -235,6 +236,18 @@ const PowersDisplay: React.FC<{
         return (
           <PowerActiveEffectAction
             definition={activeDef}
+            sheet={sheet}
+            onActivate={onActivateEffect}
+          />
+        );
+      }
+      const pwCustomEffects =
+        'customEffects' in pw && pw.customEffects ? pw.customEffects : [];
+      if (pwCustomEffects.length > 0) {
+        return (
+          <PowerCustomEffectsAction
+            powerName={pw.name}
+            customEffects={pwCustomEffects}
             sheet={sheet}
             onActivate={onActivateEffect}
           />

--- a/src/components/SheetResult/PowersDisplay.tsx
+++ b/src/components/SheetResult/PowersDisplay.tsx
@@ -24,6 +24,7 @@ import type {
   ActivePowerDefinition,
   ActiveEffectUsageOption,
 } from '@/premium/interfaces/ActiveEffect';
+import type { CustomEffect } from '@/premium/interfaces/CustomEffect';
 import PowerDisplay from './PowerDisplay';
 import PowerWeaponSelectionAction from './PowerWeaponSelectionAction';
 import PowerActiveEffectAction from './PowerActiveEffectAction';
@@ -60,6 +61,16 @@ const PowersDisplay: React.FC<{
       | CustomPower,
     newRolls: DiceRoll[]
   ) => void;
+  onUpdateCustomEffects?: (
+    power:
+      | ClassPower
+      | RaceAbility
+      | ClassAbility
+      | OriginPower
+      | GeneralPower
+      | CustomPower,
+    newEffects: CustomEffect[]
+  ) => void;
   characterName?: string;
   onCompanionClick?: () => void;
   parodyButtonSlot?: React.ReactNode;
@@ -83,6 +94,7 @@ const PowersDisplay: React.FC<{
   raceName,
   deityName,
   onUpdateRolls,
+  onUpdateCustomEffects,
   characterName,
   onCompanionClick,
   parodyButtonSlot,
@@ -242,6 +254,9 @@ const PowersDisplay: React.FC<{
       type={getPowerOrigin(power)}
       count={powerCount[power.name]}
       onUpdateRolls={reorderMode ? undefined : onUpdateRolls}
+      onUpdateCustomEffects={reorderMode ? undefined : onUpdateCustomEffects}
+      sheet={sheet}
+      className={className}
       characterName={characterName}
       onCompanionClick={
         !reorderMode && power.name === 'Melhor Amigo'

--- a/src/components/SheetResult/Result.tsx
+++ b/src/components/SheetResult/Result.tsx
@@ -79,10 +79,7 @@ import {
   getActiveEffectLabelStyle,
   ACTIVE_EFFECT_COLOR,
 } from '@/premium/functions/activeEffectHighlights';
-import {
-  getAvailableActivePowers,
-  getActiveEffectForSpell,
-} from '@/premium/data/activePowers';
+import { getActiveEffectForSpell } from '@/premium/data/activePowers';
 import type {
   ActivePowerDefinition,
   ActiveEffectUsageOption,
@@ -245,7 +242,11 @@ const Result: React.FC<ResultProps> = (props) => {
   );
 
   const handleActiveEffectActivate = useCallback(
-    (definition: ActivePowerDefinition, option: ActiveEffectUsageOption) => {
+    (
+      definition: ActivePowerDefinition,
+      option: ActiveEffectUsageOption,
+      opts?: { skipPmCost?: boolean; skipBroadcast?: boolean }
+    ) => {
       const effect: ActiveEffect = {
         instanceId: uuidv4(),
         powerKey: definition.key,
@@ -258,6 +259,7 @@ const Result: React.FC<ResultProps> = (props) => {
         grantsTempPV: option.grantsTempPV,
         appliedAt: new Date().toISOString(),
         appliedBy: { playerName: currentSheet.nome },
+        appliedManually: opts?.skipPmCost ? true : undefined,
       };
       // Substitui qualquer instância anterior do mesmo poder
       const previous = (currentSheet.activeEffects ?? []).filter(
@@ -274,7 +276,7 @@ const Result: React.FC<ResultProps> = (props) => {
       applyRecalculatedSheet({
         ...currentSheet,
         activeEffects: [...previous, effect],
-        currentPM: basePM - option.pmCost,
+        currentPM: opts?.skipPmCost ? basePM : basePM - option.pmCost,
         tempPM: Math.max(
           0,
           (currentSheet.tempPM ?? 0) -
@@ -290,7 +292,7 @@ const Result: React.FC<ResultProps> = (props) => {
       });
 
       // Oferta aos aliados da mesa (no-op fora de mesa)
-      if (definition.affectsAllies) {
+      if (definition.affectsAllies && !opts?.skipBroadcast) {
         socketService.emitPowerEffectUse({
           instanceId: effect.instanceId,
           powerKey: effect.powerKey,
@@ -1730,8 +1732,10 @@ const Result: React.FC<ResultProps> = (props) => {
             <ActiveEffectsManagerModal
               open={effectsModalOpen}
               effects={currentSheet.activeEffects ?? []}
-              readonly={!onSheetUpdate}
+              sheet={currentSheet}
+              readonly={!onSheetUpdate || !canUseActiveEffects}
               onRemove={handleActiveEffectRemove}
+              onActivate={handleActiveEffectActivate}
               onClose={() => setEffectsModalOpen(false)}
             />
 
@@ -2045,9 +2049,7 @@ const Result: React.FC<ResultProps> = (props) => {
                 spacing={1}
                 sx={{ position: 'absolute', top: -16, right: 16 }}
               >
-                {((getAvailableActivePowers(currentSheet).length > 0 &&
-                  canUseActiveEffects) ||
-                  (currentSheet.activeEffects?.length ?? 0) > 0) &&
+                {canUseActiveEffects &&
                   (() => {
                     const activeCount = currentSheet.activeEffects?.length ?? 0;
                     const hasActive = activeCount > 0;

--- a/src/components/SheetResult/Result.tsx
+++ b/src/components/SheetResult/Result.tsx
@@ -51,6 +51,7 @@ import { GeneralPower, OriginPower } from '@/interfaces/Poderes';
 import { RaceAbility } from '@/interfaces/Race';
 import { CompanionSheet } from '@/interfaces/Companion';
 import { CustomPower } from '@/interfaces/CustomPower';
+import type { CustomEffect } from '@/premium/interfaces/CustomEffect';
 import { useSubscription } from '@/hooks/useSubscription';
 import { useFeatureAccess } from '@/hooks/useFeatureAccess';
 import {
@@ -80,6 +81,7 @@ import {
   ACTIVE_EFFECT_COLOR,
 } from '@/premium/functions/activeEffectHighlights';
 import { getActiveEffectForSpell } from '@/premium/data/activePowers';
+import { collectVirtualCustomEffectDefinitions } from '@/premium/data/activePowers/customEffectAdapter';
 import type {
   ActivePowerDefinition,
   ActiveEffectUsageOption,
@@ -222,6 +224,10 @@ const Result: React.FC<ResultProps> = (props) => {
   const markersEnabled = conditionsFeature.isEnabled;
   const activeEffectHighlights = useMemo(
     () => getActiveEffectHighlights(currentSheet),
+    [currentSheet]
+  );
+  const virtualCustomEffectDefinitions = useMemo(
+    () => collectVirtualCustomEffectDefinitions(currentSheet),
     [currentSheet]
   );
 
@@ -660,6 +666,74 @@ const Result: React.FC<ResultProps> = (props) => {
         generalPowers: updatedGeneralPowers,
         classPowers: updatedClassPowers,
         customPowers: updatedCustomPowers,
+        origin:
+          currentSheet.origin && updatedOriginPowers
+            ? { ...currentSheet.origin, powers: updatedOriginPowers }
+            : currentSheet.origin,
+        raca:
+          currentSheet.raca && updatedRaceAbilities
+            ? { ...currentSheet.raca, abilities: updatedRaceAbilities }
+            : currentSheet.raca,
+        classe:
+          currentSheet.classe && updatedClassAbilities
+            ? { ...currentSheet.classe, abilities: updatedClassAbilities }
+            : currentSheet.classe,
+        devoto:
+          currentSheet.devoto && updatedDeityPowers
+            ? { ...currentSheet.devoto, poderes: updatedDeityPowers }
+            : currentSheet.devoto,
+      };
+
+      setCurrentSheet(updatedSheet);
+      if (onSheetUpdate) {
+        onSheetUpdate(updatedSheet);
+      }
+    },
+    [currentSheet, onSheetUpdate]
+  );
+
+  const handlePowerCustomEffectsUpdate = useCallback(
+    (
+      power:
+        | ClassPower
+        | RaceAbility
+        | ClassAbility
+        | OriginPower
+        | GeneralPower
+        | CustomPower,
+      newEffects: CustomEffect[]
+    ) => {
+      const updatedGeneralPowers = currentSheet.generalPowers?.map((p) =>
+        p.name === power.name ? { ...p, customEffects: newEffects } : p
+      );
+      const updatedClassPowers = currentSheet.classPowers?.map((p) =>
+        p.name === power.name ? { ...p, customEffects: newEffects } : p
+      );
+      const updatedOriginPowers = currentSheet.origin?.powers?.map((p) =>
+        p.name === power.name ? { ...p, customEffects: newEffects } : p
+      );
+      const updatedRaceAbilities = currentSheet.raca?.abilities?.map((a) =>
+        a.name === power.name ? { ...a, customEffects: newEffects } : a
+      );
+      const updatedClassAbilities = currentSheet.classe?.abilities?.map((a) =>
+        a.name === power.name ? { ...a, customEffects: newEffects } : a
+      );
+      const updatedDeityPowers = currentSheet.devoto?.poderes?.map((p) =>
+        p.name === power.name ? { ...p, customEffects: newEffects } : p
+      );
+      const updatedCustomPowers = currentSheet.customPowers?.map((p) =>
+        p.name === power.name ? { ...p, customEffects: newEffects } : p
+      );
+      const updatedCustomGrantedPowers = currentSheet.customGrantedPowers?.map(
+        (p) => (p.name === power.name ? { ...p, customEffects: newEffects } : p)
+      );
+
+      const updatedSheet = {
+        ...currentSheet,
+        generalPowers: updatedGeneralPowers,
+        classPowers: updatedClassPowers,
+        customPowers: updatedCustomPowers,
+        customGrantedPowers: updatedCustomGrantedPowers,
         origin:
           currentSheet.origin && updatedOriginPowers
             ? { ...currentSheet.origin, powers: updatedOriginPowers }
@@ -1734,6 +1808,7 @@ const Result: React.FC<ResultProps> = (props) => {
               effects={currentSheet.activeEffects ?? []}
               sheet={currentSheet}
               readonly={!onSheetUpdate || !canUseActiveEffects}
+              customDefinitions={virtualCustomEffectDefinitions}
               onRemove={handleActiveEffectRemove}
               onActivate={handleActiveEffectActivate}
               onClose={() => setEffectsModalOpen(false)}
@@ -2126,6 +2201,9 @@ const Result: React.FC<ResultProps> = (props) => {
                   deityName={devoto?.divindade?.name}
                   onUpdateRolls={
                     onSheetUpdate ? handlePowerRollsUpdate : undefined
+                  }
+                  onUpdateCustomEffects={
+                    onSheetUpdate ? handlePowerCustomEffectsUpdate : undefined
                   }
                   characterName={nome}
                   sheet={currentSheet}

--- a/src/components/SidebarV2/SidebarV2.tsx
+++ b/src/components/SidebarV2/SidebarV2.tsx
@@ -46,7 +46,7 @@ import { useAuth } from '../../hooks/useAuth';
 import { useFeatureAccess } from '../../hooks/useFeatureAccess';
 import { useAuthContext } from '../../contexts/AuthContext';
 
-const APP_VERSION = '4.16';
+const APP_VERSION = '4.17';
 const ADMIN_EMAIL = 'yuri.alessandro.m@gmail.com';
 
 interface SidebarV2Props {

--- a/src/components/ThreatGenerator/ThreatResult.tsx
+++ b/src/components/ThreatGenerator/ThreatResult.tsx
@@ -426,29 +426,27 @@ const ThreatResult: React.FC<ThreatResultProps> = ({
     getTierByChallengeLevel(threat.challengeLevel)
   );
 
-  // Get numeric resistance value
-  const getResistanceNumeric = (type: string) =>
-    getResistanceSave(type as ResistanceType, threat.combatStats);
-
-  // Format resistance values
-  const getResistanceValue = (type: string) => {
-    const resistanceValue = getResistanceNumeric(type);
-    return resistanceValue > 0 ? `+${resistanceValue}` : `${resistanceValue}`;
+  // Fonte de verdade dos saves: a skill correspondente em threat.skills
+  // (já inclui override do usuário via getEffectiveSkillTotal). Fallback para
+  // a tabela de combate em dados antigos onde a skill ainda não foi materializada.
+  const getResistanceTotal = (
+    name: 'Fortitude' | 'Reflexos' | 'Vontade'
+  ): number => {
+    const skill = threat.skills.find((s) => s.name === name);
+    if (skill) return getEffectiveSkillTotal(skill);
+    const type = threat.resistanceAssignments[name];
+    return getResistanceSave(type as ResistanceType, threat.combatStats);
   };
 
-  // Get resistance assignments (numeric and formatted)
-  const fortResistNum = getResistanceNumeric(
-    threat.resistanceAssignments.Fortitude
-  );
-  const refResistNum = getResistanceNumeric(
-    threat.resistanceAssignments.Reflexos
-  );
-  const vonResistNum = getResistanceNumeric(
-    threat.resistanceAssignments.Vontade
-  );
-  const fortResist = getResistanceValue(threat.resistanceAssignments.Fortitude);
-  const refResist = getResistanceValue(threat.resistanceAssignments.Reflexos);
-  const wonResist = getResistanceValue(threat.resistanceAssignments.Vontade);
+  const formatResistance = (value: number) =>
+    value > 0 ? `+${value}` : `${value}`;
+
+  const fortResistNum = getResistanceTotal('Fortitude');
+  const refResistNum = getResistanceTotal('Reflexos');
+  const vonResistNum = getResistanceTotal('Vontade');
+  const fortResist = formatResistance(fortResistNum);
+  const refResist = formatResistance(refResistNum);
+  const wonResist = formatResistance(vonResistNum);
 
   // Get initiative and perception values
   const initiativeSkill = threat.skills.find((s) => s.name === 'Iniciativa');

--- a/src/components/ThreatGenerator/steps/StepSix.tsx
+++ b/src/components/ThreatGenerator/steps/StepSix.tsx
@@ -131,6 +131,7 @@ const StepSix: React.FC<StepSixProps> = ({ threat, onUpdate }) => {
 
   const attributes = threat.attributes || ({} as ThreatAttributes);
   const skills = threat.skills || [];
+  const RESISTANCE_SKILL_NAMES = ['Fortitude', 'Reflexos', 'Vontade'];
 
   return (
     <Box p={3}>
@@ -294,26 +295,34 @@ const StepSix: React.FC<StepSixProps> = ({ threat, onUpdate }) => {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {skills
-                  .filter(
-                    (skill) =>
-                      !['Vontade', 'Fortitude', 'Reflexos'].includes(skill.name)
-                  )
-                  .map((skill) => (
+                {skills.map((skill) => {
+                  const isResistance = RESISTANCE_SKILL_NAMES.includes(
+                    skill.name
+                  );
+                  return (
                     <TableRow key={skill.name}>
                       <TableCell>{skill.name}</TableCell>
                       <TableCell align='center'>{skill.attribute}</TableCell>
                       <TableCell align='center'>
-                        <Checkbox
-                          checked={skill.trained}
-                          onChange={(e) =>
-                            handleSkillTrainingChange(
-                              skill.name,
-                              e.target.checked
-                            )
-                          }
-                          size='small'
-                        />
+                        {isResistance ? (
+                          <Checkbox
+                            checked={false}
+                            disabled
+                            size='small'
+                            title='Resistências usam o valor da tabela de combate (atribuição Forte/Média/Fraca). Use o campo Total para sobrescrever.'
+                          />
+                        ) : (
+                          <Checkbox
+                            checked={skill.trained}
+                            onChange={(e) =>
+                              handleSkillTrainingChange(
+                                skill.name,
+                                e.target.checked
+                              )
+                            }
+                            size='small'
+                          />
+                        )}
                       </TableCell>
                       <TableCell align='center'>
                         <TextField
@@ -349,7 +358,8 @@ const StepSix: React.FC<StepSixProps> = ({ threat, onUpdate }) => {
                         />
                       </TableCell>
                     </TableRow>
-                  ))}
+                  );
+                })}
               </TableBody>
             </Table>
           </TableContainer>
@@ -365,6 +375,11 @@ const StepSix: React.FC<StepSixProps> = ({ threat, onUpdate }) => {
             <br />
             <strong>Bônus de Treinamento:</strong> +2 (ND 1-6), +4 (ND 7-14), +6
             (ND 15+)
+            <br />
+            <strong>Resistências (Fortitude, Reflexos, Vontade):</strong> o
+            valor pré-preenchido vem da atribuição Forte/Média/Fraca feita na
+            etapa de Resistências. Treinamento não se aplica — use o campo Total
+            para sobrescrever quando precisar.
             <br />
             <strong>Sobrescrita:</strong> Insira um valor no campo
             &quot;Total&quot; para sobrescrever o cálculo automático. Limpe o

--- a/src/components/screens/Changelog.tsx
+++ b/src/components/screens/Changelog.tsx
@@ -35,7 +35,7 @@ const Changelog: React.FC = () => {
           <h1 style={{ fontFamily: 'Tfont' }}>Changelog</h1>
           <p>
             Segue a lista de mudanças no projeto. Última atualização em
-            19/05/2026 (v4.16).
+            22/05/2026 (v4.17).
           </p>
 
           <p>
@@ -69,6 +69,81 @@ const Changelog: React.FC = () => {
               </Typography>
             </AccordionSummary>
             <AccordionDetails>
+              <h3>4.17</h3>
+
+              <ul>
+                <li>
+                  <strong>
+                    Novo: Encouraçado vira efeito ativo togável na ficha.
+                  </strong>{' '}
+                  O poder geral <strong>Encouraçado</strong> agora pode ser
+                  ativado direto pelo cabeçalho, aplicando o bônus na Defesa{' '}
+                  <strong>com escala dinâmica</strong>: +2 de base e +2
+                  adicional para cada poder dependente que você possua
+                  (Inexpugnável, Fanático, Catafractário, Encastelado). Se você
+                  não estiver com armadura pesada equipada, um aviso discreto
+                  aparece no diálogo — sem bloquear a ativação.
+                </li>
+                <li>
+                  <strong>
+                    Novo: tier &quot;Customizado&quot; em magias com
+                    aprimoramento escalável.
+                  </strong>{' '}
+                  Magias como <strong>Armadura Arcana</strong> agora oferecem,
+                  além dos valores comuns, um tier <strong>Customizado</strong>{' '}
+                  com botões +/- para você ajustar o bônus quando aprimorou além
+                  do teto modelado (por exemplo, +13 na Defesa com 8
+                  aprimoramentos).
+                </li>
+                <li>
+                  <strong>
+                    Novo: três magias passam a oferecer efeito ativo.
+                  </strong>{' '}
+                  <strong>Aviso</strong> (+5 no próximo teste de Iniciativa e em
+                  Percepção, opção &quot;Alerta&quot;),{' '}
+                  <strong>Maaais Klunc</strong> (+10 em Força com cascata para
+                  perícias de Força e dano corpo a corpo) e{' '}
+                  <strong>Mente Divina</strong> (8 tiers cobrindo a base e todos
+                  os aprimoramentos para +2/+4 em um atributo mental escolhido
+                  ou nos três).
+                </li>
+                <li>
+                  <strong>
+                    Novo: aba &quot;Adicionar&quot; no gerenciador de efeitos
+                    ativos.
+                  </strong>{' '}
+                  Agora dá para incluir manualmente qualquer efeito de poder ou
+                  magia do compêndio na sua ficha — sem pagar PM e sem notificar
+                  aliados da mesa. Útil para narrar buffs do mestre ou para jogo
+                  solo. Há uma busca embutida e um aviso esclarecendo que
+                  pré-requisitos não são validados nesse modo.
+                </li>
+                <li>
+                  <strong>
+                    Melhoria: bônus de atributo em efeitos ativos finalmente
+                    aplicam de verdade.
+                  </strong>{' '}
+                  Boosts como o <strong>+2 Força</strong> do Banquete Selvagem
+                  do Druida, o <strong>+4 em atributo</strong> da Força da
+                  Natureza, o <strong>+1/+2 Força</strong> do Crescimento
+                  Feérico (qareen) e o <strong>+2 Carisma</strong> da Aparência
+                  Perfeita — antes silenciosamente ignorados pelo motor — agora
+                  cascateiam corretamente para todas as{' '}
+                  <strong>perícias</strong> derivadas do atributo (incluindo
+                  Luta/Pontaria, Iniciativa e resistências). Boosts de Força
+                  também somam no dano corpo a corpo; boosts de Destreza, na
+                  Defesa.
+                </li>
+                <li>
+                  <strong>
+                    Correção: resistências infladas de ameaças na mesa virtual.
+                  </strong>{' '}
+                  Em algumas ameaças importadas para a mesa virtual, valores de
+                  Fortitude/Reflexos/Vontade apareciam somados em duplicado.
+                  Cálculo corrigido.
+                </li>
+              </ul>
+
               <h3>4.16</h3>
 
               <Alert

--- a/src/components/screens/Changelog.tsx
+++ b/src/components/screens/Changelog.tsx
@@ -142,6 +142,15 @@ const Changelog: React.FC = () => {
                   Fortitude/Reflexos/Vontade apareciam somados em duplicado.
                   Cálculo corrigido.
                 </li>
+                <li>
+                  <strong>Novo: papel EDITOR no blog.</strong> Adicionado um
+                  novo papel de usuário <strong>EDITOR</strong> que pode criar e
+                  editar seus próprios posts no blog em modo rascunho, enquanto
+                  apenas administradores podem publicar. Útil para colaboradores
+                  que produzem conteúdo, mas precisam de revisão antes da
+                  publicação. Inclui toggle no painel de administração e UI
+                  simplificada do editor para esse papel.
+                </li>
               </ul>
 
               <h3>4.16</h3>

--- a/src/components/screens/Changelog.tsx
+++ b/src/components/screens/Changelog.tsx
@@ -151,6 +151,20 @@ const Changelog: React.FC = () => {
                   publicação. Inclui toggle no painel de administração e UI
                   simplificada do editor para esse papel.
                 </li>
+                <li>
+                  <strong>
+                    Novo: publicação anônima por padrão no Bestiário da
+                    Comunidade.
+                  </strong>{' '}
+                  Suas ameaças publicadas agora aparecem como{' '}
+                  <strong>&quot;por Anônimo&quot;</strong> para outros usuários,
+                  protegendo mestres que não querem revelar a autoria e spoilear
+                  os próprios jogadores. Quem preferir aparecer pode desativar a
+                  opção em <strong>Perfil → Sistema</strong>, na nova seção{' '}
+                  <strong>Privacidade</strong>. A página de publicação também
+                  avisa quando você está publicando anonimamente, com atalho
+                  para as configurações.
+                </li>
               </ul>
 
               <h3>4.16</h3>

--- a/src/components/screens/Changelog.tsx
+++ b/src/components/screens/Changelog.tsx
@@ -73,6 +73,30 @@ const Changelog: React.FC = () => {
 
               <ul>
                 <li>
+                  <strong>Novo: página inicial redesenhada.</strong> A home
+                  ganhou um layout em duas colunas com{' '}
+                  <strong>destaques da comunidade</strong> (últimos posts do
+                  blog, atividade do fórum, builds públicas recentes), uma seção{' '}
+                  <strong>Continue sua jornada</strong> com seus personagens e
+                  mesas, um <strong>banner de sessão ativa</strong> avisando
+                  quando você tem uma mesa rolando, e uma{' '}
+                  <strong>barra lateral de ferramentas</strong> sempre à mão. O
+                  carrossel principal ficou mais compacto pra dar protagonismo
+                  ao conteúdo abaixo.
+                </li>
+                <li>
+                  <strong>
+                    Correção: aba &quot;Sistema&quot; do Perfil voltava sozinha
+                    para &quot;Perfil&quot;.
+                  </strong>{' '}
+                  Toda vez que você alterava uma configuração na aba{' '}
+                  <strong>Sistema</strong> (tema, cor de destaque, dados 3D,
+                  privacidade do Bestiário, suplementos), a página piscava o
+                  loader de carregamento e voltava para a aba{' '}
+                  <strong>Perfil</strong>. Agora cada alteração salva sem
+                  remontar a página — você fica exatamente onde estava.
+                </li>
+                <li>
                   <strong>
                     Novo: Encouraçado vira efeito ativo togável na ficha.
                   </strong>{' '}

--- a/src/components/screens/Changelog.tsx
+++ b/src/components/screens/Changelog.tsx
@@ -73,6 +73,33 @@ const Changelog: React.FC = () => {
 
               <ul>
                 <li>
+                  <strong>Novo: lembrete dos cosméticos de apoiador.</strong>{' '}
+                  Apoiadores que ainda não experimentaram a{' '}
+                  <strong>cor de destaque personalizada</strong> ou os{' '}
+                  <strong>dados 3D</strong> agora recebem um lembrete discreto,
+                  no máximo uma vez por semana, com um atalho que abre direto a
+                  aba <strong>Sistema</strong> do perfil. Quem já personalizou
+                  tudo nunca vê o aviso, e há um botão{' '}
+                  <strong>&quot;Não mostrar mais&quot;</strong> para desativar
+                  permanentemente.
+                </li>
+                <li>
+                  <strong>Melhoria: home e menu de navegação refinados.</strong>{' '}
+                  O layout da página inicial foi reorganizado: hero e barra de
+                  ferramentas dividem a mesma linha no desktop, a coluna
+                  principal traz o <strong>fórum à esquerda</strong> (com
+                  apoiadores priorizados nos primeiros lugares) e{' '}
+                  <strong>continue jogando + blog</strong> à direita. A imagem
+                  de fundo voltou ao topo da home com gradiente até o tema. O
+                  menu superior ganhou novas categorias —{' '}
+                  <strong>
+                    Jogar / Ferramentas / Comunidade / Enciclopédia / Consulta
+                  </strong>{' '}
+                  — e a barra lateral mostra um atalho para{' '}
+                  <strong>editores e administradores</strong> criarem novos
+                  posts no blog.
+                </li>
+                <li>
                   <strong>Novo: página inicial redesenhada.</strong> A home
                   ganhou um layout em duas colunas com{' '}
                   <strong>destaques da comunidade</strong> (últimos posts do

--- a/src/components/screens/Changelog.tsx
+++ b/src/components/screens/Changelog.tsx
@@ -73,38 +73,131 @@ const Changelog: React.FC = () => {
 
               <ul>
                 <li>
-                  <strong>
-                    Novo: efeitos customizados em poderes (Apoiador).
-                  </strong>{' '}
-                  Cada poder expandido na sua ficha tem um botão de{' '}
-                  <strong>Configurações</strong> (ícone de engrenagem) que agora
-                  abre um diálogo com duas abas: <strong>Rolagens</strong> (como
-                  antes) e <strong>Efeitos</strong>. Na nova aba você cria{' '}
-                  <strong>efeitos com múltiplos tiers</strong> — cada tier com
-                  seu próprio custo de PM e seus bônus mecânicos. Os bônus
-                  cobrem praticamente tudo: atributos, ataque (geral, corpo a
-                  corpo ou à distância), dano de arma, defesa, deslocamento,
-                  perícias, PV/PM, iniciativa, testes de resistência
-                  (Fortitude/Reflexos/Vontade ou todos), CD de magias, redução
-                  de dano por tipo e margem/multiplicador de crítico. Os efeitos
-                  criados aparecem no gerenciador de{' '}
-                  <strong>Efeitos Ativos</strong> com a etiqueta{' '}
-                  <strong>Customizado</strong> e podem ser ativados/desativados
-                  como qualquer outro efeito. Poderes que já têm efeito ativo
-                  pronto no sistema (como Inspiração do Bardo) mostram o efeito
-                  embutido em modo somente-leitura na aba.
+                  <li>
+                    <strong>
+                      Novo: efeitos customizados em poderes (Apoiador).
+                    </strong>{' '}
+                    Cada poder expandido na sua ficha tem um botão de{' '}
+                    <strong>Configurações</strong> (ícone de engrenagem) que
+                    agora abre um diálogo com duas abas:{' '}
+                    <strong>Rolagens</strong> (como antes) e{' '}
+                    <strong>Efeitos</strong>. Na nova aba você cria{' '}
+                    <strong>efeitos com múltiplos tiers</strong> — cada tier com
+                    seu próprio custo de PM e seus bônus mecânicos. Os bônus
+                    cobrem praticamente tudo: atributos, ataque (geral, corpo a
+                    corpo ou à distância), dano de arma, defesa, deslocamento,
+                    perícias, PV/PM, iniciativa, testes de resistência
+                    (Fortitude/Reflexos/Vontade ou todos), CD de magias, redução
+                    de dano por tipo e margem/multiplicador de crítico. Os
+                    efeitos criados aparecem no gerenciador de{' '}
+                    <strong>Efeitos Ativos</strong> com a etiqueta{' '}
+                    <strong>Customizado</strong> e podem ser
+                    ativados/desativados como qualquer outro efeito. Poderes que
+                    já têm efeito ativo pronto no sistema (como Inspiração do
+                    Bardo) mostram o efeito embutido em modo somente-leitura na
+                    aba.
+                  </li>
+                  <strong>Efeitos de poderes e magias.</strong> Esta versão
+                  trouxe um pacote de novidades e ajustes no motor de efeitos
+                  ativos:
+                  <ul>
+                    <li>
+                      <strong>
+                        Novo: Encouraçado vira efeito ativo togável na ficha.
+                      </strong>{' '}
+                      O poder geral <strong>Encouraçado</strong> agora pode ser
+                      ativado direto pelo cabeçalho, aplicando o bônus na Defesa{' '}
+                      <strong>com escala dinâmica</strong>: +2 de base e +2
+                      adicional para cada poder dependente que você possua
+                      (Inexpugnável, Fanático, Catafractário, Encastelado). Se
+                      você não estiver com armadura pesada equipada, um aviso
+                      discreto aparece no diálogo — sem bloquear a ativação.
+                    </li>
+                    <li>
+                      <strong>
+                        Novo: tier &quot;Customizado&quot; em magias com
+                        aprimoramento escalável.
+                      </strong>{' '}
+                      Magias como <strong>Armadura Arcana</strong> agora
+                      oferecem, além dos valores comuns, um tier{' '}
+                      <strong>Customizado</strong> com botões +/- para você
+                      ajustar o bônus quando aprimorou além do teto modelado
+                      (por exemplo, +13 na Defesa com 8 aprimoramentos).
+                    </li>
+                    <li>
+                      <strong>
+                        Novo: três magias passam a oferecer efeito ativo.
+                      </strong>{' '}
+                      <strong>Aviso</strong> (+5 no próximo teste de Iniciativa
+                      e em Percepção, opção &quot;Alerta&quot;),{' '}
+                      <strong>Maaais Klunc</strong> (+10 em Força com cascata
+                      para perícias de Força e dano corpo a corpo) e{' '}
+                      <strong>Mente Divina</strong> (8 tiers cobrindo a base e
+                      todos os aprimoramentos para +2/+4 em um atributo mental
+                      escolhido ou nos três).
+                    </li>
+                    <li>
+                      <strong>
+                        Novo: aba &quot;Adicionar&quot; no gerenciador de
+                        efeitos ativos.
+                      </strong>{' '}
+                      Agora dá para incluir manualmente qualquer efeito de poder
+                      ou magia do compêndio na sua ficha — sem pagar PM e sem
+                      notificar aliados da mesa. Útil para narrar buffs do
+                      mestre ou para jogo solo. Há uma busca embutida e um aviso
+                      esclarecendo que pré-requisitos não são validados nesse
+                      modo.
+                    </li>
+                    <li>
+                      <strong>
+                        Melhoria: bônus de atributo em efeitos ativos finalmente
+                        aplicam de verdade.
+                      </strong>{' '}
+                      Boosts como o <strong>+2 Força</strong> do Banquete
+                      Selvagem do Druida, o <strong>+4 em atributo</strong> da
+                      Força da Natureza, o <strong>+1/+2 Força</strong> do
+                      Crescimento Feérico (qareen) e o{' '}
+                      <strong>+2 Carisma</strong> da Aparência Perfeita — antes
+                      silenciosamente ignorados pelo motor — agora cascateiam
+                      corretamente para todas as <strong>perícias</strong>{' '}
+                      derivadas do atributo (incluindo Luta/Pontaria, Iniciativa
+                      e resistências). Boosts de Força também somam no dano
+                      corpo a corpo; boosts de Destreza, na Defesa.
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <strong>Novo: página inicial redesenhada.</strong> A gente
+                  estará continuamente tentando melhorar a qualidade da home
+                  para refletir novas ferramentas, os conteúdos dinâmicos da
+                  comunidade e muito mais. Para isso, vamos tentar algums
+                  soluções um pouco. Nada é permanente, vamos nos adaptando e
+                  melhorando.
+                </li>
+                <li>
+                  <strong>Novo: lembrete dos cosméticos de apoiador.</strong>{' '}
+                  Apoiadores que ainda não experimentaram a{' '}
+                  <strong>cor de destaque personalizada</strong> ou os{' '}
+                  <strong>dados 3D</strong> agora recebem um lembrete discreto,
+                  no máximo uma vez por semana, com um atalho que abre direto a
+                  aba <strong>Sistema</strong> do perfil. Quem já personalizou
+                  tudo nunca vê o aviso, e há um botão{' '}
+                  <strong>&quot;Não mostrar mais&quot;</strong> para desativar
+                  permanentemente.
                 </li>
                 <li>
                   <strong>
-                    Melhoria: barra lateral de ferramentas mais densa no
-                    desktop.
+                    Novo: publicação anônima por padrão no Bestiário da
+                    Comunidade.
                   </strong>{' '}
-                  Na home, a coluna de ferramentas passa a usar{' '}
-                  <strong>três colunas</strong> em telas médias/grandes (era
-                  duas) e ganha um pouco mais de largura, mostrando mais atalhos
-                  sem precisar rolar. No celular o layout continua em duas
-                  colunas com ícones maiores e mais espaçamento para facilitar o
-                  toque.
+                  Suas ameaças publicadas agora aparecem como{' '}
+                  <strong>&quot;por Anônimo&quot;</strong> para outros usuários,
+                  protegendo mestres que não querem revelar a autoria e spoilear
+                  os próprios jogadores. Quem preferir aparecer pode desativar a
+                  opção em <strong>Perfil → Sistema</strong>, na nova seção{' '}
+                  <strong>Privacidade</strong>. A página de publicação também
+                  avisa quando você está publicando anonimamente, com atalho
+                  para as configurações.
                 </li>
                 <li>
                   <strong>
@@ -124,45 +217,6 @@ const Changelog: React.FC = () => {
                   (treinamento não se aplica a resistências).
                 </li>
                 <li>
-                  <strong>Novo: lembrete dos cosméticos de apoiador.</strong>{' '}
-                  Apoiadores que ainda não experimentaram a{' '}
-                  <strong>cor de destaque personalizada</strong> ou os{' '}
-                  <strong>dados 3D</strong> agora recebem um lembrete discreto,
-                  no máximo uma vez por semana, com um atalho que abre direto a
-                  aba <strong>Sistema</strong> do perfil. Quem já personalizou
-                  tudo nunca vê o aviso, e há um botão{' '}
-                  <strong>&quot;Não mostrar mais&quot;</strong> para desativar
-                  permanentemente.
-                </li>
-                <li>
-                  <strong>Melhoria: home e menu de navegação refinados.</strong>{' '}
-                  O layout da página inicial foi reorganizado: hero e barra de
-                  ferramentas dividem a mesma linha no desktop, a coluna
-                  principal traz o <strong>fórum à esquerda</strong> (com
-                  apoiadores priorizados nos primeiros lugares) e{' '}
-                  <strong>continue jogando + blog</strong> à direita. A imagem
-                  de fundo voltou ao topo da home com gradiente até o tema. O
-                  menu superior ganhou novas categorias —{' '}
-                  <strong>
-                    Jogar / Ferramentas / Comunidade / Enciclopédia / Consulta
-                  </strong>{' '}
-                  — e a barra lateral mostra um atalho para{' '}
-                  <strong>editores e administradores</strong> criarem novos
-                  posts no blog.
-                </li>
-                <li>
-                  <strong>Novo: página inicial redesenhada.</strong> A home
-                  ganhou um layout em duas colunas com{' '}
-                  <strong>destaques da comunidade</strong> (últimos posts do
-                  blog, atividade do fórum, builds públicas recentes), uma seção{' '}
-                  <strong>Continue sua jornada</strong> com seus personagens e
-                  mesas, um <strong>banner de sessão ativa</strong> avisando
-                  quando você tem uma mesa rolando, e uma{' '}
-                  <strong>barra lateral de ferramentas</strong> sempre à mão. O
-                  carrossel principal ficou mais compacto pra dar protagonismo
-                  ao conteúdo abaixo.
-                </li>
-                <li>
                   <strong>
                     Correção: aba &quot;Sistema&quot; do Perfil voltava sozinha
                     para &quot;Perfil&quot;.
@@ -176,96 +230,11 @@ const Changelog: React.FC = () => {
                 </li>
                 <li>
                   <strong>
-                    Novo: Encouraçado vira efeito ativo togável na ficha.
-                  </strong>{' '}
-                  O poder geral <strong>Encouraçado</strong> agora pode ser
-                  ativado direto pelo cabeçalho, aplicando o bônus na Defesa{' '}
-                  <strong>com escala dinâmica</strong>: +2 de base e +2
-                  adicional para cada poder dependente que você possua
-                  (Inexpugnável, Fanático, Catafractário, Encastelado). Se você
-                  não estiver com armadura pesada equipada, um aviso discreto
-                  aparece no diálogo — sem bloquear a ativação.
-                </li>
-                <li>
-                  <strong>
-                    Novo: tier &quot;Customizado&quot; em magias com
-                    aprimoramento escalável.
-                  </strong>{' '}
-                  Magias como <strong>Armadura Arcana</strong> agora oferecem,
-                  além dos valores comuns, um tier <strong>Customizado</strong>{' '}
-                  com botões +/- para você ajustar o bônus quando aprimorou além
-                  do teto modelado (por exemplo, +13 na Defesa com 8
-                  aprimoramentos).
-                </li>
-                <li>
-                  <strong>
-                    Novo: três magias passam a oferecer efeito ativo.
-                  </strong>{' '}
-                  <strong>Aviso</strong> (+5 no próximo teste de Iniciativa e em
-                  Percepção, opção &quot;Alerta&quot;),{' '}
-                  <strong>Maaais Klunc</strong> (+10 em Força com cascata para
-                  perícias de Força e dano corpo a corpo) e{' '}
-                  <strong>Mente Divina</strong> (8 tiers cobrindo a base e todos
-                  os aprimoramentos para +2/+4 em um atributo mental escolhido
-                  ou nos três).
-                </li>
-                <li>
-                  <strong>
-                    Novo: aba &quot;Adicionar&quot; no gerenciador de efeitos
-                    ativos.
-                  </strong>{' '}
-                  Agora dá para incluir manualmente qualquer efeito de poder ou
-                  magia do compêndio na sua ficha — sem pagar PM e sem notificar
-                  aliados da mesa. Útil para narrar buffs do mestre ou para jogo
-                  solo. Há uma busca embutida e um aviso esclarecendo que
-                  pré-requisitos não são validados nesse modo.
-                </li>
-                <li>
-                  <strong>
-                    Melhoria: bônus de atributo em efeitos ativos finalmente
-                    aplicam de verdade.
-                  </strong>{' '}
-                  Boosts como o <strong>+2 Força</strong> do Banquete Selvagem
-                  do Druida, o <strong>+4 em atributo</strong> da Força da
-                  Natureza, o <strong>+1/+2 Força</strong> do Crescimento
-                  Feérico (qareen) e o <strong>+2 Carisma</strong> da Aparência
-                  Perfeita — antes silenciosamente ignorados pelo motor — agora
-                  cascateiam corretamente para todas as{' '}
-                  <strong>perícias</strong> derivadas do atributo (incluindo
-                  Luta/Pontaria, Iniciativa e resistências). Boosts de Força
-                  também somam no dano corpo a corpo; boosts de Destreza, na
-                  Defesa.
-                </li>
-                <li>
-                  <strong>
                     Correção: resistências infladas de ameaças na mesa virtual.
                   </strong>{' '}
                   Em algumas ameaças importadas para a mesa virtual, valores de
                   Fortitude/Reflexos/Vontade apareciam somados em duplicado.
                   Cálculo corrigido.
-                </li>
-                <li>
-                  <strong>Novo: papel EDITOR no blog.</strong> Adicionado um
-                  novo papel de usuário <strong>EDITOR</strong> que pode criar e
-                  editar seus próprios posts no blog em modo rascunho, enquanto
-                  apenas administradores podem publicar. Útil para colaboradores
-                  que produzem conteúdo, mas precisam de revisão antes da
-                  publicação. Inclui toggle no painel de administração e UI
-                  simplificada do editor para esse papel.
-                </li>
-                <li>
-                  <strong>
-                    Novo: publicação anônima por padrão no Bestiário da
-                    Comunidade.
-                  </strong>{' '}
-                  Suas ameaças publicadas agora aparecem como{' '}
-                  <strong>&quot;por Anônimo&quot;</strong> para outros usuários,
-                  protegendo mestres que não querem revelar a autoria e spoilear
-                  os próprios jogadores. Quem preferir aparecer pode desativar a
-                  opção em <strong>Perfil → Sistema</strong>, na nova seção{' '}
-                  <strong>Privacidade</strong>. A página de publicação também
-                  avisa quando você está publicando anonimamente, com atalho
-                  para as configurações.
                 </li>
               </ul>
 

--- a/src/components/screens/Changelog.tsx
+++ b/src/components/screens/Changelog.tsx
@@ -74,6 +74,40 @@ const Changelog: React.FC = () => {
               <ul>
                 <li>
                   <strong>
+                    Novo: efeitos customizados em poderes (Apoiador).
+                  </strong>{' '}
+                  Cada poder expandido na sua ficha tem um botão de{' '}
+                  <strong>Configurações</strong> (ícone de engrenagem) que agora
+                  abre um diálogo com duas abas: <strong>Rolagens</strong> (como
+                  antes) e <strong>Efeitos</strong>. Na nova aba você cria{' '}
+                  <strong>efeitos com múltiplos tiers</strong> — cada tier com
+                  seu próprio custo de PM e seus bônus mecânicos. Os bônus
+                  cobrem praticamente tudo: atributos, ataque (geral, corpo a
+                  corpo ou à distância), dano de arma, defesa, deslocamento,
+                  perícias, PV/PM, iniciativa, testes de resistência
+                  (Fortitude/Reflexos/Vontade ou todos), CD de magias, redução
+                  de dano por tipo e margem/multiplicador de crítico. Os efeitos
+                  criados aparecem no gerenciador de{' '}
+                  <strong>Efeitos Ativos</strong> com a etiqueta{' '}
+                  <strong>Customizado</strong> e podem ser ativados/desativados
+                  como qualquer outro efeito. Poderes que já têm efeito ativo
+                  pronto no sistema (como Inspiração do Bardo) mostram o efeito
+                  embutido em modo somente-leitura na aba.
+                </li>
+                <li>
+                  <strong>
+                    Melhoria: barra lateral de ferramentas mais densa no
+                    desktop.
+                  </strong>{' '}
+                  Na home, a coluna de ferramentas passa a usar{' '}
+                  <strong>três colunas</strong> em telas médias/grandes (era
+                  duas) e ganha um pouco mais de largura, mostrando mais atalhos
+                  sem precisar rolar. No celular o layout continua em duas
+                  colunas com ícones maiores e mais espaçamento para facilitar o
+                  toque.
+                </li>
+                <li>
+                  <strong>
                     Correção: Fortitude, Reflexos e Vontade agora podem ser
                     editadas no Gerador de Ameaças.
                   </strong>{' '}

--- a/src/components/screens/Changelog.tsx
+++ b/src/components/screens/Changelog.tsx
@@ -73,6 +73,23 @@ const Changelog: React.FC = () => {
 
               <ul>
                 <li>
+                  <strong>
+                    Correção: Fortitude, Reflexos e Vontade agora podem ser
+                    editadas no Gerador de Ameaças.
+                  </strong>{' '}
+                  Antes, essas três perícias ficavam travadas com o valor
+                  derivado da atribuição <strong>Forte/Média/Fraca</strong> e
+                  não dava para sobrescrever. Agora elas aparecem na mesma
+                  tabela das demais perícias em{' '}
+                  <strong>Configurar Perícias</strong>, já pré-preenchidas com o
+                  valor calculado da tabela de combate — basta digitar um novo
+                  número no campo <strong>Total</strong> para sobrescrever. O
+                  valor editado se reflete no statblock, na rolagem de dados e
+                  no export para o Foundry VTT. A checkbox{' '}
+                  <strong>Treinada</strong> fica desabilitada nessas três
+                  (treinamento não se aplica a resistências).
+                </li>
+                <li>
                   <strong>Novo: lembrete dos cosméticos de apoiador.</strong>{' '}
                   Apoiadores que ainda não experimentaram a{' '}
                   <strong>cor de destaque personalizada</strong> ou os{' '}

--- a/src/components/screens/ProfilePage.tsx
+++ b/src/components/screens/ProfilePage.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-nested-ternary */
 import React, { useEffect, useState } from 'react';
-import { useParams, useHistory } from 'react-router-dom';
+import { useParams, useHistory, useLocation } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import {
   Box,
@@ -96,9 +96,16 @@ function TabPanel(props: TabPanelProps) {
   );
 }
 
+function getInitialTabFromHash(hash: string): number {
+  if (hash === '#sistema') return 1;
+  if (hash === '#apoio') return 2;
+  return 0;
+}
+
 const ProfilePage: React.FC = () => {
   const { username } = useParams<{ username: string }>();
   const history = useHistory();
+  const location = useLocation();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const dispatch = useDispatch<AppDispatch>();
@@ -134,7 +141,9 @@ const ProfilePage: React.FC = () => {
   });
   const [editLoading, setEditLoading] = useState(false);
   const [editError, setEditError] = useState<string | null>(null);
-  const [currentTab, setCurrentTab] = useState(0);
+  const [currentTab, setCurrentTab] = useState(() =>
+    getInitialTabFromHash(location.hash)
+  );
   const [selectedSupplements, setSelectedSupplements] = useState<
     SupplementId[]
   >(() => currentUser?.enabledSupplements || [SupplementId.TORMENTA20_CORE]);

--- a/src/components/screens/ProfilePage.tsx
+++ b/src/components/screens/ProfilePage.tsx
@@ -64,6 +64,7 @@ import {
   updateProfile,
   saveSystemSetup,
   saveDice3DSettings,
+  saveBestiaryAnonymous,
 } from '../../store/slices/auth/authSlice';
 import {
   SupplementId,
@@ -155,6 +156,16 @@ const ProfilePage: React.FC = () => {
   const [dice3DLoading, setDice3DLoading] = useState(false);
   const [dice3DError, setDice3DError] = useState<string | null>(null);
   const [dice3DSuccess, setDice3DSuccess] = useState(false);
+  const [bestiaryAnonymous, setBestiaryAnonymousState] = useState(
+    currentUser?.bestiaryAnonymous !== false
+  );
+  const [bestiaryAnonymousLoading, setBestiaryAnonymousLoading] =
+    useState(false);
+  const [bestiaryAnonymousError, setBestiaryAnonymousError] = useState<
+    string | null
+  >(null);
+  const [bestiaryAnonymousSuccess, setBestiaryAnonymousSuccess] =
+    useState(false);
 
   const isOwnProfile =
     isAuthenticated && currentUser?.username === username?.toLowerCase();
@@ -168,6 +179,11 @@ const ProfilePage: React.FC = () => {
       setDiceColor(currentUser.diceColor);
     }
   }, [currentUser?.dice3DEnabled, currentUser?.diceColor]);
+
+  // Sync bestiaryAnonymous state with user data (default: true)
+  useEffect(() => {
+    setBestiaryAnonymousState(currentUser?.bestiaryAnonymous !== false);
+  }, [currentUser?.bestiaryAnonymous]);
 
   // Load subscription when support tab is selected (tab index 2)
   useEffect(() => {
@@ -398,6 +414,26 @@ const ProfilePage: React.FC = () => {
       setDice3DEnabled(!checked);
     } finally {
       setDice3DLoading(false);
+    }
+  };
+
+  const handleToggleBestiaryAnonymous = async (checked: boolean) => {
+    const previous = bestiaryAnonymous;
+    try {
+      setBestiaryAnonymousLoading(true);
+      setBestiaryAnonymousError(null);
+      setBestiaryAnonymousSuccess(false);
+      setBestiaryAnonymousState(checked);
+      await dispatch(saveBestiaryAnonymous(checked)).unwrap();
+      setBestiaryAnonymousSuccess(true);
+      setTimeout(() => setBestiaryAnonymousSuccess(false), 3000);
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Erro ao salvar configuração';
+      setBestiaryAnonymousError(errorMessage);
+      setBestiaryAnonymousState(previous);
+    } finally {
+      setBestiaryAnonymousLoading(false);
     }
   };
 
@@ -1020,6 +1056,74 @@ const ProfilePage: React.FC = () => {
                         Notificações
                       </Typography>
                       <PushNotificationToggle variant='full' />
+                    </Box>
+
+                    <Box>
+                      <Typography variant='h6' fontWeight='bold' gutterBottom>
+                        Privacidade
+                      </Typography>
+                      <Typography
+                        variant='caption'
+                        color='text.secondary'
+                        sx={{ mb: 2, display: 'block' }}
+                      >
+                        Controle como você aparece para outros usuários
+                      </Typography>
+
+                      {bestiaryAnonymousError && (
+                        <Alert severity='error' sx={{ mb: 2 }}>
+                          {bestiaryAnonymousError}
+                        </Alert>
+                      )}
+
+                      {bestiaryAnonymousSuccess && (
+                        <Alert severity='success' sx={{ mb: 2 }}>
+                          Configuração salva com sucesso!
+                        </Alert>
+                      )}
+
+                      <Box
+                        sx={{
+                          p: 1.5,
+                          borderRadius: 1,
+                          border: '1px solid',
+                          borderColor: bestiaryAnonymous
+                            ? 'primary.main'
+                            : 'divider',
+                          backgroundColor: bestiaryAnonymous
+                            ? 'action.selected'
+                            : 'transparent',
+                          transition: 'all 0.2s',
+                        }}
+                      >
+                        <FormControlLabel
+                          control={
+                            <Checkbox
+                              checked={bestiaryAnonymous}
+                              onChange={(e) =>
+                                handleToggleBestiaryAnonymous(e.target.checked)
+                              }
+                              disabled={bestiaryAnonymousLoading}
+                            />
+                          }
+                          label={
+                            <Stack spacing={0.5}>
+                              <Typography variant='body1' fontWeight='medium'>
+                                Publicar no Bestiário anonimamente
+                              </Typography>
+                              <Typography
+                                variant='caption'
+                                color='text.secondary'
+                              >
+                                Quando ativado, seu nome de usuário não será
+                                exibido nas ameaças que você publica no
+                                Bestiário da Comunidade. Útil para mestres que
+                                não querem dar spoilers para seus jogadores.
+                              </Typography>
+                            </Stack>
+                          }
+                        />
+                      </Box>
                     </Box>
 
                     <Box>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -22,5 +22,6 @@ export const useAuth = () => {
     error: auth.error,
     isPremium: auth.dbUser?.isPremium || false,
     isModerator: auth.dbUser?.isModerator || false,
+    isEditor: auth.dbUser?.isEditor || false,
   };
 };

--- a/src/interfaces/Class.ts
+++ b/src/interfaces/Class.ts
@@ -1,3 +1,4 @@
+import type { CustomEffect } from '../premium/interfaces/CustomEffect';
 import { Atributo } from '../data/systems/tormenta20/atributos';
 import { SheetBonus, SheetAction } from './CharacterSheet';
 import { DiceRoll } from './DiceRoll';
@@ -59,6 +60,7 @@ export type ClassAbility = {
   sheetActions?: SheetAction[];
   sheetBonuses?: SheetBonus[];
   rolls?: DiceRoll[]; // Rolagens customizadas pelo usuário
+  customEffects?: CustomEffect[]; // Efeitos customizados pelo usuário
 };
 
 export type ClassPower = {
@@ -70,6 +72,7 @@ export type ClassPower = {
   sheetBonuses?: SheetBonus[];
   canRepeat?: boolean;
   rolls?: DiceRoll[]; // Rolagens customizadas pelo usuário
+  customEffects?: CustomEffect[]; // Efeitos customizados pelo usuário
   supplementId?: SupplementId; // Suplemento de origem do poder
   supplementName?: string; // Nome do suplemento de origem
   className?: string; // Multiclasse: qual classe concedeu este poder

--- a/src/interfaces/CustomPower.ts
+++ b/src/interfaces/CustomPower.ts
@@ -1,3 +1,4 @@
+import type { CustomEffect } from '../premium/interfaces/CustomEffect';
 import { DiceRoll } from './DiceRoll';
 
 export interface CustomPower {
@@ -5,4 +6,5 @@ export interface CustomPower {
   name: string; // Nome do poder (definido pelo usuário)
   description: string; // Descrição do poder
   rolls?: DiceRoll[]; // Rolagens opcionais (ex: "Dano" - "2d6+3")
+  customEffects?: CustomEffect[]; // Efeitos customizados (definidos pelo usuário)
 }

--- a/src/interfaces/Poderes.ts
+++ b/src/interfaces/Poderes.ts
@@ -1,3 +1,4 @@
+import type { CustomEffect } from '../premium/interfaces/CustomEffect';
 import { Atributo } from '../data/systems/tormenta20/atributos';
 // eslint-disable-next-line
 import CharacterSheet, {
@@ -52,6 +53,7 @@ export interface GeneralPower {
   sheetActions?: SheetAction[];
   sheetBonuses?: SheetBonus[];
   rolls?: DiceRoll[]; // Rolagens customizadas pelo usuário
+  customEffects?: CustomEffect[]; // Efeitos customizados pelo usuário
 }
 
 export type GeneralPowers = {
@@ -65,6 +67,7 @@ export type OriginPower = {
   sheetActions?: SheetAction[];
   sheetBonuses?: SheetBonus[];
   rolls?: DiceRoll[]; // Rolagens customizadas pelo usuário
+  customEffects?: CustomEffect[]; // Efeitos customizados pelo usuário
 };
 
 export type PowerGetter = (sheet: CharacterSheet, subSteps: SubStep[]) => void;

--- a/src/interfaces/Race.ts
+++ b/src/interfaces/Race.ts
@@ -1,3 +1,4 @@
+import type { CustomEffect } from '../premium/interfaces/CustomEffect';
 import { Atributo } from '../data/systems/tormenta20/atributos';
 import { CharacterAttributes, CharacterReligion } from './Character';
 // eslint-disable-next-line
@@ -66,6 +67,7 @@ export type RaceAbility = {
   sheetActions?: SheetAction[];
   sheetBonuses?: SheetBonus[];
   rolls?: DiceRoll[]; // Rolagens customizadas pelo usuário
+  customEffects?: CustomEffect[]; // Efeitos customizados pelo usuário
 };
 
 export interface RaceHeritage {

--- a/src/store/slices/auth/authSlice.ts
+++ b/src/store/slices/auth/authSlice.ts
@@ -119,6 +119,21 @@ export const saveAppearanceSettings = createAsyncThunk(
   }
 );
 
+export const saveBestiaryAnonymous = createAsyncThunk(
+  'auth/saveBestiaryAnonymous',
+  async (enabled: boolean, { rejectWithValue }) => {
+    try {
+      const updatedUser = await authService.saveBestiaryAnonymous(enabled);
+      return updatedUser;
+    } catch (error) {
+      if (error instanceof Error) {
+        return rejectWithValue(error.message);
+      }
+      return rejectWithValue('Failed to save bestiary anonymous setting');
+    }
+  }
+);
+
 export const acceptTerms = createAsyncThunk(
   'auth/acceptTerms',
   async (version: number, { rejectWithValue }) => {
@@ -267,6 +282,21 @@ const authSlice = createSlice({
         state.dbUser = action.payload;
       })
       .addCase(saveAppearanceSettings.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload as string;
+      });
+
+    // Save Bestiary Anonymous
+    builder
+      .addCase(saveBestiaryAnonymous.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(saveBestiaryAnonymous.fulfilled, (state, action) => {
+        state.loading = false;
+        state.dbUser = action.payload;
+      })
+      .addCase(saveBestiaryAnonymous.rejected, (state, action) => {
         state.loading = false;
         state.error = action.payload as string;
       });

--- a/src/store/slices/auth/authSlice.ts
+++ b/src/store/slices/auth/authSlice.ts
@@ -242,62 +242,53 @@ const authSlice = createSlice({
     });
 
     // Save System Setup
+    // Não tocar em state.loading: o AuthLoadingWrapper desmonta a árvore
+    // inteira quando loading=true, o que reseta state local (ex.: aba ativa
+    // na ProfilePage). Loading de cada save é controlado pela própria UI.
     builder
       .addCase(saveSystemSetup.pending, (state) => {
-        state.loading = true;
         state.error = null;
       })
       .addCase(saveSystemSetup.fulfilled, (state, action) => {
-        state.loading = false;
         state.dbUser = action.payload;
       })
       .addCase(saveSystemSetup.rejected, (state, action) => {
-        state.loading = false;
         state.error = action.payload as string;
       });
 
     // Save Dice 3D Settings
     builder
       .addCase(saveDice3DSettings.pending, (state) => {
-        state.loading = true;
         state.error = null;
       })
       .addCase(saveDice3DSettings.fulfilled, (state, action) => {
-        state.loading = false;
         state.dbUser = action.payload;
       })
       .addCase(saveDice3DSettings.rejected, (state, action) => {
-        state.loading = false;
         state.error = action.payload as string;
       });
 
     // Save Appearance Settings
     builder
       .addCase(saveAppearanceSettings.pending, (state) => {
-        state.loading = true;
         state.error = null;
       })
       .addCase(saveAppearanceSettings.fulfilled, (state, action) => {
-        state.loading = false;
         state.dbUser = action.payload;
       })
       .addCase(saveAppearanceSettings.rejected, (state, action) => {
-        state.loading = false;
         state.error = action.payload as string;
       });
 
     // Save Bestiary Anonymous
     builder
       .addCase(saveBestiaryAnonymous.pending, (state) => {
-        state.loading = true;
         state.error = null;
       })
       .addCase(saveBestiaryAnonymous.fulfilled, (state, action) => {
-        state.loading = false;
         state.dbUser = action.payload;
       })
       .addCase(saveBestiaryAnonymous.rejected, (state, action) => {
-        state.loading = false;
         state.error = action.payload as string;
       });
 

--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -26,6 +26,7 @@ export interface DbUser {
   darkMode?: boolean;
   termsAcceptedVersion?: number;
   isModerator?: boolean;
+  isEditor?: boolean;
 }
 
 export interface AuthState {

--- a/src/types/auth.types.ts
+++ b/src/types/auth.types.ts
@@ -24,6 +24,7 @@ export interface DbUser {
   diceColor?: DiceColorId;
   accentColor?: AccentColorId;
   darkMode?: boolean;
+  bestiaryAnonymous?: boolean;
   termsAcceptedVersion?: number;
   isModerator?: boolean;
   isEditor?: boolean;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ import { VitePWA } from 'vite-plugin-pwa';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
 
 // Version used for cache naming - changing this invalidates all PWA caches
-const APP_VERSION = '4.16';
+const APP_VERSION = '4.17';
 
 // Plugin to handle SPA routing for paths with dots (e.g., /perfil/user.name)
 // This runs AFTER Vite's middleware to catch 404s on client-side routes


### PR DESCRIPTION
## Summary

### Home (redesenho)
- Hero compacto + sidebar de ferramentas sticky compartilhando a primeira linha.
- Nova área "Continue Jogando" com fichas recentes e mesas virtuais em duas colunas; mesa com status ACTIVE ganha banner verde full-width.
- Conteúdo da comunidade reorganizado: Fórum à esquerda (lista compacta, top 3 priorizam apoiadores, ordenado por última atividade), Continue + Blog à direita.
- Backdrop full-width atrás do hero e do navbar (não acompanha scroll).
- Sidebar de ferramentas em 4 grupos (Personagens, Comunidade, Consulta, Gerar) + categoria Editor para admin/editor com atalho "Novo Post".
- Navbar reorganizada: Jogar / Ferramentas / Comunidade / Enciclopédia / Consulta.

### Features
- Bestiário da comunidade integrado na home (banner + destaques).
- Blog: role EDITOR cria rascunhos.
- Efeitos customizados em poderes na ficha (Apoiador).
- Novos efeitos ativos: escala custom, cascata de atributo, adição manual.
- Nudge semanal de cosméticos para apoiadores.

### Fixes
- Botão ✨ aparece em poderes com efeitos customizados.
- "Minhas Ameaças" da sidebar aponta para `/meus-personagens?tab=ameacas`.
- Aba "Sistema" do Perfil não volta para "Perfil" ao salvar configuração.
- Editar Fortitude/Reflexos/Vontade no Gerador de Ameaças.
- Resistências infladas de ameaças na mesa virtual.

### Infra
- Bump APP_VERSION → 4.17 em todos os arquivos (Vite, JamboFooter, SidebarV2).
- Bump dos submódulos backend (PR #80) e premium (PR #4).

## Test plan
- [ ] Home: hero + sidebar dividem topo (desktop), empilham (mobile)
- [ ] Backdrop fica atrás do navbar, não acompanha scroll
- [ ] Continue Jogando: 2 colunas; banner verde para mesa ACTIVE
- [ ] Fórum ordenado por última atividade, top 3 = apoiadores
- [ ] Sidebar "Editor → Novo Post" só para admin/editor
- [ ] Mobile: Continue → Fórum → Blog
- [ ] Bestiário, efeitos customizados, EDITOR no blog funcionando
- [ ] Geração de fichas normal não quebrou; PDF export funciona

🤖 Generated with [Claude Code](https://claude.com/claude-code)