### PR TITLE
feat(ficha): busca de perícias no seletor de chips do wizard

### DIFF
--- a/src/components/CharacterCreationWizard/steps/ClassSkillStep.tsx
+++ b/src/components/CharacterCreationWizard/steps/ClassSkillStep.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box, Typography, Alert, Chip, Divider } from '@mui/material';
 import Skill from '@/interfaces/Skills';
 import { BasicExpertise } from '@/interfaces/Class';
+import SkillChipSelector from '@/components/common/SkillChipSelector';
 
 interface ClassSkillStepProps {
   // Base skills data
@@ -168,44 +169,12 @@ const ClassSkillStep: React.FC<ClassSkillStepProps> = ({
             Selecionadas: {selectedSkills.length} / {requiredCount}
           </Typography>
 
-          <Box
-            sx={{
-              display: 'flex',
-              gap: 1,
-              flexWrap: 'wrap',
-            }}
-          >
-            {availableSkills.map((skill) => {
-              const isSelected = selectedSkills.includes(skill);
-              const isDisabled =
-                !isSelected && selectedSkills.length >= requiredCount;
-
-              let hoverBgColor: string | undefined;
-              if (isSelected) {
-                hoverBgColor = 'primary.dark';
-              } else if (!isDisabled) {
-                hoverBgColor = 'rgba(209, 50, 53, 0.08)';
-              }
-
-              return (
-                <Chip
-                  key={skill}
-                  label={skill}
-                  size='small'
-                  variant={isSelected ? 'filled' : 'outlined'}
-                  color={isSelected ? 'primary' : 'default'}
-                  onClick={() => handleToggleSkill(skill)}
-                  disabled={isDisabled}
-                  sx={{
-                    cursor: isDisabled ? 'not-allowed' : 'pointer',
-                    '&:hover': {
-                      backgroundColor: hoverBgColor,
-                    },
-                  }}
-                />
-              );
-            })}
-          </Box>
+          <SkillChipSelector
+            availableSkills={availableSkills}
+            selectedSkills={selectedSkills}
+            onToggle={handleToggleSkill}
+            maxReached={selectedSkills.length >= requiredCount}
+          />
 
           {selectedSkills.length > requiredCount && (
             <Alert severity='error'>

--- a/src/components/CharacterCreationWizard/steps/IntelligenceSkillStep.tsx
+++ b/src/components/CharacterCreationWizard/steps/IntelligenceSkillStep.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Box, Typography, Alert, Chip } from '@mui/material';
+import { Box, Typography, Alert } from '@mui/material';
 import Skill from '@/interfaces/Skills';
+import SkillChipSelector from '@/components/common/SkillChipSelector';
 
 interface IntelligenceSkillStepProps {
   availableSkills: Skill[];
@@ -69,45 +70,12 @@ const IntelligenceSkillStep: React.FC<IntelligenceSkillStepProps> = ({
       >
         Selecionadas: {selectedSkills.length} / {requiredCount}
       </Typography>
-      <Box
-        sx={{
-          display: 'flex',
-          gap: 1,
-          flexWrap: 'wrap',
-        }}
-      >
-        {availableSkills.map((skill) => {
-          const isSelected = selectedSkills.includes(skill);
-          const isDisabled =
-            !isSelected && selectedSkills.length >= requiredCount;
-
-          // Determine hover background color without nested ternary
-          let hoverBgColor: string | undefined;
-          if (isSelected) {
-            hoverBgColor = 'primary.dark';
-          } else if (!isDisabled) {
-            hoverBgColor = 'rgba(209, 50, 53, 0.08)';
-          }
-
-          return (
-            <Chip
-              key={skill}
-              label={skill}
-              size='small'
-              variant={isSelected ? 'filled' : 'outlined'}
-              color={isSelected ? 'primary' : 'default'}
-              onClick={() => handleToggleSkill(skill)}
-              disabled={isDisabled}
-              sx={{
-                cursor: isDisabled ? 'not-allowed' : 'pointer',
-                '&:hover': {
-                  backgroundColor: hoverBgColor,
-                },
-              }}
-            />
-          );
-        })}
-      </Box>
+      <SkillChipSelector
+        availableSkills={availableSkills}
+        selectedSkills={selectedSkills}
+        onToggle={handleToggleSkill}
+        maxReached={selectedSkills.length >= requiredCount}
+      />
       {selectedSkills.length > requiredCount && (
         <Alert severity='error'>
           Você selecionou {selectedSkills.length} perícias, mas só pode escolher{' '}

--- a/src/components/common/SkillChipSelector.tsx
+++ b/src/components/common/SkillChipSelector.tsx
@@ -1,0 +1,126 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Box,
+  Chip,
+  IconButton,
+  InputAdornment,
+  TextField,
+  Typography,
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import ClearIcon from '@mui/icons-material/Clear';
+import Skill from '@/interfaces/Skills';
+
+// Busca só aparece quando a lista é grande o suficiente para valer a pena
+const SEARCH_THRESHOLD = 10;
+
+const normalize = (text: string): string =>
+  text
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+
+interface SkillChipSelectorProps {
+  availableSkills: Skill[];
+  selectedSkills: Skill[];
+  onToggle: (skill: Skill) => void;
+  maxReached: boolean;
+}
+
+const SkillChipSelector: React.FC<SkillChipSelectorProps> = ({
+  availableSkills,
+  selectedSkills,
+  onToggle,
+  maxReached,
+}) => {
+  const [search, setSearch] = useState('');
+  const showSearch = availableSkills.length > SEARCH_THRESHOLD;
+
+  // Perícias selecionadas permanecem visíveis mesmo fora do filtro, para a
+  // seleção atual nunca "sumir" durante a busca
+  const visibleSkills = useMemo(() => {
+    if (!showSearch || !search.trim()) return availableSkills;
+    const query = normalize(search.trim());
+    return availableSkills.filter(
+      (skill) =>
+        selectedSkills.includes(skill) || normalize(skill).includes(query)
+    );
+  }, [availableSkills, selectedSkills, search, showSearch]);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+      {showSearch && (
+        <TextField
+          size='small'
+          placeholder='Buscar perícia...'
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          sx={{ maxWidth: 320 }}
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position='start'>
+                  <SearchIcon fontSize='small' />
+                </InputAdornment>
+              ),
+              endAdornment: search ? (
+                <InputAdornment position='end'>
+                  <IconButton
+                    size='small'
+                    aria-label='Limpar busca'
+                    onClick={() => setSearch('')}
+                  >
+                    <ClearIcon fontSize='small' />
+                  </IconButton>
+                </InputAdornment>
+              ) : undefined,
+            },
+          }}
+        />
+      )}
+      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+        {visibleSkills.map((skill) => {
+          const isSelected = selectedSkills.includes(skill);
+          const isDisabled = !isSelected && maxReached;
+
+          let hoverBgColor: string | undefined;
+          if (isSelected) {
+            hoverBgColor = 'primary.dark';
+          } else if (!isDisabled) {
+            hoverBgColor = 'rgba(209, 50, 53, 0.08)';
+          }
+
+          return (
+            <Chip
+              key={skill}
+              label={skill}
+              size='small'
+              variant={isSelected ? 'filled' : 'outlined'}
+              color={isSelected ? 'primary' : 'default'}
+              onClick={isDisabled ? undefined : () => onToggle(skill)}
+              disabled={isDisabled}
+              sx={{
+                cursor: isDisabled ? 'not-allowed' : 'pointer',
+                '&:hover': {
+                  backgroundColor: hoverBgColor,
+                },
+              }}
+            />
+          );
+        })}
+        {visibleSkills.length === 0 && (
+          <Typography
+            variant='body2'
+            sx={{
+              color: 'text.secondary',
+            }}
+          >
+            Nenhuma perícia encontrada.
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default SkillChipSelector;

--- a/src/components/common/__tests__/SkillChipSelector.test.tsx
+++ b/src/components/common/__tests__/SkillChipSelector.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import Skill from '@/interfaces/Skills';
+import SkillChipSelector from '../SkillChipSelector';
+
+const manySkills = [
+  Skill.ACROBACIA,
+  Skill.ADESTRAMENTO,
+  Skill.ATLETISMO,
+  Skill.ATUACAO,
+  Skill.CAVALGAR,
+  Skill.CONHECIMENTO,
+  Skill.CURA,
+  Skill.DIPLOMACIA,
+  Skill.ENGANACAO,
+  Skill.FORTITUDE,
+  Skill.FURTIVIDADE,
+];
+
+describe('SkillChipSelector', () => {
+  it('renderiza um chip para cada perícia disponível', () => {
+    render(
+      <SkillChipSelector
+        availableSkills={manySkills}
+        selectedSkills={[]}
+        onToggle={() => undefined}
+        maxReached={false}
+      />
+    );
+    manySkills.forEach((skill) => {
+      expect(screen.getByText(skill)).toBeInTheDocument();
+    });
+  });
+
+  it('filtra perícias ignorando acentos e caixa', () => {
+    render(
+      <SkillChipSelector
+        availableSkills={manySkills}
+        selectedSkills={[]}
+        onToggle={() => undefined}
+        maxReached={false}
+      />
+    );
+    const input = screen.getByPlaceholderText('Buscar perícia...');
+    fireEvent.change(input, { target: { value: 'atuacao' } });
+
+    expect(screen.getByText(Skill.ATUACAO)).toBeInTheDocument();
+    expect(screen.queryByText(Skill.ACROBACIA)).not.toBeInTheDocument();
+  });
+
+  it('mantém perícias selecionadas visíveis mesmo fora do filtro', () => {
+    render(
+      <SkillChipSelector
+        availableSkills={manySkills}
+        selectedSkills={[Skill.CURA]}
+        onToggle={() => undefined}
+        maxReached={false}
+      />
+    );
+    const input = screen.getByPlaceholderText('Buscar perícia...');
+    fireEvent.change(input, { target: { value: 'diplo' } });
+
+    expect(screen.getByText(Skill.DIPLOMACIA)).toBeInTheDocument();
+    expect(screen.getByText(Skill.CURA)).toBeInTheDocument();
+    expect(screen.queryByText(Skill.ACROBACIA)).not.toBeInTheDocument();
+  });
+
+  it('chama onToggle ao clicar em um chip', () => {
+    const toggled: Skill[] = [];
+    render(
+      <SkillChipSelector
+        availableSkills={manySkills}
+        selectedSkills={[]}
+        onToggle={(skill) => toggled.push(skill)}
+        maxReached={false}
+      />
+    );
+    fireEvent.click(screen.getByText(Skill.ACROBACIA));
+    expect(toggled).toEqual([Skill.ACROBACIA]);
+  });
+
+  it('desabilita chips não selecionados quando o limite foi atingido', () => {
+    const toggled: Skill[] = [];
+    render(
+      <SkillChipSelector
+        availableSkills={manySkills}
+        selectedSkills={[Skill.CURA]}
+        onToggle={(skill) => toggled.push(skill)}
+        maxReached
+      />
+    );
+    fireEvent.click(screen.getByText(Skill.ACROBACIA));
+    expect(toggled).toEqual([]);
+
+    // Chips selecionados continuam clicáveis para desmarcar
+    fireEvent.click(screen.getByText(Skill.CURA));
+    expect(toggled).toEqual([Skill.CURA]);
+  });
+
+  it('não exibe busca para listas pequenas', () => {
+    render(
+      <SkillChipSelector
+        availableSkills={[Skill.CURA, Skill.LUTA]}
+        selectedSkills={[]}
+        onToggle={() => undefined}
+        maxReached={false}
+      />
+    );
+    expect(
+      screen.queryByPlaceholderText('Buscar perícia...')
+    ).not.toBeInTheDocument();
+  });
+
+  it('exibe mensagem quando nenhuma perícia corresponde à busca', () => {
+    render(
+      <SkillChipSelector
+        availableSkills={manySkills}
+        selectedSkills={[]}
+        onToggle={() => undefined}
+        maxReached={false}
+      />
+    );
+    const input = screen.getByPlaceholderText('Buscar perícia...');
+    fireEvent.change(input, { target: { value: 'xyz' } });
+    expect(screen.getByText('Nenhuma perícia encontrada.')).toBeInTheDocument();
+  });
+
+  it('limpa a busca pelo botão de limpar', () => {
+    render(
+      <SkillChipSelector
+        availableSkills={manySkills}
+        selectedSkills={[]}
+        onToggle={() => undefined}
+        maxReached={false}
+      />
+    );
+    const input = screen.getByPlaceholderText(
+      'Buscar perícia...'
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'cura' } });
+    expect(screen.queryByText(Skill.ACROBACIA)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Limpar busca'));
+    expect(input.value).toBe('');
+    expect(screen.getByText(Skill.ACROBACIA)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## O que

Adiciona um campo de **busca/filtro** acima dos chips de perícias nos passos de criação de ficha, para encontrar perícias mais rápido em listas longas.

## Por quê

No wizard de build da ficha, a seleção de perícias é feita clicando numa série de chips. Em listas grandes (perícias por Inteligência mostram todas as ~35 do jogo, incluindo variações de Ofício) isso fica trabalhoso. Um campo de busca resolve.

## Como

- Novo componente reutilizável **`SkillChipSelector`** (`src/components/common/`)
  - Campo de busca com filtro **insensível a acento e caixa** (`atuacao` acha `Atuação`)
  - A busca só aparece quando há **mais de 10** perícias na lista (listas curtas não precisam)
  - Perícias **já selecionadas permanecem visíveis** mesmo fora do filtro, para a seleção não "sumir"
  - Botão de limpar, mensagem de "nenhuma perícia encontrada", respeito ao limite (`maxReached` desabilita chips não selecionados)
- Integrado em **`ClassSkillStep`** e **`IntelligenceSkillStep`**, removendo a duplicação do grid de chips que existia nos dois

## Verificação

- ✅ Suíte de testes: 658 passed (65 arquivos), incluindo 8 novos testes do `SkillChipSelector`
- ✅ `tsc --noEmit` limpo (com submódulo premium inicializado)
- ✅ ESLint + Prettier nos arquivos alterados
- ✅ Testado end-to-end no app (Playwright): fluxo Humano/Ladino até os passos de perícias — filtro por nome, busca sem acento, persistência da seleção sob filtro, botão limpar, estado vazio, e limite 2/2 desabilitando os demais chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)