### PR TITLE
feat(ficha): dano da Briga escala com o nível de lutador

### DIFF
--- a/docs/superpowers/specs/2026-07-17-briga-escala-nivel-design.md
+++ b/docs/superpowers/specs/2026-07-17-briga-escala-nivel-design.md
@@ -1,0 +1,61 @@
+# Briga escala com o nível de Lutador
+
+## Problema
+
+A habilidade Briga (Lutador) tem um roll fixo de `1d6` em
+`src/data/systems/tormenta20/classes/lutador.ts`. Pelas regras oficiais do
+Tormenta 20, o dano desarmado aumenta com o nível de lutador, mas a ficha
+gerada mostra `1d6` em qualquer nível.
+
+## Regra oficial (tabela do Lutador)
+
+| Nível de lutador  | Dano desarmado |
+| ----------------- | -------------- |
+| 1º–4º             | 1d6            |
+| 5º–8º             | 1d8            |
+| 9º–12º            | 1d10           |
+| 13º–16º           | 1d12           |
+| 17º–19º           | 2d8            |
+| 20º (Dono da Rua) | 2d10           |
+
+A variante Atleta reutiliza a habilidade Briga e tem a mesma progressão
+(Corpo Ideal no 20º também leva a 2d10). Em multiclasse, vale o nível na
+classe que concede a Briga, não o nível do personagem.
+
+## Abordagem escolhida
+
+Helper dedicado (`src/functions/powers/lutador-special.ts`), seguindo o
+padrão de `frade-special.ts`:
+
+- `getBrigaDice(classLevel)`: mapeia nível de classe → dado.
+- `updateBrigaRolls(sheet)`: localiza a habilidade Briga em
+  `sheet.classe.abilities`, resolve o nível via `getClassLevel(sheet, ability.sourceClassName ?? sheet.classe.name)` e substitui o `dice` do
+  roll. Substitui os objetos (não muta in place) para não contaminar
+  `classe.originalAbilities`. Retorna o novo dado quando houve mudança,
+  para o level-up registrar um substep.
+
+Pontos de chamada (onde as habilidades de classe são materializadas na ficha):
+
+1. `applyClassAbilities` em `src/functions/general.ts` (geração aleatória).
+2. `levelUp` em `src/functions/general.ts` (level-up aleatório) — com
+   substep "Briga: dano desarmado aumenta para X" quando cruza um limiar.
+3. `applyClassAbilities` em `src/functions/recalculateSheet.ts` (recálculo:
+   edições, fichas históricas, level-up manual — que recalcula ao final).
+
+## Alternativas descartadas
+
+- **Mecanismo genérico de rolls por nível** (ex.: `diceByLevel` em
+  `DiceRoll`): exigiria propagar contexto de nível para os componentes de
+  exibição; invasivo demais para um único caso.
+- **Habilidades "Briga melhorada" nos níveis 5/9/13/17**: não existe
+  mecanismo de substituição de habilidade; geraria entradas duplicadas na
+  ficha.
+
+## Testes
+
+`src/__tests__/functions/lutadorBriga.test.ts` (vitest):
+
+- Tabela completa de `getBrigaDice` (limiares 1/5/9/13/17/20).
+- `recalculateSheet` de um Lutador nível N ajusta o roll da Briga.
+- Multiclasse: nível de classe (não de personagem) decide o dado.
+- Fichas de outras classes não são afetadas.

--- a/src/__tests__/functions/lutadorBriga.test.ts
+++ b/src/__tests__/functions/lutadorBriga.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for Briga (Lutador) unarmed damage scaling with class level.
+ * Official table: 1º-4º 1d6, 5º-8º 1d8, 9º-12º 1d10, 13º-16º 1d12,
+ * 17º-19º 2d8, 20º 2d10 (Dono da Rua).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  getBrigaDice,
+  updateBrigaRolls,
+} from '../../functions/powers/lutador-special';
+import { recalculateSheet } from '../../functions/recalculateSheet';
+import generateRandomSheet from '../../functions/general';
+import CharacterSheet from '../../interfaces/CharacterSheet';
+import { CharacterAttributes } from '../../interfaces/Character';
+import { Atributo } from '../../data/systems/tormenta20/atributos';
+import Bag from '../../interfaces/Bag';
+import { SupplementId } from '../../types/supplement.types';
+import { dataRegistry } from '../../data/registry';
+
+const createLutadorSheet = (nivel: number): CharacterSheet => {
+  const coreClasses = dataRegistry.getClassesBySupplements([
+    SupplementId.TORMENTA20_CORE,
+  ]);
+  const coreRaces = dataRegistry.getRacesBySupplements([
+    SupplementId.TORMENTA20_CORE,
+  ]);
+
+  const lutadorClass = coreClasses.find((c) => c.name === 'Lutador');
+  const humanoRace = coreRaces.find((r) => r.name === 'Humano');
+
+  if (!lutadorClass || !humanoRace) {
+    throw new Error('Lutador class or Humano race not found in registry');
+  }
+
+  const attributes: CharacterAttributes = {
+    [Atributo.FORCA]: { name: Atributo.FORCA, value: 3 },
+    [Atributo.DESTREZA]: { name: Atributo.DESTREZA, value: 1 },
+    [Atributo.CONSTITUICAO]: { name: Atributo.CONSTITUICAO, value: 2 },
+    [Atributo.INTELIGENCIA]: { name: Atributo.INTELIGENCIA, value: 0 },
+    [Atributo.SABEDORIA]: { name: Atributo.SABEDORIA, value: 0 },
+    [Atributo.CARISMA]: { name: Atributo.CARISMA, value: 0 },
+  };
+
+  return {
+    id: `test-lutador-${nivel}`,
+    nome: 'Test Lutador',
+    sexo: 'Masculino',
+    nivel,
+    atributos: attributes,
+    raca: humanoRace,
+    classe: lutadorClass,
+    skills: [],
+    pv: 20,
+    pm: 3,
+    sheetBonuses: [],
+    sheetActionHistory: [],
+    defesa: 10,
+    bag: new Bag(),
+    devoto: undefined,
+    origin: undefined,
+    spells: [],
+    displacement: 9,
+    size: humanoRace.size!,
+    maxSpaces: 10,
+    generalPowers: [],
+    classPowers: [],
+    steps: [],
+  };
+};
+
+const getBrigaRollDice = (sheet: CharacterSheet): string | undefined => {
+  const briga = sheet.classe.abilities.find((a) => a.name === 'Briga');
+  return briga?.rolls?.[0]?.dice;
+};
+
+describe('getBrigaDice — official damage table', () => {
+  it('returns 1d6 from level 1 to 4', () => {
+    expect(getBrigaDice(1)).toBe('1d6');
+    expect(getBrigaDice(4)).toBe('1d6');
+  });
+
+  it('returns 1d8 from level 5 to 8', () => {
+    expect(getBrigaDice(5)).toBe('1d8');
+    expect(getBrigaDice(8)).toBe('1d8');
+  });
+
+  it('returns 1d10 from level 9 to 12', () => {
+    expect(getBrigaDice(9)).toBe('1d10');
+    expect(getBrigaDice(12)).toBe('1d10');
+  });
+
+  it('returns 1d12 from level 13 to 16', () => {
+    expect(getBrigaDice(13)).toBe('1d12');
+    expect(getBrigaDice(16)).toBe('1d12');
+  });
+
+  it('returns 2d8 from level 17 to 19', () => {
+    expect(getBrigaDice(17)).toBe('2d8');
+    expect(getBrigaDice(19)).toBe('2d8');
+  });
+
+  it('returns 2d10 at level 20 (Dono da Rua)', () => {
+    expect(getBrigaDice(20)).toBe('2d10');
+  });
+});
+
+describe('updateBrigaRolls', () => {
+  it('updates the Briga roll dice according to class level', () => {
+    const sheet = createLutadorSheet(9);
+    // Simulate abilities already materialized on the sheet
+    sheet.classe = {
+      ...sheet.classe,
+      abilities: sheet.classe.abilities.filter((a) => a.nivel <= 9),
+    };
+
+    const newDice = updateBrigaRolls(sheet);
+
+    expect(newDice).toBe('1d10');
+    expect(getBrigaRollDice(sheet)).toBe('1d10');
+  });
+
+  it('returns null when the dice does not change', () => {
+    const sheet = createLutadorSheet(3);
+    sheet.classe = {
+      ...sheet.classe,
+      abilities: sheet.classe.abilities.filter((a) => a.nivel <= 3),
+    };
+
+    expect(updateBrigaRolls(sheet)).toBeNull();
+    expect(getBrigaRollDice(sheet)).toBe('1d6');
+  });
+
+  it('does not mutate originalAbilities', () => {
+    const sheet = createLutadorSheet(13);
+    sheet.classe = {
+      ...sheet.classe,
+      abilities: sheet.classe.abilities.filter((a) => a.nivel <= 13),
+    };
+    sheet.classe.originalAbilities = [...sheet.classe.abilities];
+
+    updateBrigaRolls(sheet);
+
+    const originalBriga = sheet.classe.originalAbilities.find(
+      (a) => a.name === 'Briga'
+    );
+    expect(originalBriga?.rolls?.[0]?.dice).toBe('1d6');
+    expect(getBrigaRollDice(sheet)).toBe('1d12');
+  });
+
+  it('uses the class level, not the character level, for multiclass', () => {
+    const sheet = createLutadorSheet(6);
+    sheet.classe = {
+      ...sheet.classe,
+      abilities: sheet.classe.abilities.filter((a) => a.nivel <= 4),
+    };
+    sheet.classLevels = [
+      { className: 'Lutador', level: 1 },
+      { className: 'Lutador', level: 2 },
+      { className: 'Lutador', level: 3 },
+      { className: 'Lutador', level: 4 },
+      { className: 'Guerreiro', level: 5 },
+      { className: 'Guerreiro', level: 6 },
+    ];
+
+    expect(updateBrigaRolls(sheet)).toBeNull();
+    expect(getBrigaRollDice(sheet)).toBe('1d6');
+  });
+});
+
+describe('generateRandomSheet — Briga scaling integration', () => {
+  it('scales Briga dice on a randomly generated level 10 Lutador', () => {
+    const sheet = generateRandomSheet({
+      nivel: 10,
+      raca: 'Humano',
+      classe: 'Lutador',
+      origin: '',
+      devocao: { label: '', value: '' },
+      supplements: [SupplementId.TORMENTA20_CORE],
+    });
+
+    expect(getBrigaRollDice(sheet)).toBe('1d10');
+  });
+});
+
+describe('recalculateSheet — Briga scaling integration', () => {
+  it('scales Briga dice on a level 9 Lutador', () => {
+    const sheet = createLutadorSheet(9);
+    const recalculated = recalculateSheet(sheet);
+
+    expect(getBrigaRollDice(recalculated)).toBe('1d10');
+  });
+
+  it('keeps 1d6 on a level 1 Lutador', () => {
+    const sheet = createLutadorSheet(1);
+    const recalculated = recalculateSheet(sheet);
+
+    expect(getBrigaRollDice(recalculated)).toBe('1d6');
+  });
+
+  it('reaches 2d10 at level 20', () => {
+    const sheet = createLutadorSheet(20);
+    const recalculated = recalculateSheet(sheet);
+
+    expect(getBrigaRollDice(recalculated)).toBe('2d10');
+  });
+});

--- a/src/functions/general.ts
+++ b/src/functions/general.ts
@@ -156,6 +156,7 @@ import {
   MoreauHeritageName,
 } from '../data/systems/tormenta20/ameacas-de-arton/races/moreau-heritages';
 import { applyFradeAutoridadeEclesiastica } from './powers/frade-special';
+import { updateBrigaRolls } from './powers/lutador-special';
 import { SURAGEL_ALTERNATIVE_ABILITIES } from '../data/systems/tormenta20/deuses-de-arton/races/suragelAbilities';
 import { addOtherBonusToSkill } from './skills/general';
 import { applyGolemDespertoCustomization } from '../data/systems/tormenta20/ameacas-de-arton/races/golem-desperto';
@@ -2969,7 +2970,7 @@ export const applyPower = (
 
         const chosenOptions = chosenNames
           .map((n) => options.find((o) => o.name === n))
-          .filter((o): o is (typeof options)[number] => Boolean(o));
+          .filter((o): o is typeof options[number] => Boolean(o));
 
         // Atualiza o texto da habilidade de classe (quando houver) com as escolhas.
         const abilityIndex = sheet.classe.abilities.findIndex(
@@ -3504,6 +3505,9 @@ function applyClassAbilities(
     (ability) => ability.nivel <= sheet.nivel
   );
 
+  // Briga (Lutador/Atleta): dano desarmado escala com o nível de classe
+  updateBrigaRolls(sheetClone);
+
   // Apply text modifications from chooseFromOptions history
   applyOptionChosenTexts(sheetClone);
 
@@ -3892,6 +3896,16 @@ function levelUp(
 
     // Apply text modifications from chooseFromOptions history
     applyOptionChosenTexts(updatedSheet);
+  }
+
+  // Briga (Lutador/Atleta): dano desarmado escala com o nível de classe
+  const newBrigaDice = updateBrigaRolls(updatedSheet);
+  if (newBrigaDice) {
+    updatedSheet.steps.push({
+      type: 'Poderes',
+      label: 'Briga',
+      value: [{ name: 'Dano desarmado aumenta', value: newBrigaDice }],
+    });
   }
 
   return updatedSheet;

--- a/src/functions/powers/lutador-special.ts
+++ b/src/functions/powers/lutador-special.ts
@@ -1,0 +1,46 @@
+import CharacterSheet from '../../interfaces/CharacterSheet';
+import { getClassLevel } from '../multiclass';
+
+/**
+ * Tabela oficial de dano desarmado da Briga (Lutador/Atleta), por nível de
+ * classe: 1º-4º 1d6, 5º-8º 1d8, 9º-12º 1d10, 13º-16º 1d12, 17º-19º 2d8,
+ * 20º 2d10 (Dono da Rua / Corpo Ideal).
+ */
+export function getBrigaDice(classLevel: number): string {
+  if (classLevel >= 20) return '2d10';
+  if (classLevel >= 17) return '2d8';
+  if (classLevel >= 13) return '1d12';
+  if (classLevel >= 9) return '1d10';
+  if (classLevel >= 5) return '1d8';
+  return '1d6';
+}
+
+/**
+ * Ajusta o roll de dano da habilidade Briga em `sheet.classe.abilities` para
+ * o dado correspondente ao nível na classe que concede a habilidade
+ * (multiclasse usa o nível de classe, não o nível do personagem). Substitui
+ * os objetos da habilidade em vez de mutá-los, preservando
+ * `classe.originalAbilities`.
+ *
+ * Retorna o novo dado quando houve mudança, ou null caso contrário.
+ */
+export function updateBrigaRolls(sheet: CharacterSheet): string | null {
+  let changedDice: string | null = null;
+
+  sheet.classe.abilities = sheet.classe.abilities.map((ability) => {
+    if (ability.name !== 'Briga' || !ability.rolls?.length) return ability;
+
+    const className = ability.sourceClassName ?? sheet.classe.name;
+    const dice = getBrigaDice(getClassLevel(sheet, className));
+
+    if (ability.rolls.every((roll) => roll.dice === dice)) return ability;
+
+    changedDice = dice;
+    return {
+      ...ability,
+      rolls: ability.rolls.map((roll) => ({ ...roll, dice })),
+    };
+  });
+
+  return changedDice;
+}

--- a/src/functions/recalculateSheet.ts
+++ b/src/functions/recalculateSheet.ts
@@ -37,6 +37,7 @@ import {
   findClassDescription,
 } from './multiclass';
 import { stepUpDamage, addFlatDamageBonus } from './weaponDamageStep';
+import { updateBrigaRolls } from './powers/lutador-special';
 import { expandAttributeBonus } from './attributeExpansion';
 import { isWeaponMelee } from './weaponSkill';
 import { isBonusActive } from './bonusConditions';
@@ -926,6 +927,9 @@ function applyClassAbilities(
   }
 
   sheetClone.classe.abilities = allAbilities;
+
+  // Briga (Lutador/Atleta): dano desarmado escala com o nível de classe
+  updateBrigaRolls(sheetClone);
 
   // Apply text modifications from chooseFromOptions history
   applyOptionChosenTexts(sheetClone);


### PR DESCRIPTION
## Resumo

A habilidade **Briga** (Lutador e variante Atleta) tinha um roll fixo de `1d6` em qualquer nível. Agora o dado de dano desarmado segue a tabela oficial do Tormenta 20, por **nível de classe**:

| Nível de lutador | Dano desarmado |
| --- | --- |
| 1º–4º | 1d6 |
| 5º–8º | 1d8 |
| 9º–12º | 1d10 |
| 13º–16º | 1d12 |
| 17º–19º | 2d8 |
| 20º (Dono da Rua) | 2d10 |

## Implementação

- Novo helper `src/functions/powers/lutador-special.ts` (padrão de `frade-special.ts`): `getBrigaDice(nivel)` + `updateBrigaRolls(sheet)`, que substitui o `dice` do roll da Briga em `sheet.classe.abilities` sem mutar `originalAbilities`.
- Chamado nos três pontos onde as habilidades de classe são materializadas: geração aleatória e level-up aleatório (`general.ts`, com substep "Briga: dano desarmado aumenta" ao cruzar limiar) e recálculo (`recalculateSheet.ts` — cobre edições, fichas históricas e level-up manual).
- Multiclasse usa `getClassLevel` com a classe de origem da habilidade (`sourceClassName`), então um Lutador 4/Guerreiro 2 mantém 1d6.

## Testes

`src/__tests__/functions/lutadorBriga.test.ts` (14 testes): tabela completa de limiares, preservação de `originalAbilities`, multiclasse, integração com `recalculateSheet` (níveis 1/9/20) e com `generateRandomSheet` (nível 10).

Falhas pré-existentes não relacionadas: `NumberField.test.tsx` (dependência `@base-ui/react` não resolvida no ambiente) e um teste flaky de sorteio de equipamento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)