### PR TITLE
Fix: Texto de rendição de Gnoll

### DIFF
--- a/src/data/systems/tormenta20/ameacas-de-arton/races/gnoll.ts
+++ b/src/data/systems/tormenta20/ameacas-de-arton/races/gnoll.ts
@@ -57,7 +57,7 @@ const GNOLL: Race = {
     {
       name: 'Rendição',
       description:
-        'Quando um inimigo se rende, você recebe 1d PM temporários cumulativos. Da mesma forma, quando é reduzido a um quarto de seus PV ou menos, seu instinto é se render. Caso continue lutando, fica abalroado.',
+        'Quando um inimigo se rende, você recebe 1d4 PM temporários cumulativos. Da mesma forma, quando é reduzido a um quarto de seus PV ou menos, seu instinto é se render. Caso continue lutando, fica Alquebrado.',
     },
   ],
 };


### PR DESCRIPTION
Fix de uma linha de descrição de habilidade

https://fichasdenimb.com.br/forum/rendicao-da-raca-gnoll-esta-mal-escrita