### PR TITLE
Fixes pra Kobolds e Ladinos

### DIFF
--- a/src/components/CharacterCreationWizard/steps/AlmaLivreSelectionField.tsx
+++ b/src/components/CharacterCreationWizard/steps/AlmaLivreSelectionField.tsx
@@ -43,8 +43,13 @@ const AlmaLivreSelectionField: React.FC<AlmaLivreSelectionFieldProps> = ({
 }) => {
   const [searchQuery, setSearchQuery] = useState('');
 
-  const selectedClassName = selections.almaLivreClass || '';
-  const selectedPower = selections.almaLivrePower;
+  const selectedClassName =
+    (immediateClassPower
+      ? selections.diferentaoClass
+      : selections.almaLivreClass) || '';
+  const selectedPower = immediateClassPower
+    ? selections.diferentaoPower
+    : selections.almaLivrePower;
 
   const sortedClasses = useMemo(
     () =>
@@ -78,6 +83,8 @@ const AlmaLivreSelectionField: React.FC<AlmaLivreSelectionFieldProps> = ({
                 classe:
                   dataRegistry.getClassByName(selectedClassName, supplements) ||
                   sheet.classe,
+                // Nível 0 não é válido no filtro de requisitos; poderes de
+                // classe são avaliados a partir do nível efetivo mínimo 1.
                 nivel: Math.max(1, sheet.nivel - 4),
               },
               power
@@ -103,15 +110,17 @@ const AlmaLivreSelectionField: React.FC<AlmaLivreSelectionFieldProps> = ({
   const handleClassChange = (className: string) => {
     setSearchQuery('');
     onChange({
-      almaLivreClass: className,
-      almaLivrePower: undefined,
+      ...(immediateClassPower
+        ? { diferentaoClass: className, diferentaoPower: undefined }
+        : { almaLivreClass: className, almaLivrePower: undefined }),
     });
   };
 
   const handlePowerSelect = (power: ClassPower) => {
     onChange({
-      almaLivreClass: selectedClassName,
-      almaLivrePower: power,
+      ...(immediateClassPower
+        ? { diferentaoClass: selectedClassName, diferentaoPower: power }
+        : { almaLivreClass: selectedClassName, almaLivrePower: power }),
     });
   };
 

--- a/src/components/CharacterCreationWizard/steps/AlmaLivreSelectionField.tsx
+++ b/src/components/CharacterCreationWizard/steps/AlmaLivreSelectionField.tsx
@@ -16,17 +16,21 @@ import {
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import { ClassDescription, ClassPower } from '@/interfaces/Class';
+import CharacterSheet from '@/interfaces/CharacterSheet';
 import { SelectionOptions } from '@/interfaces/PowerSelections';
 import { dataRegistry } from '@/data/registry';
 import { SupplementId } from '@/types/supplement.types';
 import { normalizeSearch } from '@/functions/stringUtils';
 import { formatRequirements } from '@/functions/requirementText';
+import { isPowerAvailable } from '@/functions/powers';
 
 interface AlmaLivreSelectionFieldProps {
   availableClasses: ClassDescription[];
   supplements: SupplementId[];
   selections: SelectionOptions;
   onChange: (selections: SelectionOptions) => void;
+  immediateClassPower?: boolean;
+  sheet?: CharacterSheet;
 }
 
 const AlmaLivreSelectionField: React.FC<AlmaLivreSelectionFieldProps> = ({
@@ -34,6 +38,8 @@ const AlmaLivreSelectionField: React.FC<AlmaLivreSelectionFieldProps> = ({
   supplements,
   selections,
   onChange,
+  immediateClassPower = false,
+  sheet,
 }) => {
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -63,14 +69,36 @@ const AlmaLivreSelectionField: React.FC<AlmaLivreSelectionFieldProps> = ({
 
   // Filter powers by search query
   const filteredPowers = useMemo(() => {
-    if (!searchQuery) return selectedClassPowers;
+    const eligiblePowers =
+      immediateClassPower && sheet
+        ? selectedClassPowers.filter((power) =>
+            isPowerAvailable(
+              {
+                ...sheet,
+                classe:
+                  dataRegistry.getClassByName(selectedClassName, supplements) ||
+                  sheet.classe,
+                nivel: Math.max(1, sheet.nivel - 4),
+              },
+              power
+            )
+          )
+        : selectedClassPowers;
+    if (!searchQuery) return eligiblePowers;
     const query = normalizeSearch(searchQuery);
-    return selectedClassPowers.filter(
+    return eligiblePowers.filter(
       (power) =>
         normalizeSearch(power.name).includes(query) ||
         normalizeSearch(power.text).includes(query)
     );
-  }, [selectedClassPowers, searchQuery]);
+  }, [
+    selectedClassPowers,
+    searchQuery,
+    immediateClassPower,
+    sheet,
+    selectedClassName,
+    supplements,
+  ]);
 
   const handleClassChange = (className: string) => {
     setSearchQuery('');
@@ -91,10 +119,12 @@ const AlmaLivreSelectionField: React.FC<AlmaLivreSelectionFieldProps> = ({
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
       <Alert severity='info'>
         <Typography variant='body2'>
-          <strong>Alma Livre:</strong> Escolha uma classe diferente da sua. Você
-          poderá escolher um poder dessa classe em uma subida de nível futura
-          (nível efetivo = seu nível − 4). Você não recebe o poder agora, apenas
-          o direito de escolhê-lo mais tarde.
+          <strong>{immediateClassPower ? 'Diferentão' : 'Alma Livre'}:</strong>{' '}
+          Escolha uma classe diferente da sua e um poder dessa classe (nível
+          efetivo = seu nível − 4).{' '}
+          {immediateClassPower
+            ? 'Você recebe o poder imediatamente.'
+            : 'Você poderá escolhê-lo em uma subida de nível futura.'}
         </Typography>
       </Alert>
       {/* Class Selection */}

--- a/src/components/CharacterCreationWizard/steps/PowerEffectSelectionStep.tsx
+++ b/src/components/CharacterCreationWizard/steps/PowerEffectSelectionStep.tsx
@@ -673,6 +673,7 @@ const PowerEffectSelectionStep: React.FC<PowerEffectSelectionStepProps> = ({
         schools?: string[];
         optionKey?: string;
         linkedTo?: string;
+        immediateClassPower?: boolean;
         minLevel?: number;
         abilityLevel?: number;
         pickByAttribute?: Atributo;
@@ -1653,6 +1654,7 @@ const PowerEffectSelectionStep: React.FC<PowerEffectSelectionStepProps> = ({
       const availableClassesForAL = allClassesForAL.filter(
         (c) => c.name !== sheetForFiltering.classe.name
       );
+      const immediateClassPower = requirement.metadata?.immediateClassPower;
 
       return (
         <Box
@@ -1665,6 +1667,8 @@ const PowerEffectSelectionStep: React.FC<PowerEffectSelectionStepProps> = ({
             availableClasses={availableClassesForAL}
             supplements={supplements}
             selections={powerSelections}
+            immediateClassPower={immediateClassPower}
+            sheet={sheetForFiltering}
             onChange={(newSelections) => {
               onChange({
                 ...selections,

--- a/src/components/LevelUpWizard/LevelUpWizardModal.tsx
+++ b/src/components/LevelUpWizard/LevelUpWizardModal.tsx
@@ -1511,8 +1511,8 @@ const LevelUpWizardModal: React.FC<LevelUpWizardModalProps> = ({
             ];
           }
 
-          // Apply Alma Livre class/power selections to the simulated sheet
-          // so the next level can detect and offer the pre-selected power
+          // Apply class/power selections to the simulated sheet so the next
+          // level can detect and offer the pre-selected power.
           if (selectedPower && currentLevelSelection.powerEffectSelections) {
             const almaLivreEffects =
               currentLevelSelection.powerEffectSelections[selectedPower.name];
@@ -1522,6 +1522,13 @@ const LevelUpWizardModal: React.FC<LevelUpWizardModalProps> = ({
             ) {
               nextSheet.almaLivreClass = almaLivreEffects.almaLivreClass;
               nextSheet.almaLivrePower = almaLivreEffects.almaLivrePower;
+            }
+            if (
+              almaLivreEffects?.diferentaoClass &&
+              almaLivreEffects?.diferentaoPower
+            ) {
+              nextSheet.diferentaoClass = almaLivreEffects.diferentaoClass;
+              nextSheet.diferentaoPower = almaLivreEffects.diferentaoPower;
             }
           }
         }

--- a/src/components/SheetResult/BackpackModal/BackpackModal.tsx
+++ b/src/components/SheetResult/BackpackModal/BackpackModal.tsx
@@ -39,6 +39,7 @@ import CharacterSheet, {
   Step,
   SubStep,
 } from '../../../interfaces/CharacterSheet';
+import { Atributo } from '../../../data/systems/tormenta20/atributos';
 import Bag from '../../../interfaces/Bag';
 import Equipment, { equipGroup } from '../../../interfaces/Equipment';
 import { recalculateSheet } from '../../../functions/recalculateSheet';
@@ -116,14 +117,15 @@ const BackpackModal: React.FC<BackpackModalProps> = ({
     }),
     [sheet.dinheiro, sheet.dinheiroTC, sheet.dinheiroTO]
   );
-  const forca = sheet.atributos.Força.value;
+  const maxSpacesAttribute = sheet.maxSpacesAttribute ?? Atributo.FORCA;
   // "Devagar e Sempre"/Golem: sobrecarregar não custa deslocamento.
   const sheetIgnoresEncumbrance = ignoresEncumbrance(sheet);
 
   const state = useBackpackState({
     bag: sheet.bag,
     initialMoney,
-    forca,
+    maxSpacesAttribute,
+    maxSpacesAttributeValue: sheet.atributos[maxSpacesAttribute].value,
     initialCustomMaxSpaces: sheet.customMaxSpaces,
     initialMainHandItemId: sheet.mainHandItemId,
     initialOffHandItemId: sheet.offHandItemId,

--- a/src/components/SheetResult/BackpackModal/BackpackModal.tsx
+++ b/src/components/SheetResult/BackpackModal/BackpackModal.tsx
@@ -8,9 +8,13 @@ import {
   Collapse,
   Dialog,
   Divider,
+  FormControl,
   Grid,
+  InputLabel,
   IconButton,
   LinearProgress,
+  MenuItem,
+  Select,
   Slide,
   Stack,
   TextField,
@@ -118,6 +122,17 @@ const BackpackModal: React.FC<BackpackModalProps> = ({
     [sheet.dinheiro, sheet.dinheiroTC, sheet.dinheiroTO]
   );
   const maxSpacesAttribute = sheet.maxSpacesAttribute ?? Atributo.FORCA;
+  const attributeValues = useMemo(
+    () =>
+      Object.values(Atributo).reduce(
+        (values, attribute) => ({
+          ...values,
+          [attribute]: sheet.atributos[attribute].value,
+        }),
+        {} as Record<Atributo, number>
+      ),
+    [sheet.atributos]
+  );
   // "Devagar e Sempre"/Golem: sobrecarregar não custa deslocamento.
   const sheetIgnoresEncumbrance = ignoresEncumbrance(sheet);
 
@@ -125,7 +140,7 @@ const BackpackModal: React.FC<BackpackModalProps> = ({
     bag: sheet.bag,
     initialMoney,
     maxSpacesAttribute,
-    maxSpacesAttributeValue: sheet.atributos[maxSpacesAttribute].value,
+    attributeValues,
     initialCustomMaxSpaces: sheet.customMaxSpaces,
     initialMainHandItemId: sheet.mainHandItemId,
     initialOffHandItemId: sheet.offHandItemId,
@@ -152,6 +167,7 @@ const BackpackModal: React.FC<BackpackModalProps> = ({
     setQuantity,
     updateItem,
     setMoney,
+    setMaxSpacesAttribute,
     setCustomMaxSpaces,
     setAutoDeductMoney,
     reorder,
@@ -264,6 +280,7 @@ const BackpackModal: React.FC<BackpackModalProps> = ({
         dinheiro: staged.money.dinheiro,
         dinheiroTC: staged.money.dinheiroTC,
         dinheiroTO: staged.money.dinheiroTO,
+        manualMaxSpacesAttribute: staged.maxSpacesAttribute,
         customMaxSpaces: staged.customMaxSpaces,
         // Drive the recalc off the STAGED equip-state, not the stale sheet
         // values — otherwise defesa/armor-penalty are computed against the
@@ -323,6 +340,8 @@ const BackpackModal: React.FC<BackpackModalProps> = ({
       dinheiro: staged.money.dinheiro,
       dinheiroTC: staged.money.dinheiroTC,
       dinheiroTO: staged.money.dinheiroTO,
+      manualMaxSpacesAttribute: staged.maxSpacesAttribute,
+      maxSpacesAttribute: recalculated.maxSpacesAttribute,
       customMaxSpaces: staged.customMaxSpaces,
       maxSpaces: recalculated.maxSpaces ?? sheet.maxSpaces,
       defesa: recalculated.defesa ?? sheet.defesa,
@@ -971,6 +990,28 @@ const BackpackModal: React.FC<BackpackModalProps> = ({
               (v) => setMoney({ dinheiroTO: v }),
               '1 TO = T$ 10'
             )}
+            <FormControl
+              size='small'
+              sx={{ width: { xs: 'calc(50% - 4px)', sm: 170 } }}
+            >
+              <InputLabel id='backpack-load-attribute-label'>
+                Atributo de carga
+              </InputLabel>
+              <Select
+                labelId='backpack-load-attribute-label'
+                value={staged.maxSpacesAttribute}
+                label='Atributo de carga'
+                onChange={(event) =>
+                  setMaxSpacesAttribute(event.target.value as Atributo)
+                }
+              >
+                {Object.values(Atributo).map((attribute) => (
+                  <MenuItem key={attribute} value={attribute}>
+                    {attribute}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
             <TextField
               label='Espaço máx.'
               size='small'

--- a/src/components/SheetResult/BackpackModal/BackpackModal.tsx
+++ b/src/components/SheetResult/BackpackModal/BackpackModal.tsx
@@ -272,6 +272,12 @@ const BackpackModal: React.FC<BackpackModalProps> = ({
 
     const beforeItems = sheet.bag.getOrderedEquipments();
     const newBag = new Bag(staged.equipments, true, staged.displayOrder);
+    const derivedMaxSpacesAttribute =
+      sheet.maxSpacesAttribute ?? Atributo.FORCA;
+    const manualMaxSpacesAttribute =
+      staged.maxSpacesAttribute !== derivedMaxSpacesAttribute
+        ? staged.maxSpacesAttribute
+        : sheet.manualMaxSpacesAttribute;
 
     const recalculated = recalculateSheet(
       {
@@ -280,7 +286,7 @@ const BackpackModal: React.FC<BackpackModalProps> = ({
         dinheiro: staged.money.dinheiro,
         dinheiroTC: staged.money.dinheiroTC,
         dinheiroTO: staged.money.dinheiroTO,
-        manualMaxSpacesAttribute: staged.maxSpacesAttribute,
+        manualMaxSpacesAttribute,
         customMaxSpaces: staged.customMaxSpaces,
         // Drive the recalc off the STAGED equip-state, not the stale sheet
         // values — otherwise defesa/armor-penalty are computed against the
@@ -340,7 +346,7 @@ const BackpackModal: React.FC<BackpackModalProps> = ({
       dinheiro: staged.money.dinheiro,
       dinheiroTC: staged.money.dinheiroTC,
       dinheiroTO: staged.money.dinheiroTO,
-      manualMaxSpacesAttribute: staged.maxSpacesAttribute,
+      manualMaxSpacesAttribute,
       maxSpacesAttribute: recalculated.maxSpacesAttribute,
       customMaxSpaces: staged.customMaxSpaces,
       maxSpaces: recalculated.maxSpaces ?? sheet.maxSpaces,

--- a/src/components/SheetResult/BackpackModal/useBackpackState.ts
+++ b/src/components/SheetResult/BackpackModal/useBackpackState.ts
@@ -31,6 +31,7 @@ interface StagedState {
   equipments: BagEquipments;
   displayOrder: string[];
   money: BackpackMoney;
+  maxSpacesAttribute: Atributo;
   customMaxSpaces?: number;
   autoDeductMoney: boolean;
   mainHandItemId?: string;
@@ -43,7 +44,7 @@ export interface BackpackInputs {
   bag: Bag;
   initialMoney: BackpackMoney;
   maxSpacesAttribute: Atributo;
-  maxSpacesAttributeValue: number;
+  attributeValues: Record<Atributo, number>;
   initialCustomMaxSpaces?: number;
   /** Default for the auto-deduct toggle when entering the modal. */
   initialAutoDeductMoney?: boolean;
@@ -92,6 +93,7 @@ export interface BackpackActions {
   /** Replaces the item in place by id. */
   updateItem: (id: string, next: Equipment) => void;
   setMoney: (money: Partial<BackpackMoney>) => void;
+  setMaxSpacesAttribute: (attribute: Atributo) => void;
   setCustomMaxSpaces: (value: number | undefined) => void;
   setAutoDeductMoney: (value: boolean) => void;
   /** Reorders by item id (used by drag-and-drop in PR 6). */
@@ -161,6 +163,7 @@ type Action =
   | { type: 'SET_QUANTITY'; id: string; quantity: number }
   | { type: 'UPDATE_ITEM'; id: string; next: Equipment }
   | { type: 'SET_MONEY'; money: Partial<BackpackMoney> }
+  | { type: 'SET_MAX_SPACES_ATTRIBUTE'; attribute: Atributo }
   | { type: 'SET_CUSTOM_MAX_SPACES'; value: number | undefined }
   | { type: 'SET_AUTO_DEDUCT'; value: boolean }
   | { type: 'REORDER'; orderedIds: string[] }
@@ -431,6 +434,12 @@ function reducer(state: StagedState, action: Action): StagedState {
       };
     case 'SET_MONEY':
       return { ...state, money: { ...state.money, ...action.money } };
+    case 'SET_MAX_SPACES_ATTRIBUTE':
+      return {
+        ...state,
+        maxSpacesAttribute: action.attribute,
+        customMaxSpaces: undefined,
+      };
     case 'SET_CUSTOM_MAX_SPACES':
       return { ...state, customMaxSpaces: action.value };
     case 'SET_AUTO_DEDUCT':
@@ -482,7 +491,7 @@ export function useBackpackState({
   bag,
   initialMoney,
   maxSpacesAttribute,
-  maxSpacesAttributeValue,
+  attributeValues,
   initialCustomMaxSpaces,
   initialAutoDeductMoney = true,
   initialMainHandItemId,
@@ -532,6 +541,7 @@ export function useBackpackState({
       equipments,
       displayOrder,
       money: { ...initialMoney },
+      maxSpacesAttribute,
       customMaxSpaces: initialCustomMaxSpaces,
       autoDeductMoney: initialAutoDeductMoney,
       mainHandItemId: pruned.mainHandItemId,
@@ -609,7 +619,8 @@ export function useBackpackState({
     const equipMaxSpacesBonus = getEquipmentMaxSpacesBonus(orderedItems);
     const maxSpaces =
       staged.customMaxSpaces ??
-      calculateMaxSpaces(maxSpacesAttributeValue) + equipMaxSpacesBonus;
+      calculateMaxSpaces(attributeValues[staged.maxSpacesAttribute]) +
+        equipMaxSpacesBonus;
     const { overflowItemIds, overflowStartIndex } = computeOverflow(
       orderedItems,
       maxSpaces - currencySpaces
@@ -627,8 +638,8 @@ export function useBackpackState({
     orderedItems,
     staged.money,
     staged.customMaxSpaces,
-    maxSpacesAttribute,
-    maxSpacesAttributeValue,
+    staged.maxSpacesAttribute,
+    attributeValues,
   ]);
 
   const filteredItems = useMemo(() => {
@@ -659,6 +670,9 @@ export function useBackpackState({
 
   const isDirty = useMemo(() => {
     if (staged.autoDeductMoney !== initialSnapshot.autoDeductMoney) return true;
+    if (staged.maxSpacesAttribute !== initialSnapshot.maxSpacesAttribute) {
+      return true;
+    }
     if (staged.customMaxSpaces !== initialSnapshot.customMaxSpaces) return true;
     if (
       staged.money.dinheiro !== initialSnapshot.money.dinheiro ||
@@ -725,6 +739,12 @@ export function useBackpackState({
     []
   );
 
+  const setMaxSpacesAttribute = useCallback(
+    (attribute: Atributo) =>
+      dispatch({ type: 'SET_MAX_SPACES_ATTRIBUTE', attribute }),
+    []
+  );
+
   const setCustomMaxSpaces = useCallback(
     (value: number | undefined) =>
       dispatch({ type: 'SET_CUSTOM_MAX_SPACES', value }),
@@ -779,6 +799,7 @@ export function useBackpackState({
     setQuantity,
     updateItem,
     setMoney,
+    setMaxSpacesAttribute,
     setCustomMaxSpaces,
     setAutoDeductMoney,
     reorder,

--- a/src/components/SheetResult/BackpackModal/useBackpackState.ts
+++ b/src/components/SheetResult/BackpackModal/useBackpackState.ts
@@ -6,6 +6,7 @@ import Equipment, {
   BagEquipments,
   equipGroup,
 } from '../../../interfaces/Equipment';
+import { Atributo } from '../../../data/systems/tormenta20/atributos';
 import {
   calculateCurrencySpaces,
   calculateMaxSpaces,
@@ -41,7 +42,8 @@ interface StagedState {
 export interface BackpackInputs {
   bag: Bag;
   initialMoney: BackpackMoney;
-  forca: number;
+  maxSpacesAttribute: Atributo;
+  maxSpacesAttributeValue: number;
   initialCustomMaxSpaces?: number;
   /** Default for the auto-deduct toggle when entering the modal. */
   initialAutoDeductMoney?: boolean;
@@ -479,7 +481,8 @@ function reducer(state: StagedState, action: Action): StagedState {
 export function useBackpackState({
   bag,
   initialMoney,
-  forca,
+  maxSpacesAttribute,
+  maxSpacesAttributeValue,
   initialCustomMaxSpaces,
   initialAutoDeductMoney = true,
   initialMainHandItemId,
@@ -605,7 +608,8 @@ export function useBackpackState({
     // destaque de sobrecarga reajam ao adicionar/remover esses itens.
     const equipMaxSpacesBonus = getEquipmentMaxSpacesBonus(orderedItems);
     const maxSpaces =
-      staged.customMaxSpaces ?? calculateMaxSpaces(forca) + equipMaxSpacesBonus;
+      staged.customMaxSpaces ??
+      calculateMaxSpaces(maxSpacesAttributeValue) + equipMaxSpacesBonus;
     const { overflowItemIds, overflowStartIndex } = computeOverflow(
       orderedItems,
       maxSpaces - currencySpaces
@@ -619,7 +623,13 @@ export function useBackpackState({
       overflowItemIds,
       overflowStartIndex,
     };
-  }, [orderedItems, staged.money, staged.customMaxSpaces, forca]);
+  }, [
+    orderedItems,
+    staged.money,
+    staged.customMaxSpaces,
+    maxSpacesAttribute,
+    maxSpacesAttributeValue,
+  ]);
 
   const filteredItems = useMemo(() => {
     const q = normalize(searchQuery);

--- a/src/data/systems/tormenta20/ameacas-de-arton/powers/koboldsTalents.ts
+++ b/src/data/systems/tormenta20/ameacas-de-arton/powers/koboldsTalents.ts
@@ -45,6 +45,15 @@ const KOBOLDS_TALENTS: GeneralPower[] = [
     description:
       'Escolham um poder de outra classe cujos requisitos vocês cumpram (como um poder de bardo da lista de Poderes de Bardo). Vocês recebem o poder escolhido; para efeitos de nível na classe desse poder, considere seu nível de personagem −4.',
     requirements: [[{ type: RequirementType.RACA, name: 'Kobolds' }]],
+    sheetActions: [
+      {
+        source: { type: 'power', name: 'Diferentão (Kobolds)' },
+        action: {
+          type: 'special',
+          specialAction: 'diferentaoSelectClassPower',
+        },
+      },
+    ],
   },
   {
     type: GeneralPowerType.DESTINO,

--- a/src/data/systems/tormenta20/ameacas-de-arton/powers/koboldsTalents.ts
+++ b/src/data/systems/tormenta20/ameacas-de-arton/powers/koboldsTalents.ts
@@ -80,6 +80,15 @@ const KOBOLDS_TALENTS: GeneralPower[] = [
     description:
       'Vocês podem usar Destreza para estabelecer seu limite de carga (em vez de Força) e podem se beneficiar de um vestido adicional.',
     requirements: [[{ type: RequirementType.RACA, name: 'Kobolds' }]],
+    sheetActions: [
+      {
+        source: { type: 'power', name: 'Organizadinhos (Kobolds)' },
+        action: {
+          type: 'setMaxSpacesAttribute',
+          attribute: Atributo.DESTREZA,
+        },
+      },
+    ],
   },
   {
     type: GeneralPowerType.DESTINO,

--- a/src/data/systems/tormenta20/ameacas-de-arton/powers/koboldsTalents.ts
+++ b/src/data/systems/tormenta20/ameacas-de-arton/powers/koboldsTalents.ts
@@ -59,6 +59,12 @@ const KOBOLDS_TALENTS: GeneralPower[] = [
         modifier: { type: 'Fixed', value: 2 },
       },
     ],
+    sheetActions: [
+      {
+        source: { type: 'power', name: 'Ex-Familiar (Kobolds)' },
+        action: { type: 'selectFamiliar' },
+      },
+    ],
   },
   {
     type: GeneralPowerType.DESTINO,

--- a/src/data/systems/tormenta20/ameacas-de-arton/races/kobolds.ts
+++ b/src/data/systems/tormenta20/ameacas-de-arton/races/kobolds.ts
@@ -10,12 +10,12 @@ const koboldsAbilities: RaceAbility[] = [
       'Embora sejam um grupo de kobolds, para todos os efeitos vocês são uma única criatura Média com dois braços. Entretanto, contam como Pequenos para efeitos dos espaços por onde podem passar e, quando fazem um teste de resistência contra um efeito que afeta apenas uma criatura e não causa dano, rolam dois dados e usam o melhor resultado. Por fim, têm vulnerabilidade a dano de área.',
   },
   {
-    name: 'Praga Perigosa',
+    name: 'Praga Monstruosa',
     description:
       'Vocês são criaturas do tipo monstro e recebem visão no escuro e +2 em Sobrevivência.',
     sheetBonuses: [
       {
-        source: { type: 'power', name: 'Praga Perigosa' },
+        source: { type: 'power', name: 'Praga Monstruosa' },
         target: { type: 'Skill', name: Skill.SOBREVIVENCIA },
         modifier: { type: 'Fixed', value: 2 },
       },

--- a/src/data/systems/tormenta20/ameacas-de-arton/races/kobolds.ts
+++ b/src/data/systems/tormenta20/ameacas-de-arton/races/kobolds.ts
@@ -10,12 +10,12 @@ const koboldsAbilities: RaceAbility[] = [
       'Embora sejam um grupo de kobolds, para todos os efeitos vocês são uma única criatura Média com dois braços. Entretanto, contam como Pequenos para efeitos dos espaços por onde podem passar e, quando fazem um teste de resistência contra um efeito que afeta apenas uma criatura e não causa dano, rolam dois dados e usam o melhor resultado. Por fim, têm vulnerabilidade a dano de área.',
   },
   {
-    name: 'Praça Perigosa',
+    name: 'Praga Perigosa',
     description:
       'Vocês são criaturas do tipo monstro e recebem visão no escuro e +2 em Sobrevivência.',
     sheetBonuses: [
       {
-        source: { type: 'power', name: 'Praça Perigosa' },
+        source: { type: 'power', name: 'Praga Perigosa' },
         target: { type: 'Skill', name: Skill.SOBREVIVENCIA },
         modifier: { type: 'Fixed', value: 2 },
       },

--- a/src/data/systems/tormenta20/classes/ladino.ts
+++ b/src/data/systems/tormenta20/classes/ladino.ts
@@ -190,7 +190,7 @@ const LADINO: ClassDescription = {
       name: 'Mente Criminosa',
       text: 'Você soma sua Inteligência em Ladinagem e Furtividade',
       requirements: [
-        [{ type: RequirementType.ATRIBUTO, name: 'Destreza', value: 1 }],
+        [{ type: RequirementType.ATRIBUTO, name: 'Inteligência', value: 1 }],
       ],
       sheetBonuses: [
         {

--- a/src/data/systems/tormenta20/classes/ladino.ts
+++ b/src/data/systems/tormenta20/classes/ladino.ts
@@ -141,9 +141,7 @@ const LADINO: ClassDescription = {
     {
       name: 'Gatuno',
       text: 'Você recebe +2 em Atletismo. Quando escala, não fica desprevenido e avança seu deslocamento normal, em vez de metade dele.',
-      requirements: [
-        [{ type: RequirementType.PERICIA, name: Skill.ATLETISMO }],
-      ],
+      requirements: [],
       sheetBonuses: [
         {
           source: {

--- a/src/data/systems/tormenta20/deuses-de-arton/powers/index.ts
+++ b/src/data/systems/tormenta20/deuses-de-arton/powers/index.ts
@@ -59,6 +59,15 @@ const DEUSES_ARTON_POWERS: { [key in GeneralPowerType]: GeneralPower[] } = {
         'Sua mochila de aventureiro não conta no seu limite de itens vestidos e, se estiver vestindo uma dessas mochilas, você pode usar Sabedoria para estabelecer seu limite de carga (em vez de Força). A critério do mestre, este poder pode ser aplicado a outro item equivalente (como uma mochila de carga).',
       type: GeneralPowerType.CONCEDIDOS,
       requirements: [[{ type: RequirementType.DEVOTO, name: 'Valkaria' }]],
+      sheetActions: [
+        {
+          source: { type: 'power', name: 'Andarilho Carregado' },
+          action: {
+            type: 'setMaxSpacesAttribute',
+            attribute: Atributo.SABEDORIA,
+          },
+        },
+      ],
     },
     {
       name: 'Armadilha Divina',

--- a/src/functions/__tests__/maxSpacesAttribute.spec.ts
+++ b/src/functions/__tests__/maxSpacesAttribute.spec.ts
@@ -1,0 +1,74 @@
+import { recalculateSheet } from '../recalculateSheet';
+import { calculateMaxSpaces } from '../general';
+import { createMockCharacterSheet } from '../../__mocks__/characterSheet';
+import { Atributo } from '../../data/systems/tormenta20/atributos';
+import { GeneralPowerType } from '../../interfaces/Poderes';
+import KOBOLDS_TALENTS from '../../data/systems/tormenta20/ameacas-de-arton/powers/koboldsTalents';
+import DEITY_POWERS from '../../data/systems/tormenta20/deuses-de-arton/powers';
+
+describe('max spaces attribute', () => {
+  it('uses the selected attribute and replays it after recalculation', () => {
+    const sheet = createMockCharacterSheet();
+    const power = {
+      name: 'Teste de carga por Destreza',
+      description: '',
+      type: GeneralPowerType.DESTINO,
+      requirements: [],
+      sheetActions: [
+        {
+          source: {
+            type: 'power' as const,
+            name: 'Teste de carga por Destreza',
+          },
+          action: {
+            type: 'setMaxSpacesAttribute' as const,
+            attribute: Atributo.DESTREZA,
+          },
+        },
+      ],
+    };
+    sheet.generalPowers = [power];
+    sheet.atributos[Atributo.FORCA].value = 1;
+    sheet.atributos[Atributo.DESTREZA].value = 4;
+
+    const first = recalculateSheet(sheet);
+    expect(first.maxSpacesAttribute).toBe(Atributo.DESTREZA);
+    expect(first.maxSpaces).toBe(18);
+
+    const second = recalculateSheet(first);
+    expect(second.maxSpacesAttribute).toBe(Atributo.DESTREZA);
+    expect(second.maxSpaces).toBe(18);
+    expect(
+      second.sheetActionHistory.filter(
+        (entry) => entry.powerName === power.name
+      )
+    ).toHaveLength(1);
+
+    second.generalPowers = [];
+    const removed = recalculateSheet(second);
+    expect(removed.maxSpacesAttribute).toBeUndefined();
+    expect(removed.maxSpaces).toBe(12);
+  });
+
+  it('applies the special negative attribute rule universally', () => {
+    expect(calculateMaxSpaces(-1)).toBe(9);
+  });
+
+  it('configures Organizadinhos and Andarilho Carregado with the action', () => {
+    const organizadinhos = KOBOLDS_TALENTS.find(
+      (power) => power.name === 'Organizadinhos (Kobolds)'
+    );
+    const andarilho = Object.values(DEITY_POWERS)
+      .flat()
+      .find((power) => power.name === 'Andarilho Carregado');
+
+    expect(organizadinhos?.sheetActions?.[0].action).toEqual({
+      type: 'setMaxSpacesAttribute',
+      attribute: Atributo.DESTREZA,
+    });
+    expect(andarilho?.sheetActions?.[0].action).toEqual({
+      type: 'setMaxSpacesAttribute',
+      attribute: Atributo.SABEDORIA,
+    });
+  });
+});

--- a/src/functions/__tests__/maxSpacesAttribute.spec.ts
+++ b/src/functions/__tests__/maxSpacesAttribute.spec.ts
@@ -153,4 +153,41 @@ describe('max spaces attribute', () => {
       )
     ).toBe(true);
   });
+
+  it('selects and grants a Diferentão class power immediately', () => {
+    const sheet = createMockCharacterSheet();
+    const diferentao = KOBOLDS_TALENTS.find(
+      (power) => power.name === 'Diferentão (Kobolds)'
+    );
+    if (!diferentao) throw new Error('Diferentão não encontrado');
+
+    const selectedPower = {
+      name: 'Poder de Teste do Diferentão',
+      text: 'Um poder de classe escolhido por teste.',
+      requirements: [],
+    };
+    sheet.generalPowers = [diferentao];
+
+    const result = recalculateSheet(sheet, undefined, {
+      'Diferentão (Kobolds)': {
+        almaLivreClass: 'Bardo',
+        almaLivrePower: selectedPower,
+      },
+    });
+
+    expect(result.diferentaoClass).toBe('Bardo');
+    expect(result.diferentaoPower?.name).toBe(selectedPower.name);
+    expect(
+      result.classPowers?.some((power) => power.name === selectedPower.name)
+    ).toBe(true);
+    expect(
+      result.sheetActionHistory.some((entry) =>
+        entry.changes.some(
+          (change) =>
+            change.type === 'ClassPowerAdded' &&
+            change.powerName === selectedPower.name
+        )
+      )
+    ).toBe(true);
+  });
 });

--- a/src/functions/__tests__/maxSpacesAttribute.spec.ts
+++ b/src/functions/__tests__/maxSpacesAttribute.spec.ts
@@ -3,6 +3,7 @@ import { calculateMaxSpaces } from '../general';
 import { createMockCharacterSheet } from '../../__mocks__/characterSheet';
 import { Atributo } from '../../data/systems/tormenta20/atributos';
 import { GeneralPowerType } from '../../interfaces/Poderes';
+import Skill from '../../interfaces/Skills';
 import KOBOLDS_TALENTS from '../../data/systems/tormenta20/ameacas-de-arton/powers/koboldsTalents';
 import DEITY_POWERS from '../../data/systems/tormenta20/deuses-de-arton/powers';
 import { getPowerSelectionRequirements } from '../powers/manualPowerSelection';
@@ -165,13 +166,23 @@ describe('max spaces attribute', () => {
       name: 'Poder de Teste do Diferentão',
       text: 'Um poder de classe escolhido por teste.',
       requirements: [],
+      sheetBonuses: [
+        {
+          source: {
+            type: 'power' as const,
+            name: 'Poder de Teste do Diferentão',
+          },
+          target: { type: 'Skill' as const, name: Skill.FURTIVIDADE },
+          modifier: { type: 'Fixed' as const, value: 2 },
+        },
+      ],
     };
     sheet.generalPowers = [diferentao];
 
     const result = recalculateSheet(sheet, undefined, {
       'Diferentão (Kobolds)': {
-        almaLivreClass: 'Bardo',
-        almaLivrePower: selectedPower,
+        diferentaoClass: 'Bardo',
+        diferentaoPower: selectedPower,
       },
     });
 
@@ -181,13 +192,21 @@ describe('max spaces attribute', () => {
       result.classPowers?.some((power) => power.name === selectedPower.name)
     ).toBe(true);
     expect(
-      result.sheetActionHistory.some((entry) =>
-        entry.changes.some(
-          (change) =>
-            change.type === 'ClassPowerAdded' &&
-            change.powerName === selectedPower.name
-        )
+      result.sheetBonuses.filter(
+        (bonus) =>
+          bonus.target.type === 'Skill' &&
+          bonus.target.name === Skill.FURTIVIDADE &&
+          bonus.modifier.type === 'Fixed' &&
+          bonus.modifier.value === 2
       )
-    ).toBe(true);
+    ).toHaveLength(1);
+
+    result.generalPowers = [];
+    const removed = recalculateSheet(result);
+    expect(removed.diferentaoClass).toBeUndefined();
+    expect(removed.diferentaoPower).toBeUndefined();
+    expect(
+      removed.classPowers?.some((power) => power.name === selectedPower.name)
+    ).toBe(false);
   });
 });

--- a/src/functions/__tests__/maxSpacesAttribute.spec.ts
+++ b/src/functions/__tests__/maxSpacesAttribute.spec.ts
@@ -54,6 +54,37 @@ describe('max spaces attribute', () => {
     expect(calculateMaxSpaces(-1)).toBe(9);
   });
 
+  it('persists a manual load attribute through recalculation', () => {
+    const sheet = createMockCharacterSheet();
+    sheet.manualMaxSpacesAttribute = Atributo.DESTREZA;
+    sheet.atributos[Atributo.FORCA].value = 1;
+    sheet.atributos[Atributo.DESTREZA].value = 4;
+
+    const result = recalculateSheet(sheet);
+
+    expect(result.maxSpacesAttribute).toBe(Atributo.DESTREZA);
+    expect(result.maxSpaces).toBe(18);
+  });
+
+  it('lets the manual choice override Organizadinhos', () => {
+    const sheet = createMockCharacterSheet();
+    const organizadinhos = KOBOLDS_TALENTS.find(
+      (power) => power.name === 'Organizadinhos (Kobolds)'
+    );
+    if (!organizadinhos) throw new Error('Organizadinhos não encontrado');
+
+    sheet.generalPowers = [organizadinhos];
+    sheet.manualMaxSpacesAttribute = Atributo.SABEDORIA;
+    sheet.atributos[Atributo.DESTREZA].value = 4;
+    sheet.atributos[Atributo.SABEDORIA].value = 2;
+
+    const result = recalculateSheet(sheet);
+
+    expect(result.maxSpacesAttribute).toBe(Atributo.SABEDORIA);
+    expect(result.manualMaxSpacesAttribute).toBe(Atributo.SABEDORIA);
+    expect(result.maxSpaces).toBe(14);
+  });
+
   it('configures Organizadinhos and Andarilho Carregado with the action', () => {
     const organizadinhos = KOBOLDS_TALENTS.find(
       (power) => power.name === 'Organizadinhos (Kobolds)'

--- a/src/functions/__tests__/maxSpacesAttribute.spec.ts
+++ b/src/functions/__tests__/maxSpacesAttribute.spec.ts
@@ -5,6 +5,7 @@ import { Atributo } from '../../data/systems/tormenta20/atributos';
 import { GeneralPowerType } from '../../interfaces/Poderes';
 import KOBOLDS_TALENTS from '../../data/systems/tormenta20/ameacas-de-arton/powers/koboldsTalents';
 import DEITY_POWERS from '../../data/systems/tormenta20/deuses-de-arton/powers';
+import { getPowerSelectionRequirements } from '../powers/manualPowerSelection';
 
 describe('max spaces attribute', () => {
   it('uses the selected attribute and replays it after recalculation', () => {
@@ -101,5 +102,55 @@ describe('max spaces attribute', () => {
       type: 'setMaxSpacesAttribute',
       attribute: Atributo.SABEDORIA,
     });
+  });
+
+  it('configures Ex-Familiar with the familiar selection step', () => {
+    const exFamiliar = KOBOLDS_TALENTS.find(
+      (power) => power.name === 'Ex-Familiar (Kobolds)'
+    );
+
+    expect(exFamiliar?.sheetActions?.[0].action).toEqual({
+      type: 'selectFamiliar',
+    });
+
+    const requirements = exFamiliar
+      ? getPowerSelectionRequirements(exFamiliar)
+      : undefined;
+    expect(
+      requirements?.requirements.some(
+        (requirement) => requirement.type === 'selectFamiliar'
+      )
+    ).toBe(true);
+  });
+
+  it('applies the selected familiar from Ex-Familiar to the sheet', () => {
+    const sheet = createMockCharacterSheet();
+    const exFamiliar = KOBOLDS_TALENTS.find(
+      (power) => power.name === 'Ex-Familiar (Kobolds)'
+    );
+    if (!exFamiliar) throw new Error('Ex-Familiar não encontrado');
+
+    sheet.generalPowers = [exFamiliar];
+    const result = recalculateSheet(sheet, undefined, {
+      'Ex-Familiar (Kobolds)': { familiars: ['GATO'] },
+    });
+
+    const familiarChange = result.sheetActionHistory
+      .flatMap((entry) => entry.changes)
+      .find((change) => change.type === 'FamiliarSelected');
+    expect(familiarChange).toEqual({
+      type: 'FamiliarSelected',
+      familiarKey: 'GATO',
+    });
+    expect(result.pm).toBe(8);
+    expect(
+      result.sheetBonuses.some(
+        (bonus) =>
+          bonus.target.type === 'Skill' &&
+          bonus.target.name === 'Furtividade' &&
+          bonus.modifier.type === 'Fixed' &&
+          bonus.modifier.value === 2
+      )
+    ).toBe(true);
   });
 });

--- a/src/functions/general.ts
+++ b/src/functions/general.ts
@@ -1415,9 +1415,9 @@ export function getNewSpells(
   );
 }
 
-export function calculateMaxSpaces(forca: number): number {
-  if (forca < 0) return 10 + forca;
-  return 10 + 2 * forca;
+export function calculateMaxSpaces(attributeValue: number): number {
+  if (attributeValue < 0) return 10 + attributeValue;
+  return 10 + 2 * attributeValue;
 }
 
 // Soma os bônus de capacidade de carga (MaxSpaces) concedidos por equipamentos
@@ -1726,6 +1726,7 @@ export const applyPower = (
     selectFamiliar: ['FamiliarSelected'],
     selectWeaponSpecialization: ['WeaponSpecializationSelected'],
     selectAnimalTotem: ['AnimalTotemSelected'],
+    setMaxSpacesAttribute: ['MaxSpacesAttributeSet'],
   };
 
   const isActionAlreadyApplied = (
@@ -1929,6 +1930,14 @@ export const applyPower = (
         !forceApply &&
         isActionAlreadyApplied(sheetAction.action.type, powerOrAbility.name)
       ) {
+        if (sheetAction.action.type === 'setMaxSpacesAttribute') {
+          const { attribute } = sheetAction.action;
+          sheet.maxSpacesAttribute = attribute;
+          sheet.maxSpaces = calculateMaxSpaces(
+            sheet.atributos[attribute].value
+          );
+          return;
+        }
         // For chooseFromOptions, re-apply sheetBonuses from the chosen option
         // (sheetBonuses are cleared during recalculation, so they need to be re-added)
         if (sheetAction.action.type === 'chooseFromOptions') {
@@ -2072,7 +2081,16 @@ export const applyPower = (
         return;
       }
 
-      if (sheetAction.action.type === 'ModifyAttribute') {
+      if (sheetAction.action.type === 'setMaxSpacesAttribute') {
+        const { attribute } = sheetAction.action;
+        sheet.maxSpacesAttribute = attribute;
+        sheet.maxSpaces = calculateMaxSpaces(sheet.atributos[attribute].value);
+        sheet.sheetActionHistory.push({
+          source: sheetAction.source,
+          powerName: powerOrAbility.name,
+          changes: [{ type: 'MaxSpacesAttributeSet', attribute }],
+        });
+      } else if (sheetAction.action.type === 'ModifyAttribute') {
         const { attribute, value } = sheetAction.action;
         const newValue = sheet.atributos[attribute].value + value;
         sheet.atributos[attribute].value = newValue;

--- a/src/functions/general.ts
+++ b/src/functions/general.ts
@@ -176,6 +176,7 @@ import {
   applyMeioElfoAmbicaoHerdada,
   applyQareenResistenciaElemental,
   applyAlmaLivreSelectClass,
+  applyDiferentaoSelectClassPower,
   applyTeurgistaMistico,
   applyMashinChassi,
 } from './powers/special';
@@ -2858,6 +2859,13 @@ export const applyPower = (
           sheetAction.action.specialAction === 'almaLivreSelectClass'
         ) {
           currentSteps = applyAlmaLivreSelectClass(sheet, manualSelections);
+        } else if (
+          sheetAction.action.specialAction === 'diferentaoSelectClassPower'
+        ) {
+          currentSteps = applyDiferentaoSelectClassPower(
+            sheet,
+            manualSelections
+          );
         } else if (sheetAction.action.specialAction === 'teurgistaMistico') {
           currentSteps = applyTeurgistaMistico(sheet);
         } else if (sheetAction.action.specialAction === 'mashinChassi') {

--- a/src/functions/powers/manualPowerSelection.ts
+++ b/src/functions/powers/manualPowerSelection.ts
@@ -342,6 +342,19 @@ export function getPowerSelectionRequirements(
         });
       }
 
+      if (
+        action.type === 'special' &&
+        action.specialAction === 'diferentaoSelectClassPower'
+      ) {
+        requirements.push({
+          type: 'almaLivreSelectClass',
+          availableOptions: [],
+          pick: 1,
+          label: 'Selecione uma classe e um poder dessa classe',
+          metadata: { immediateClassPower: true },
+        });
+      }
+
       // Marcar perícias já treinadas (ex.: "Especialista" do Ladino). O `pick`
       // real é dinâmico (modificador do atributo, piso `min`) e só pode ser
       // calculado por quem tem a ficha — aqui vai o piso, e o atributo segue no

--- a/src/functions/powers/manualPowerSelection.ts
+++ b/src/functions/powers/manualPowerSelection.ts
@@ -969,8 +969,15 @@ export function countRequirementSelections(
       return selections?.chosenOption?.length ?? 0;
     case 'buildGolpePessoal':
       return selections?.golpePessoalBuild ? 1 : 0;
-    case 'almaLivreSelectClass':
-      return selections?.almaLivreClass && selections?.almaLivrePower ? 1 : 0;
+    case 'almaLivreSelectClass': {
+      const selectedClass = requirement.metadata?.immediateClassPower
+        ? selections?.diferentaoClass
+        : selections?.almaLivreClass;
+      const selectedPower = requirement.metadata?.immediateClassPower
+        ? selections?.diferentaoPower
+        : selections?.almaLivrePower;
+      return selectedClass && selectedPower ? 1 : 0;
+    }
 
     // Escolha em dois passos: ao selecionar a classe o campo já grava
     // `{ className, abilityName: '' }` para que a classe sobreviva à navegação
@@ -1120,13 +1127,16 @@ export function validateSelections(
 
       case 'almaLivreSelectClass': {
         // 1 class + 1 power
-        const hasClass = selections.almaLivreClass ? 1 : 0;
-        const hasPower = selections.almaLivrePower ? 1 : 0;
+        const selectedClass = requirement.metadata?.immediateClassPower
+          ? selections.diferentaoClass
+          : selections.almaLivreClass;
+        const selectedPower = requirement.metadata?.immediateClassPower
+          ? selections.diferentaoPower
+          : selections.almaLivrePower;
+        const hasClass = selectedClass ? 1 : 0;
+        const hasPower = selectedPower ? 1 : 0;
         selectedCount = hasClass && hasPower ? 1 : 0;
-        selectedItems = [
-          selections.almaLivreClass,
-          selections.almaLivrePower,
-        ].filter(Boolean);
+        selectedItems = [selectedClass, selectedPower].filter(Boolean);
         break;
       }
 

--- a/src/functions/powers/special.ts
+++ b/src/functions/powers/special.ts
@@ -750,6 +750,45 @@ export function applyAlmaLivreSelectClass(
   return substeps;
 }
 
+export function applyDiferentaoSelectClassPower(
+  sheet: CharacterSheet,
+  manualSelections?: SelectionOptions
+): SubStep[] {
+  const substeps: SubStep[] = [];
+  const selectedClass = manualSelections?.almaLivreClass;
+  const selectedPower = manualSelections?.almaLivrePower;
+
+  if (selectedClass && selectedPower) {
+    sheet.diferentaoClass = selectedClass;
+    sheet.diferentaoPower = selectedPower;
+  }
+
+  const power = sheet.diferentaoPower;
+  if (!power) return substeps;
+
+  const alreadyGranted = sheet.classPowers?.some(
+    (classPower) => classPower.name === power.name
+  );
+  if (!alreadyGranted) {
+    const grantedPower = { ...power, className: sheet.diferentaoClass };
+    sheet.classPowers = [...(sheet.classPowers || []), grantedPower];
+    sheet.sheetActionHistory.push({
+      source: { type: 'power', name: 'Diferentão (Kobolds)' },
+      powerName: 'Diferentão (Kobolds)',
+      changes: [{ type: 'ClassPowerAdded', powerName: grantedPower.name }],
+    });
+    const [updatedSheet, powerSubsteps] = applyPower(sheet, grantedPower);
+    Object.assign(sheet, updatedSheet);
+    substeps.push(...powerSubsteps);
+  }
+
+  substeps.unshift({
+    name: 'Diferentão (Kobolds)',
+    value: `Classe: ${sheet.diferentaoClass} — Poder: ${power.name}`,
+  });
+  return substeps;
+}
+
 export function applyTeurgistaMistico(sheet: CharacterSheet): SubStep[] {
   const substeps: SubStep[] = [];
 

--- a/src/functions/powers/special.ts
+++ b/src/functions/powers/special.ts
@@ -755,8 +755,23 @@ export function applyDiferentaoSelectClassPower(
   manualSelections?: SelectionOptions
 ): SubStep[] {
   const substeps: SubStep[] = [];
-  const selectedClass = manualSelections?.almaLivreClass;
-  const selectedPower = manualSelections?.almaLivrePower;
+  const selectedClass = manualSelections?.diferentaoClass;
+  const selectedPower = manualSelections?.diferentaoPower;
+
+  const diferentao = sheet.generalPowers?.some(
+    (power) => power.name === 'Diferentão (Kobolds)'
+  );
+  if (!diferentao && sheet.diferentaoPower) {
+    sheet.classPowers = (sheet.classPowers || []).filter(
+      (classPower) =>
+        !(
+          classPower.name === sheet.diferentaoPower?.name &&
+          classPower.className === sheet.diferentaoClass
+        )
+    );
+    sheet.diferentaoClass = undefined;
+    sheet.diferentaoPower = undefined;
+  }
 
   if (selectedClass && selectedPower) {
     sheet.diferentaoClass = selectedClass;
@@ -772,14 +787,6 @@ export function applyDiferentaoSelectClassPower(
   if (!alreadyGranted) {
     const grantedPower = { ...power, className: sheet.diferentaoClass };
     sheet.classPowers = [...(sheet.classPowers || []), grantedPower];
-    sheet.sheetActionHistory.push({
-      source: { type: 'power', name: 'Diferentão (Kobolds)' },
-      powerName: 'Diferentão (Kobolds)',
-      changes: [{ type: 'ClassPowerAdded', powerName: grantedPower.name }],
-    });
-    const [updatedSheet, powerSubsteps] = applyPower(sheet, grantedPower);
-    Object.assign(sheet, updatedSheet);
-    substeps.push(...powerSubsteps);
   }
 
   substeps.unshift({

--- a/src/functions/recalculateSheet.ts
+++ b/src/functions/recalculateSheet.ts
@@ -1891,7 +1891,9 @@ export function recalculateSheet(
   // Step 1: Clear existing bonuses to avoid accumulation
   updatedSheet.sheetBonuses = [];
 
-  // Step 1.5: Recalculate maxSpaces based on current Força modifier
+  // Step 1.5: Recalculate maxSpaces based on the default Força modifier.
+  // Powers that replace the attribute reapply their choice below.
+  updatedSheet.maxSpacesAttribute = undefined;
   updatedSheet.maxSpaces = calculateMaxSpaces(
     updatedSheet.atributos.Força.value
   );

--- a/src/functions/recalculateSheet.ts
+++ b/src/functions/recalculateSheet.ts
@@ -1891,11 +1891,13 @@ export function recalculateSheet(
   // Step 1: Clear existing bonuses to avoid accumulation
   updatedSheet.sheetBonuses = [];
 
-  // Step 1.5: Recalculate maxSpaces based on the default Força modifier.
-  // Powers that replace the attribute reapply their choice below.
-  updatedSheet.maxSpacesAttribute = undefined;
+  // Step 1.5: Recalculate maxSpaces from the manual attribute choice when
+  // present. Powers that replace the attribute reapply their choice below.
+  updatedSheet.maxSpacesAttribute = updatedSheet.manualMaxSpacesAttribute;
+  const baseMaxSpacesAttribute =
+    updatedSheet.manualMaxSpacesAttribute ?? Atributo.FORCA;
   updatedSheet.maxSpaces = calculateMaxSpaces(
-    updatedSheet.atributos.Força.value
+    updatedSheet.atributos[baseMaxSpacesAttribute].value
   );
 
   // Step 1.6: Reset extraArmorPenalty to avoid accumulation across recalculations
@@ -1934,6 +1936,15 @@ export function recalculateSheet(
   // e.g. Bard's Inspiração). Parallel pipeline to conditions — does not
   // replace it. Pushes SheetBonus entries for the main loop below.
   updatedSheet = applyActiveEffectBonuses(updatedSheet);
+
+  // A escolha explícita da mochila tem precedência sobre substituições de
+  // atributo concedidas por poderes.
+  if (updatedSheet.manualMaxSpacesAttribute) {
+    updatedSheet.maxSpacesAttribute = updatedSheet.manualMaxSpacesAttribute;
+    updatedSheet.maxSpaces = calculateMaxSpaces(
+      updatedSheet.atributos[updatedSheet.manualMaxSpacesAttribute].value
+    );
+  }
 
   // Step 7.47: Substituição de atributo em escopo de ficha (Usurpador, "Poder
   // de Clérigo": Sabedoria vira Carisma nos poderes de clérigo e concedidos).

--- a/src/functions/recalculateSheet.ts
+++ b/src/functions/recalculateSheet.ts
@@ -1888,6 +1888,26 @@ export function recalculateSheet(
     synthesizeHistoryForRemovedPowers(updatedSheet, removedPowerNames);
   }
 
+  // Diferentão grants a class power directly, so its removal does not pass
+  // through reverseSheetActionsForPower. Remove the granted power with the
+  // source talent instead of leaving it orphaned on the sheet.
+  if (
+    !updatedSheet.generalPowers?.some(
+      (power) => power.name === 'Diferentão (Kobolds)'
+    ) &&
+    updatedSheet.diferentaoPower
+  ) {
+    updatedSheet.classPowers = (updatedSheet.classPowers || []).filter(
+      (power) =>
+        !(
+          power.name === updatedSheet.diferentaoPower?.name &&
+          power.className === updatedSheet.diferentaoClass
+        )
+    );
+    updatedSheet.diferentaoClass = undefined;
+    updatedSheet.diferentaoPower = undefined;
+  }
+
   // Step 1: Clear existing bonuses to avoid accumulation
   updatedSheet.sheetBonuses = [];
 

--- a/src/interfaces/CharacterSheet.ts
+++ b/src/interfaces/CharacterSheet.ts
@@ -754,6 +754,7 @@ export default interface CharacterSheet {
   size: RaceSize;
   maxSpaces: number;
   maxSpacesAttribute?: Atributo;
+  manualMaxSpacesAttribute?: Atributo;
   customMaxSpaces?: number; // Manual override for max spaces
   customDisplacement?: number; // Manual override for displacement
   customSize?: RaceSize; // Manual override for size

--- a/src/interfaces/CharacterSheet.ts
+++ b/src/interfaces/CharacterSheet.ts
@@ -136,6 +136,7 @@ export type SheetActionStep =
         | 'meioElfoAmbicaoHerdada'
         | 'qareenResistenciaElemental'
         | 'almaLivreSelectClass'
+        | 'diferentaoSelectClassPower'
         | 'teurgistaMistico'
         | 'mashinChassi';
     }
@@ -848,6 +849,8 @@ export default interface CharacterSheet {
   removedProficiencias?: string[]; // Proficiências base removidas manualmente pelo usuário
   almaLivreClass?: string; // Classe escolhida pelo poder Alma Livre
   almaLivrePower?: ClassPower; // Poder pré-selecionado pelo poder Alma Livre
+  diferentaoClass?: string; // Classe escolhida pelo poder Diferentão
+  diferentaoPower?: ClassPower; // Poder escolhido pelo poder Diferentão
   poderesCapturados?: PoderCapturadoChoice[]; // Usurpador: Poder Capturado (4º nível)
   notes?: string; // Anotações livres do jogador
   imageUrl?: string; // URL de imagem do personagem

--- a/src/interfaces/CharacterSheet.ts
+++ b/src/interfaces/CharacterSheet.ts
@@ -120,6 +120,10 @@ export type SheetActionStep =
       optionKey?: string;
     }
   | {
+      type: 'setMaxSpacesAttribute';
+      attribute: Atributo;
+    }
+  | {
       type: 'special';
       specialAction:
         | 'humanoVersatil'
@@ -269,6 +273,10 @@ export type SheetActionReceipt =
       type: 'Attribute';
       attribute: Atributo;
       value: number; // Positive or negative
+    }
+  | {
+      type: 'MaxSpacesAttributeSet';
+      attribute: Atributo;
     }
   | {
       type: 'SkillsAdded';
@@ -745,6 +753,7 @@ export default interface CharacterSheet {
   displacement: number;
   size: RaceSize;
   maxSpaces: number;
+  maxSpacesAttribute?: Atributo;
   customMaxSpaces?: number; // Manual override for max spaces
   customDisplacement?: number; // Manual override for displacement
   customSize?: RaceSize; // Manual override for size

--- a/src/interfaces/PowerSelections.ts
+++ b/src/interfaces/PowerSelections.ts
@@ -95,6 +95,7 @@ export interface PowerSelectionRequirement {
     schools?: string[];
     optionKey?: string; // For chooseFromOptions: the option key identifier
     linkedTo?: string; // For chooseFromOptions: linked to another option choice
+    immediateClassPower?: boolean; // Diferentão grants the selected power now
     minLevel?: number; // For getClassPower: nível em que os requisitos são avaliados
     abilityLevel?: number; // For learnClassAbility: nível das habilidades elegíveis
     // For markTrainedSkills: o `pick` real é o modificador deste atributo, com

--- a/src/interfaces/PowerSelections.ts
+++ b/src/interfaces/PowerSelections.ts
@@ -26,6 +26,8 @@ export interface SelectionOptions {
   raceAbilities?: Array<{ raceName: string; abilityName: string }>; // Race ability selections for Memória Póstuma
   almaLivreClass?: string; // Classe escolhida pelo poder Alma Livre
   almaLivrePower?: ClassPower; // Poder pré-selecionado pelo poder Alma Livre
+  diferentaoClass?: string; // Classe escolhida pelo poder Diferentão
+  diferentaoPower?: ClassPower; // Poder escolhido pelo poder Diferentão
   alchemyItems?: Equipment[]; // Selected alchemy items for addAlchemyItems action
   golpePessoalBuild?: GolpePessoalBuild; // Build do Golpe Pessoal montado no assistente
 }


### PR DESCRIPTION
## 📋 Descrição

Pequenos fixes e ajustes pra Kobolds, Ladino, e outras bobagens.

* Ladino Mente Criminosa corrigido de Requerimento 1 de DES pra 1 de INT
* Talento de Kobolds "Organizadinhos" agora usa a DES pra limite de equipamento
   * O mesma implementação pra uma poder lá de Valkaria que usa SAB no limite de equipamento
   * Agora existe um picker na mochila, junto do dinheiro, utilizado pra dizer qual atributo usar.
* Kobolds "Diferentão" agora permite pegar um poder como esperado (reutiliza a UI de Alma Livre com alguns ajustes)
* Kobolds "Ex-familiar" agora abre o wizard pra escolher qual familiar pegar assim como no arcanista.
* Fix no typo de uma das habilidades "Praça" -> "Praga"
* Corrigido pré-requisito de Gatuno

## 🎯 Tipo de Mudança

- [x] Bug fix
- [ ] Nova funcionalidade
- [ ] Melhoria de código
- [ ] Documentação

## 🧪 Testes

- [ ] Testes passando
- [x] Novos testes adicionados
- [~] Testado manualmente

## 📱 Screenshots

[Se aplicável, inclua imagens das mudanças]