### PR TITLE
fix(multiclasse): busca poder concedido no catálogo da classe do nível

### DIFF
--- a/src/functions/__tests__/applyManualLevelUp.spec.ts
+++ b/src/functions/__tests__/applyManualLevelUp.spec.ts
@@ -182,3 +182,50 @@ describe('applyManualLevelUp - Treino Especializado (Treinador 5)', () => {
     expect(result.companions![0].treinoIntensivo).toBe(true);
   });
 });
+
+describe('applyManualLevelUp - grantSpecificClassPower em multiclasse', () => {
+  // Cenário do bug: Ladino 6 / Alquimista 1 subindo para o 2º nível de
+  // Alquimista, que concede o poder "Alquimista Iniciado" via
+  // grantSpecificClassPower. O poder pertence ao catálogo do Inventor (do qual
+  // Alquimista é variante), e não ao da Ladino — a busca precisa usar a classe
+  // do nível, não `sheet.classe`.
+  const buildLadino6Alquimista1 = (): CharacterSheet => {
+    const ladino = findClassDescription('Ladino')!;
+    const sheet = createMockCharacterSheet();
+    sheet.classe = cloneDeep(ladino);
+    sheet.nivel = 7;
+    sheet.classLevels = [
+      ...[1, 2, 3, 4, 5, 6].map((level) => ({ level, className: 'Ladino' })),
+      { level: 7, className: 'Alquimista' },
+    ];
+    return sheet;
+  };
+
+  test('concede o poder da classe secundária sem lançar erro', () => {
+    const sheet = buildLadino6Alquimista1();
+
+    const result = applyManualLevelUp(sheet, {
+      level: 8,
+      selectedClassName: 'Alquimista',
+      powerChoice: 'class',
+    });
+
+    expect(result.nivel).toBe(8);
+    const map = getClassLevelsMap(result);
+    expect(map.get('Ladino')).toBe(6);
+    expect(map.get('Alquimista')).toBe(2);
+    expect(result.classPowers?.map((p) => p.name)).toContain(
+      'Alquimista Iniciado'
+    );
+  });
+
+  test('a classe primária continua sendo Ladino', () => {
+    const sheet = buildLadino6Alquimista1();
+    const result = applyManualLevelUp(sheet, {
+      level: 8,
+      selectedClassName: 'Alquimista',
+      powerChoice: 'class',
+    });
+    expect(result.classe.name).toBe('Ladino');
+  });
+});

--- a/src/functions/general.ts
+++ b/src/functions/general.ts
@@ -2890,19 +2890,28 @@ export const applyPower = (
       } else if (sheetAction.action.type === 'grantSpecificClassPower') {
         const { powerName: targetPowerName } = sheetAction.action;
 
-        let targetPower = sheet.classe.powers.find(
-          (p) => p.name === targetPowerName
-        );
+        // Multiclasse: o poder concedido pertence à classe que concedeu a
+        // habilidade (`sourceClassName`), que não é necessariamente a classe
+        // primária da ficha — ex.: Alquimista 2 concede "Alquimista Iniciado"
+        // numa ficha cuja `sheet.classe` é Ladino.
+        const { sourceClassName } = powerOrAbility;
+        const ownerClassName = sourceClassName ?? sheet.classe.name;
+        const isForeignClass = ownerClassName !== sheet.classe.name;
+
+        let targetPower = isForeignClass
+          ? undefined
+          : sheet.classe.powers.find((p) => p.name === targetPowerName);
 
         // Fallback: o catálogo `classe.powers` pode estar vazio em fichas
         // carregadas (stripSheetForStorage zera os poderes e rehydrateSheet só
         // os restaura se a variante for resolvida). Buscar no catálogo completo
         // da classe antes de falhar.
         if (!targetPower) {
-          const fullClass = findClassDescription(
-            sheet.classe.name,
-            sheet.classe.subname
-          );
+          const ownerSubname = isForeignClass
+            ? sheet.classLevels?.find((cl) => cl.className === ownerClassName)
+                ?.classSubname
+            : sheet.classe.subname;
+          const fullClass = findClassDescription(ownerClassName, ownerSubname);
           targetPower = fullClass?.powers.find(
             (p) => p.name === targetPowerName
           );
@@ -2910,7 +2919,7 @@ export const applyPower = (
 
         if (!targetPower) {
           throw new Error(
-            `Poder de classe "${targetPowerName}" não encontrado na classe ${sheet.classe.name}`
+            `Poder de classe "${targetPowerName}" não encontrado na classe ${ownerClassName}`
           );
         }
 
@@ -4515,7 +4524,10 @@ export function applyManualLevelUp(
     newlyAvailableAbilities.forEach((ability) => {
       const [newSheet, newSubSteps] = applyPower(
         updatedSheet,
-        ability,
+        // Multiclasse: a habilidade pertence à classe escolhida para ESTE
+        // nível, não à classe primária da ficha. Sem isso, ações como
+        // grantSpecificClassPower procuram o poder no catálogo errado.
+        { ...ability, sourceClassName: selectedClassName },
         selections.abilityEffectSelections?.[ability.name]
       );
       // Mesmo guard do branch de poderes: nunca substituir a ficha por um


### PR DESCRIPTION
## Descrição

Subir de nível uma classe secundária trava quando a habilidade daquele nível concede um poder de classe.

Reproduzi com um Ladino 6 / Alquimista 1 subindo para Alquimista 2. A habilidade desse nível concede "Alquimista Iniciado", que vive no catálogo do Inventor, já que Alquimista é variante dele. O assistente não deixa concluir o level-up e mostra:

> Poder de classe "Alquimista Iniciado" não encontrado na classe Ladino

A ação `grantSpecificClassPower` procurava o poder em `sheet.classe.powers`, que é sempre a classe primária da ficha, e não na classe do nível que está sendo subido.

## Mudanças

- `applyManualLevelUp` passou a informar a classe de origem ao aplicar as habilidades do novo nível. Antes ela deixava `sourceClassName` indefinido, enquanto `applyClassAbilities` já preenchia esse campo.
- `grantSpecificClassPower` passou a usar `sourceClassName` para resolver a classe, buscando o subname correspondente em `classLevels`. A mensagem de erro também passou a citar a classe certa.

Ficha de classe única segue exatamente pelo mesmo caminho de antes, porque nela `sourceClassName` coincide com `sheet.classe.name`.

## Tipo de Mudança

- [x] Bug fix
- [ ] Nova funcionalidade
- [ ] Melhoria de código
- [ ] Documentação

## Testes

- [x] Testes passando
- [x] Novos testes adicionados
- [x] Testado manualmente

Dois testes de regressão em `applyManualLevelUp.spec.ts` cobrem o caso. Os dois falham com a mensagem original se a correção for revertida.

Rodei `npx vitest run src/functions/__tests__/applyManualLevelUp.spec.ts`, além de prettier e eslint nos arquivos tocados. O `tsc --noEmit` eu não consigo rodar aqui: contribuo sem acesso ao submódulo privado, como o CONTRIBUTING.md descreve na seção "Rodando sem o módulo premium".

Só um aviso sobre o CI: o job do CircleCI inicializa o submódulo `src/premium` com `$GITHUB_PAT` antes de rodar os testes, e PRs vindos de fork não recebem essa variável. Se o build ficar vermelho por causa disso, não é a mudança deste PR.
