### PR TITLE
fix(mochila): itens transformados deixam de se fundir e de perder configuração

### DIFF
--- a/src/components/SheetResult/BackpackModal/__tests__/stacking.spec.ts
+++ b/src/components/SheetResult/BackpackModal/__tests__/stacking.spec.ts
@@ -1,0 +1,195 @@
+import Equipment, { BagEquipments } from '../../../../interfaces/Equipment';
+import { isStackable } from '../stacking';
+import { addItemToEquipments } from '../useBackpackState';
+
+function emptyBag(): BagEquipments {
+  return {
+    Arma: [],
+    Armadura: [],
+    Escudo: [],
+    'Item Geral': [],
+    Alquimía: [],
+    Esotérico: [],
+    Vestuário: [],
+    Hospedagem: [],
+    Alimentação: [],
+    Animal: [],
+    Veículo: [],
+    Serviço: [],
+  };
+}
+
+const adaga = (over: Partial<Equipment> = {}): Equipment => ({
+  id: 'adaga-base',
+  nome: 'Adaga',
+  group: 'Arma',
+  dano: '1d4',
+  critico: '19',
+  spaces: 1,
+  preco: 2,
+  ...over,
+});
+
+/** Adaga da Tormenta: adaga de catálogo com apelido + os dois encantamentos. */
+const adagaDaTormenta = (): Equipment =>
+  adaga({
+    id: 'adaga-tormenta',
+    customDisplayName: 'Adaga da Tormenta',
+    dano: '1d4+2',
+    atkBonus: 2,
+    hasManualEdits: undefined,
+    enchantments: [{ enchantment: 'Formidável' }, { enchantment: 'Tumular' }],
+  });
+
+describe('isStackable', () => {
+  test('um item de catálogo intocado empilha', () => {
+    expect(isStackable(adaga())).toBe(true);
+  });
+
+  test('encantamentos tornam o item único', () => {
+    expect(
+      isStackable(adaga({ enchantments: [{ enchantment: 'Tumular' }] }))
+    ).toBe(false);
+  });
+
+  test('modificações tornam o item único', () => {
+    expect(isStackable(adaga({ modifications: [{ mod: 'Certeira' }] }))).toBe(
+      false
+    );
+  });
+
+  test('apelido torna o item único', () => {
+    expect(isStackable(adaga({ customDisplayName: 'Adaga da Tormenta' }))).toBe(
+      false
+    );
+  });
+
+  test('estatísticas editadas à mão tornam o item único', () => {
+    expect(isStackable(adaga({ hasManualEdits: true }))).toBe(false);
+  });
+
+  test('arrays vazios não impedem o empilhamento', () => {
+    expect(isStackable(adaga({ enchantments: [], modifications: [] }))).toBe(
+      true
+    );
+  });
+
+  test('apelido só com espaços não conta como identidade própria', () => {
+    expect(isStackable(adaga({ customDisplayName: '   ' }))).toBe(true);
+  });
+});
+
+describe('addItemToEquipments - empilhamento', () => {
+  test('duas adagas comuns continuam empilhando', () => {
+    const bag = emptyBag();
+    bag.Arma = [adaga()];
+
+    const { equipments } = addItemToEquipments(
+      bag,
+      ['adaga-base'],
+      adaga({ id: 'adaga-2' }),
+      1
+    );
+
+    expect(equipments.Arma).toHaveLength(1);
+    expect(equipments.Arma[0].quantity).toBe(2);
+  });
+
+  test('adaga comum NÃO empilha na Adaga da Tormenta encantada', () => {
+    // O bug: o merge mantinha `existing` e só somava quantity, devolvendo duas
+    // adagas encantadas e sumindo com a adaga comum.
+    const bag = emptyBag();
+    bag.Arma = [adagaDaTormenta()];
+
+    const { equipments } = addItemToEquipments(
+      bag,
+      ['adaga-tormenta'],
+      adaga({ id: 'adaga-comum' }),
+      1
+    );
+
+    expect(equipments.Arma).toHaveLength(2);
+    const encantada = equipments.Arma.find((i) => i.id === 'adaga-tormenta')!;
+    const comum = equipments.Arma.find((i) => i.id === 'adaga-comum')!;
+    expect(encantada.quantity ?? 1).toBe(1);
+    expect(encantada.enchantments).toHaveLength(2);
+    expect(comum.enchantments).toBeUndefined();
+    expect(comum.dano).toBe('1d4');
+  });
+
+  test('a Adaga da Tormenta não empilha numa adaga comum já na mochila', () => {
+    // Ordem inversa: aqui o bug perdia os encantamentos do item adicionado.
+    const bag = emptyBag();
+    bag.Arma = [adaga()];
+
+    const { equipments } = addItemToEquipments(
+      bag,
+      ['adaga-base'],
+      adagaDaTormenta(),
+      1
+    );
+
+    expect(equipments.Arma).toHaveLength(2);
+    const encantada = equipments.Arma.find((i) => i.id === 'adaga-tormenta')!;
+    expect(encantada.enchantments).toHaveLength(2);
+    expect(encantada.customDisplayName).toBe('Adaga da Tormenta');
+  });
+
+  test('itens que não empilham recebem ids distintos', () => {
+    // Sem isso, as duas entradas agem como uma só: empunhadura, edição e
+    // remoção resolvem por id.
+    const bag = emptyBag();
+    bag.Arma = [adagaDaTormenta()];
+
+    const { equipments } = addItemToEquipments(
+      bag,
+      ['adaga-tormenta'],
+      adaga({ id: 'adaga-tormenta' }), // mesmo id, como vem do catálogo contaminado
+      1
+    );
+
+    expect(equipments.Arma).toHaveLength(2);
+    const ids = equipments.Arma.map((i) => i.id);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  test('não guarda a referência do objeto recebido (catálogo é compartilhado)', () => {
+    const bag = emptyBag();
+    const doCatalogo = adaga({ id: undefined });
+
+    const { equipments } = addItemToEquipments(bag, [], doCatalogo, 1);
+
+    expect(equipments.Arma[0]).not.toBe(doCatalogo);
+    expect(doCatalogo.id).toBeUndefined(); // não contaminou o catálogo
+  });
+
+  test('o displayOrder recebe o id realmente inserido', () => {
+    const bag = emptyBag();
+    bag.Arma = [adagaDaTormenta()];
+
+    const { displayOrder, equipments, addedId } = addItemToEquipments(
+      bag,
+      ['adaga-tormenta'],
+      adaga({ id: 'adaga-tormenta' }),
+      1
+    );
+
+    const inserido = equipments.Arma.find((i) => i.id !== 'adaga-tormenta')!;
+    expect(addedId).toBe(inserido.id);
+    expect(displayOrder).toContain(inserido.id);
+  });
+
+  test('duas Adagas da Tormenta não se fundem entre si', () => {
+    const bag = emptyBag();
+    bag.Arma = [adagaDaTormenta()];
+
+    const { equipments } = addItemToEquipments(
+      bag,
+      ['adaga-tormenta'],
+      { ...adagaDaTormenta(), id: 'adaga-tormenta-2' },
+      1
+    );
+
+    expect(equipments.Arma).toHaveLength(2);
+  });
+});

--- a/src/components/SheetResult/BackpackModal/stacking.ts
+++ b/src/components/SheetResult/BackpackModal/stacking.ts
@@ -1,0 +1,28 @@
+import Equipment from '../../../interfaces/Equipment';
+
+/**
+ * Um item só pode empilhar com outro de mesmo nome quando os dois são
+ * realmente intercambiáveis — caso contrário o merge (que mantém `existing` e
+ * apenas soma `quantity`) descarta silenciosamente o item adicionado.
+ *
+ * O bug que isso evita: uma adaga com os encantamentos Formidável + Tumular e
+ * apelido "Adaga da Tormenta" continua com `nome: 'Adaga'` e sem `isCustom`
+ * (editar um item de catálogo só marca `hasManualEdits`). Adicionar uma adaga
+ * comum empilhava nela e devolvia DUAS adagas encantadas; na ordem inversa, os
+ * encantamentos eram perdidos.
+ *
+ * Qualquer uma destas marcas torna o item único na mochila:
+ * - `enchantments` / `modifications`: alteram dano, ataque, crítico e bônus
+ * - `customDisplayName`: o jogador deu identidade própria ao item
+ * - `hasManualEdits`: estatísticas editadas à mão, que o merge sobrescreveria
+ *
+ * `isCustom` é checado à parte por quem chama, junto da comparação de nome.
+ */
+export function isStackable(item: Equipment): boolean {
+  if (item.enchantments && item.enchantments.length > 0) return false;
+  if (item.modifications && item.modifications.length > 0) return false;
+  if (item.customDisplayName && item.customDisplayName.trim() !== '')
+    return false;
+  if (item.hasManualEdits) return false;
+  return true;
+}

--- a/src/components/SheetResult/BackpackModal/useBackpackState.ts
+++ b/src/components/SheetResult/BackpackModal/useBackpackState.ts
@@ -19,6 +19,7 @@ import {
   WieldingSlot,
   WORN_ARMOR_NONE,
 } from './wielding';
+import { isStackable } from './stacking';
 
 export interface BackpackMoney {
   dinheiro: number;
@@ -167,34 +168,72 @@ type Action =
   | { type: 'SET_GROUP_BY_CATEGORY'; value: boolean }
   | { type: 'RESET'; snapshot: StagedState };
 
-function ensureId(item: Equipment): Equipment {
-  if (item.id) return item;
+/** Todos os ids já ocupados na mochila, em todas as categorias. */
+function collectIds(equipments: BagEquipments): Set<string> {
+  const ids = new Set<string>();
+  (Object.keys(equipments) as equipGroup[]).forEach((cat) => {
+    const list = equipments[cat];
+    if (!Array.isArray(list)) return;
+    list.forEach((it) => {
+      if (it.id) ids.add(it.id);
+    });
+  });
+  return ids;
+}
+
+/**
+ * Garante que o item entre na mochila com identidade PRÓPRIA.
+ *
+ * Duas armadilhas justificam o clone e o id novo:
+ *
+ * 1. `AddItemDialog` entrega o objeto do catálogo por referência, e o catálogo
+ *    é compartilhado e cacheado (ver aviso em `registry.getEquipmentBySupplements`).
+ *    Guardar essa referência na mochila faz a edição de um item vazar para o
+ *    catálogo — e para toda ficha que adicione o mesmo item depois.
+ * 2. Se o objeto do catálogo já carrega um `id` (contaminado por um `ensureIds`
+ *    anterior), reusá-lo cria DUAS entradas com o mesmo id. Empunhadura, edição
+ *    e remoção resolvem por id, então as duas entradas passam a agir como uma:
+ *    empunhar uma empunha a outra, editar não salva, e a chave React duplicada
+ *    faz uma delas desaparecer da lista enquanto os espaços seguem somando.
+ */
+function ensureUniqueId(item: Equipment, taken: Set<string>): Equipment {
+  if (item.id && !taken.has(item.id)) return { ...item };
   return { ...item, id: uuid() };
 }
 
 /**
  * Adds an item to the proper category bucket. Stacks by name when adding a
- * non-custom catalog item that already exists; otherwise appends. Armor and
+ * non-custom catalog item that already exists AND both sides are
+ * interchangeable (ver `isStackable`); otherwise appends. Armor and
  * shields are no longer single-item — multiple may coexist; only the worn
  * armor and the wielded shield apply their bonuses to the sheet.
  *
  * Returns the id of the item that ended up in the bag (existing stack id when
  * merged, fresh id otherwise) so the caller can auto-wield/auto-wear etc.
+ *
+ * Exportada para teste — o merge é a única via de perda de dados da mochila.
  */
-function addItemToEquipments(
+export function addItemToEquipments(
   equipments: BagEquipments,
   displayOrder: string[],
   itemRaw: Equipment,
   quantity: number
 ): { equipments: BagEquipments; displayOrder: string[]; addedId?: string } {
-  const item = ensureId(itemRaw);
+  const item = ensureUniqueId(itemRaw, collectIds(equipments));
   const next: BagEquipments = { ...equipments };
   const nextOrder = [...displayOrder];
 
   const list = (next[item.group] ?? []) as Equipment[];
-  // Stack by name when a non-custom catalog item is added.
+  // Stack by name when a non-custom catalog item is added. Itens encantados,
+  // modificados, apelidados ou editados à mão nunca empilham — o merge
+  // preserva `existing` e descartaria as diferenças do outro lado.
   const existingIdx = list.findIndex(
-    (it) => it.nome === item.nome && !it.isCustom && !item.isCustom
+    (it) =>
+      it.nome === item.nome &&
+      !it.isCustom &&
+      !item.isCustom &&
+      isStackable(it) &&
+      isStackable(item)
   );
   if (existingIdx >= 0) {
     const existing = list[existingIdx];

--- a/src/functions/itemEnhancements/__tests__/applyEnhancements.spec.ts
+++ b/src/functions/itemEnhancements/__tests__/applyEnhancements.spec.ts
@@ -124,6 +124,112 @@ describe('applyItemEnhancements — encantamentos', () => {
     ]);
   });
 
+  // O atributo de dano por modo é escolha do usuário no editor da mochila.
+  // Como `baseSpecialActions` é um snapshot congelado na primeira passagem, o
+  // rebuild da lista apagava essa escolha a cada recálculo — o sintoma era a
+  // troca de Força para Destreza não persistir em armas encantadas.
+  describe('atributo de dano por modo (override do usuário)', () => {
+    const adaga: Equipment = {
+      nome: 'Adaga',
+      group: 'Arma',
+      dano: '1d4',
+      critico: '19',
+      atkBonus: 0,
+      spaces: 1,
+      arremesso: true,
+      specialActions: [
+        { id: 'corpo-a-corpo', label: 'Corpo a corpo', skill: 'Luta' },
+        {
+          id: 'arremessar',
+          label: 'Arremessar',
+          skill: 'Pontaria',
+          damageAttribute: 'Força',
+        },
+      ],
+    };
+
+    test('preserva a troca para Destreza num item encantado', () => {
+      // Primeira passagem: congela baseSpecialActions com 'Força'.
+      const encantada = applyItemEnhancements({
+        ...adaga,
+        enchantments: [
+          { enchantment: 'Formidável' },
+          { enchantment: 'Tumular' },
+        ],
+      });
+
+      // O editor grava o override do usuário em `specialActions`.
+      const editada: Equipment = {
+        ...encantada,
+        specialActions: encantada.specialActions!.map((a) => ({
+          ...a,
+          damageAttribute: 'Destreza' as const,
+        })),
+      };
+
+      const result = applyItemEnhancements(editada);
+      const porId = new Map(
+        (result.specialActions ?? []).map((a) => [a.id, a.damageAttribute])
+      );
+      expect(porId.get('corpo-a-corpo')).toBe('Destreza');
+      expect(porId.get('arremessar')).toBe('Destreza');
+    });
+
+    test('sobrevive a recálculos repetidos (idempotente)', () => {
+      const encantada = applyItemEnhancements({
+        ...adaga,
+        enchantments: [{ enchantment: 'Formidável' }],
+      });
+      const editada: Equipment = {
+        ...encantada,
+        specialActions: encantada.specialActions!.map((a) => ({
+          ...a,
+          damageAttribute: 'Destreza' as const,
+        })),
+      };
+
+      const uma = applyItemEnhancements(editada);
+      const duas = applyItemEnhancements(uma);
+      expect(
+        duas.specialActions?.every((a) => a.damageAttribute === 'Destreza')
+      ).toBe(true);
+    });
+
+    test('sem override, o valor do snapshot base continua valendo', () => {
+      const result = applyItemEnhancements({
+        ...adaga,
+        enchantments: [{ enchantment: 'Formidável' }],
+      });
+      const porId = new Map(
+        (result.specialActions ?? []).map((a) => [a.id, a.damageAttribute])
+      );
+      expect(porId.get('arremessar')).toBe('Força');
+      expect(porId.get('corpo-a-corpo')).toBeUndefined();
+    });
+
+    test('override também vale para ações derivadas de encantamento', () => {
+      // O modo de arremesso concedido pelo encantamento nasce com 'Nenhum'.
+      const encantada = applyItemEnhancements({
+        ...baseSword,
+        enchantments: [{ enchantment: 'Arremesso' }],
+      });
+      const editada: Equipment = {
+        ...encantada,
+        specialActions: encantada.specialActions!.map((a) =>
+          a.id === 'ench-arremesso-throw'
+            ? { ...a, damageAttribute: 'Destreza' as const }
+            : a
+        ),
+      };
+
+      const result = applyItemEnhancements(editada);
+      const lancar = result.specialActions?.find(
+        (a) => a.id === 'ench-arremesso-throw'
+      );
+      expect(lancar?.damageAttribute).toBe('Destreza');
+    });
+  });
+
   test('removing Arremesso restores baseArremesso and strips derived actions', () => {
     const item: Equipment = {
       ...baseSword,

--- a/src/functions/itemEnhancements/core.ts
+++ b/src/functions/itemEnhancements/core.ts
@@ -477,7 +477,20 @@ export function applyDelta<T extends Equipment>(
   const newDerived = delta.derivedSpecialActions.filter(
     (a) => !baseIds.has(a.id)
   );
-  const combinedActions = [...baseActions, ...newDerived];
+  // O atributo de dano por modo é escolha do usuário (editor da mochila, que
+  // grava em `specialActions`). `baseSpecialActions` é um snapshot congelado na
+  // primeira passagem do pipeline, então reconstruir a lista só a partir dele
+  // apagaria essa escolha a cada recálculo. Reaplicamos os overrides atuais por
+  // id — mesmo princípio do `extraDamage` do usuário, preservado acima.
+  const damageAttributeOverrides = new Map(
+    (captured.specialActions ?? []).map((a) => [a.id, a.damageAttribute])
+  );
+  const combinedActions = [...baseActions, ...newDerived].map<WeaponAction>(
+    (a) =>
+      damageAttributeOverrides.has(a.id)
+        ? { ...a, damageAttribute: damageAttributeOverrides.get(a.id) }
+        : a
+  );
   result.specialActions =
     combinedActions.length > 0 ? combinedActions : undefined;
 


### PR DESCRIPTION
## Descrição

Um item de catálogo que o jogador transforma (encanta, modifica, apelida ou tem estatísticas editadas) não sobrevive à mochila. Achei três problemas encadeados, todos no mesmo cenário: montar uma "Adaga da Tormenta", que é uma adaga com Formidável e Tumular, e manter adagas comuns junto dela.

### 1. Empilhamento indevido

O merge casava só por nome, exigindo apenas que nenhum dos lados fosse `isCustom`. Só que editar um item de catálogo não marca `isCustom`, marca `hasManualEdits`, então o item transformado continuava elegível a empilhar com o item base de mesmo nome. Como o merge preserva o item existente e apenas soma a quantidade, adicionar uma adaga comum devolvia duas adagas encantadas e a comum sumia. Na ordem inversa, os encantamentos iam embora.

### 2. Identidade compartilhada

O `AddItemDialog` entrega o objeto do catálogo por referência, e o `ensureId` devolvia esse mesmo objeto quando ele já tinha `id`. Como o catálogo é compartilhado e cacheado, ele pode já ter sido marcado por um `ensureIds` anterior, e o resultado eram duas entradas com o mesmo `id`.

Empunhadura, edição e remoção resolvem por `id`, então as duas entradas agiam como uma só: empunhar uma empunhava a outra, editar não salvava, e a chave React duplicada fazia uma sumir da lista enquanto os espaços continuavam sendo contados. O empilhamento do item 1 mascarava isso, porque a segunda entrada nunca chegava a existir.

### 3. Atributo de dano por modo de ataque era descartado

O `applyItemEnhancements` reconstrói `specialActions` a partir de `baseSpecialActions`, que é um snapshot congelado na primeira passagem do pipeline. A escolha de atributo de dano por modo de ataque, que o editor grava em `specialActions`, era apagada a cada recálculo. Na prática, trocar Força por Destreza no modo de arremesso não persistia em armas encantadas. O atributo global não era afetado porque não é regenerado.

## Mudanças

- Novo predicado `isStackable`, em `stacking.ts`, exigindo que os dois lados sejam de fato intercambiáveis para empilhar.
- `ensureUniqueId` sempre clona e gera um `id` novo quando o `id` recebido já está ocupado.
- Os overrides de atributo de dano passam a ser reaplicados por `id` sobre as ações base e as derivadas de encantamento, no mesmo princípio que já era usado para o `extraDamage` do usuário.

## Tipo de Mudança

- [x] Bug fix
- [ ] Nova funcionalidade
- [ ] Melhoria de código
- [ ] Documentação

## Testes

- [x] Testes passando
- [x] Novos testes adicionados
- [x] Testado manualmente

18 testes novos, entre `stacking.spec.ts` e `applyEnhancements.spec.ts`. Nove deles falham no comportamento anterior.

Rodei os dois arquivos com vitest, mais prettier e eslint nos arquivos tocados. O `tsc --noEmit` eu não consigo rodar aqui: contribuo sem acesso ao submódulo privado, como o CONTRIBUTING.md descreve na seção "Rodando sem o módulo premium".

Só um aviso sobre o CI: o job do CircleCI inicializa o submódulo `src/premium` com `$GITHUB_PAT` antes de rodar os testes, e PRs vindos de fork não recebem essa variável. Se o build ficar vermelho por causa disso, não é a mudança deste PR.
