### PR TITLE
Fix/abilities prerequisites

### DIFF
--- a/src/__tests__/components/LevelUpWizardModal.test.tsx
+++ b/src/__tests__/components/LevelUpWizardModal.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import LevelUpWizardModal from '@/components/LevelUpWizard/LevelUpWizardModal';
+import { dataRegistry } from '@/data/registry';
+import { createMockCharacterSheet } from '@/__mocks__/characterSheet';
+import { SupplementId } from '@/types/supplement.types';
+
+vi.mock('@/hooks/useFeatureAccess', () => ({
+  useFeatureAccess: () => ({
+    hasAccess: false,
+    isEnabled: false,
+    isLoading: false,
+    supporterOnly: false,
+  }),
+}));
+
+const ACTIVE_SUPPLEMENTS = [
+  SupplementId.TORMENTA20_CORE,
+  SupplementId.TORMENTA20_HEROIS_ARTON,
+];
+
+describe('LevelUpWizardModal — pré-requisitos do nível atual', () => {
+  it('libera poderes que exigem poder concedido por habilidade do mesmo nível', () => {
+    const sheet = createMockCharacterSheet();
+    const alquimista = dataRegistry.getClassByName(
+      'Alquimista',
+      ACTIVE_SUPPLEMENTS
+    );
+    if (!alquimista) throw new Error('Alquimista não encontrado no registry');
+
+    sheet.nivel = 1;
+    sheet.classe = alquimista;
+    sheet.classLevels = [{ level: 1, className: 'Alquimista' }];
+
+    render(
+      <LevelUpWizardModal
+        open
+        initialSheet={sheet}
+        targetLevel={2}
+        supplements={ACTIVE_SUPPLEMENTS}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Próximo' }));
+
+    expect(screen.getByText('Alquimista Exímio')).toBeInTheDocument();
+    expect(screen.queryByText('Indisponível')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/functions/powerAbilityRequirements.test.ts
+++ b/src/__tests__/functions/powerAbilityRequirements.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { isPowerAvailable } from '../../functions/powers';
+import { createMockCharacterSheet } from '../../__mocks__/characterSheet';
+import LUTADOR from '../../data/systems/tormenta20/classes/lutador';
+import combatPowers from '../../data/systems/tormenta20/herois-de-arton/powers/combatPowers';
+
+const buildLutadorSheet = (nivel: number) => {
+  const sheet = createMockCharacterSheet();
+
+  sheet.nivel = nivel;
+  sheet.classe = {
+    ...LUTADOR,
+    abilities: LUTADOR.abilities.filter((ability) => ability.nivel <= nivel),
+  };
+
+  return sheet;
+};
+
+describe('pré-requisitos PODER referenciando habilidades de classe', () => {
+  it('libera Briga de Rua para um Lutador com Briga (habilidade automática do 1º nível)', () => {
+    const sheet = buildLutadorSheet(3);
+
+    expect(isPowerAvailable(sheet, combatPowers.BRIGA_DE_RUA)).toBe(true);
+  });
+
+  it('não libera Briga de Rua antes da habilidade Briga estar disponível', () => {
+    const sheet = buildLutadorSheet(3);
+    sheet.classe = { ...sheet.classe, abilities: [] };
+
+    expect(isPowerAvailable(sheet, combatPowers.BRIGA_DE_RUA)).toBe(false);
+  });
+});

--- a/src/__tests__/functions/powerSkillRequirements.test.ts
+++ b/src/__tests__/functions/powerSkillRequirements.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { getAllowedClassPowers } from '../../functions/powers';
+import { createMockCharacterSheet } from '../../__mocks__/characterSheet';
+import CAVALEIRO from '../../data/systems/tormenta20/classes/cavaleiro';
+import CAVALEIRO_HEROIS_POWERS from '../../data/systems/tormenta20/herois-de-arton/classPowers/cavaleiro';
+import Skill from '../../interfaces/Skills';
+
+const buildCavaleiroSheet = () => {
+  const sheet = createMockCharacterSheet();
+
+  sheet.nivel = 3;
+  sheet.classe = {
+    ...CAVALEIRO,
+    powers: [...CAVALEIRO.powers, ...CAVALEIRO_HEROIS_POWERS],
+  };
+  sheet.skills = sheet.skills.filter((skill) => skill !== Skill.RELIGIAO);
+  sheet.completeSkills = sheet.completeSkills?.map((skill) =>
+    skill.name === Skill.RELIGIAO ? { ...skill, training: 0 } : skill
+  );
+
+  return sheet;
+};
+
+const powerNames = (sheet: ReturnType<typeof buildCavaleiroSheet>) =>
+  getAllowedClassPowers(sheet, { classLevel: 4 }).map((power) => power.name);
+
+describe('pré-requisitos de perícia em poderes', () => {
+  it('não libera Cavaleiro Sagrado sem Religião treinada', () => {
+    expect(powerNames(buildCavaleiroSheet())).not.toContain(
+      'Cavaleiro Sagrado'
+    );
+  });
+
+  it('libera Cavaleiro Sagrado quando Religião foi treinada manualmente', () => {
+    const sheet = buildCavaleiroSheet();
+    sheet.completeSkills = sheet.completeSkills?.map((skill) =>
+      skill.name === Skill.RELIGIAO ? { ...skill, training: 2 } : skill
+    );
+
+    expect(sheet.skills).not.toContain(Skill.RELIGIAO);
+    expect(powerNames(sheet)).toContain('Cavaleiro Sagrado');
+  });
+
+  it('não libera pré-requisito quando a perícia base foi destreinada manualmente', () => {
+    const sheet = buildCavaleiroSheet();
+    sheet.skills = [...sheet.skills, Skill.RELIGIAO];
+    sheet.completeSkills = sheet.completeSkills?.map((skill) =>
+      skill.name === Skill.RELIGIAO
+        ? { ...skill, training: 0, manuallyUntrained: true }
+        : skill
+    );
+
+    expect(powerNames(sheet)).not.toContain('Cavaleiro Sagrado');
+  });
+});

--- a/src/components/LevelUpWizard/LevelUpWizardModal.tsx
+++ b/src/components/LevelUpWizard/LevelUpWizardModal.tsx
@@ -38,7 +38,7 @@ import {
   getCurrentPlateau,
   getDeityMaxSpellCircleFor,
 } from '@/functions/powers/general';
-import { isClassOrVariantOf } from '@/functions/general';
+import { applyPower, isClassOrVariantOf } from '@/functions/general';
 import { Atributo } from '@/data/systems/tormenta20/atributos';
 import {
   getClassLevel,
@@ -1435,6 +1435,54 @@ const LevelUpWizardModal: React.FC<LevelUpWizardModalProps> = ({
             ...(nextSheet.generalPowers || []),
             currentLevelSelection.selectedGeneralPower,
           ];
+        }
+
+        // Aplica as habilidades de classe que estreiam neste nível ao sheet
+        // simulado. Sem isto, poderes concedidos por habilidade (ex.:
+        // "Alquimista Iniciado" via grantSpecificClassPower) e pré-requisitos
+        // de HABILIDADE (ex.: "Duelo" p/ "Cavaleiro Bandido") nunca aparecem
+        // satisfeitos durante uma criação de múltiplos níveis — só depois que
+        // a ficha já está instanciada, quando `applyManualLevelUp` reaplica
+        // tudo de verdade a partir do zero.
+        const abilitiesThisLevel = getAbilitiesForCurrentLevel();
+        abilitiesThisLevel.forEach((ability) => {
+          const [abilitySheet] = applyPower(
+            nextSheet,
+            { ...ability, sourceClassName: selectedClassName },
+            currentLevelSelection.abilityEffectSelections?.[ability.name]
+          );
+          if (abilitySheet) {
+            nextSheet.classPowers = abilitySheet.classPowers;
+            nextSheet.generalPowers = abilitySheet.generalPowers;
+            nextSheet.spells = abilitySheet.spells;
+            nextSheet.sheetActionHistory = abilitySheet.sheetActionHistory;
+            nextSheet.skills = abilitySheet.skills;
+            nextSheet.completeSkills = abilitySheet.completeSkills;
+            nextSheet.sheetBonuses = abilitySheet.sheetBonuses;
+            nextSheet.atributos = abilitySheet.atributos;
+            nextSheet.classe = {
+              ...nextSheet.classe,
+              proficiencias: abilitySheet.classe.proficiencias,
+            };
+          }
+        });
+
+        if (abilitiesThisLevel.length > 0) {
+          const originalAbilities =
+            nextSheet.classe.originalAbilities || nextSheet.classe.abilities;
+          const newPrimaryClassLevel = getClassLevel(
+            nextSheet,
+            nextSheet.classe.name
+          );
+          const allAvailableAbilities = originalAbilities.filter(
+            (ability) => ability.nivel <= newPrimaryClassLevel
+          );
+          // Multiclasse: habilidades de classe secundária não estão em
+          // `originalAbilities` (que é só da classe primária) — anexa direto.
+          if (selectedClassName !== nextSheet.classe.name) {
+            allAvailableAbilities.push(...abilitiesThisLevel);
+          }
+          nextSheet.classe.abilities = allAvailableAbilities;
         }
 
         // Add selected spells to the simulated sheet

--- a/src/components/LevelUpWizard/LevelUpWizardModal.tsx
+++ b/src/components/LevelUpWizard/LevelUpWizardModal.tsx
@@ -205,6 +205,73 @@ const LevelUpWizardModal: React.FC<LevelUpWizardModalProps> = ({
     nivel: currentLevel,
   };
 
+  // Habilidades da classe que está subindo de nível. As injetadas no setup
+  // (linhagens do Feiticeiro) vivem na FICHA, não na entrada do registry — por
+  // isso a mescla. Fonte única do passo "Efeitos de Habilidades": detecção,
+  // render e validação.
+  const getMergedClassAbilities = (): ClassAbility[] => [
+    ...getBaseAbilitiesForLevelUp(
+      simulatedSheet.classe,
+      selectedClassDesc,
+      selectedClassName
+    ),
+    ...getClassSetupAbilities(
+      selectedClassName,
+      currentLevelSelection.classSetup
+    ),
+  ];
+
+  // Só as que estreiam neste nível de CLASSE (importa na multiclasse).
+  const getAbilitiesForCurrentLevel = (): ClassAbility[] =>
+    getMergedClassAbilities().filter(
+      (ability) => ability.nivel === selectedClassLevel
+    );
+
+  const getSheetWithCurrentLevelAbilities = (
+    baseSheet: CharacterSheet
+  ): CharacterSheet => {
+    const abilitiesThisLevel = getAbilitiesForCurrentLevel();
+    if (abilitiesThisLevel.length === 0) return baseSheet;
+
+    let nextSheet = baseSheet;
+
+    abilitiesThisLevel.forEach((ability) => {
+      const requirements = getPowerSelectionRequirements(ability);
+      if (requirements !== null) return;
+
+      const [abilitySheet] = applyPower(nextSheet, {
+        ...ability,
+        sourceClassName: selectedClassName,
+      });
+      if (abilitySheet) {
+        nextSheet = {
+          ...abilitySheet,
+          classe: {
+            ...abilitySheet.classe,
+            abilities: nextSheet.classe.abilities,
+          },
+        };
+      }
+    });
+
+    const knownAbilityNames = new Set(
+      (nextSheet.classe.abilities || []).map((ability) => ability.name)
+    );
+    const projectedAbilities = abilitiesThisLevel.filter(
+      (ability) => !knownAbilityNames.has(ability.name)
+    );
+
+    if (projectedAbilities.length === 0) return nextSheet;
+
+    return {
+      ...nextSheet,
+      classe: {
+        ...nextSheet.classe,
+        abilities: [...nextSheet.classe.abilities, ...projectedAbilities],
+      },
+    };
+  };
+
   // Companheiro com os truques pendentes da OUTRA razão (auto/power) deste
   // nível projetados sobre os truques já refletidos no simulatedSheet — evita
   // escolher o mesmo truque não-repetível nos dois steps do mesmo nível
@@ -242,6 +309,9 @@ const LevelUpWizardModal: React.FC<LevelUpWizardModalProps> = ({
     generalPowers: GeneralPower[];
     unavailableGeneralPowers: string[];
   } => {
+    const sheetForPowerSelection =
+      getSheetWithCurrentLevelAbilities(sheetForCurrentLevel);
+
     // Get class with merged supplement powers from registry
     // Use the SELECTED class for power filtering (multiclass support)
     const classNameForPowers = selectedClassName;
@@ -254,18 +324,18 @@ const LevelUpWizardModal: React.FC<LevelUpWizardModalProps> = ({
     const classForFiltering = classWithSupplementPowers || selectedClassDesc;
     const sheetForFiltering: CharacterSheet = classForFiltering
       ? {
-          ...sheetForCurrentLevel,
+          ...sheetForPowerSelection,
           classe: {
-            ...sheetForCurrentLevel.classe,
+            ...sheetForPowerSelection.classe,
             name: classNameForPowers,
             powers: classForFiltering.powers,
             proficiencias:
-              sheetForCurrentLevel.classe.proficiencias ||
+              sheetForPowerSelection.classe.proficiencias ||
               classForFiltering.proficiencias ||
               [],
           },
         }
-      : sheetForCurrentLevel;
+      : sheetForPowerSelection;
 
     // Get class powers using the selected class's powers.
     // Sempre usar getAllowedClassPowers na lista manual: a ponderação do
@@ -289,12 +359,12 @@ const LevelUpWizardModal: React.FC<LevelUpWizardModalProps> = ({
       ...allPowers.MAGIA,
       ...allPowers.TORMENTA,
       ...allPowers.RACA.filter((power) =>
-        isPowerAvailable(sheetForCurrentLevel, power)
+        isPowerAvailable(sheetForFiltering, power)
       ),
     ];
 
     // Track which powers are unavailable (requirements not met)
-    const existingGeneralPowers = sheetForCurrentLevel.generalPowers;
+    const existingGeneralPowers = sheetForFiltering.generalPowers;
     const unavailableGeneralPowers: string[] = [];
     const generalPowers = allGeneralPowers.filter((power) => {
       const isRepeatedPower = existingGeneralPowers.find(
@@ -305,7 +375,7 @@ const LevelUpWizardModal: React.FC<LevelUpWizardModalProps> = ({
         return true; // Keep in list; isPowerKnown handles disable in UI
       }
 
-      if (!isPowerAvailable(sheetForCurrentLevel, power)) {
+      if (!isPowerAvailable(sheetForFiltering, power)) {
         unavailableGeneralPowers.push(power.name);
       }
       return true; // Always include
@@ -493,28 +563,6 @@ const LevelUpWizardModal: React.FC<LevelUpWizardModalProps> = ({
     const requirements = getPowerSelectionRequirements(power);
     return requirements !== null && requirements.requirements.length > 0;
   };
-
-  // Habilidades da classe que está subindo de nível. As injetadas no setup
-  // (linhagens do Feiticeiro) vivem na FICHA, não na entrada do registry — por
-  // isso a mescla. Fonte única do passo "Efeitos de Habilidades": detecção,
-  // render e validação.
-  const getMergedClassAbilities = (): ClassAbility[] => [
-    ...getBaseAbilitiesForLevelUp(
-      simulatedSheet.classe,
-      selectedClassDesc,
-      selectedClassName
-    ),
-    ...getClassSetupAbilities(
-      selectedClassName,
-      currentLevelSelection.classSetup
-    ),
-  ];
-
-  // Só as que estreiam neste nível de CLASSE (importa na multiclasse).
-  const getAbilitiesForCurrentLevel = (): ClassAbility[] =>
-    getMergedClassAbilities().filter(
-      (ability) => ability.nivel === selectedClassLevel
-    );
 
   // Check if class abilities for this level need effect selections
   const needsAbilityEffectSelections = (): boolean =>
@@ -936,20 +984,22 @@ const LevelUpWizardModal: React.FC<LevelUpWizardModalProps> = ({
       case 'Escolha de Poder': {
         const { classPowers, generalPowers, unavailableGeneralPowers } =
           getAvailablePowers();
+        const sheetForPowerSelection =
+          getSheetWithCurrentLevelAbilities(sheetForCurrentLevel);
 
         // Get known powers from simulated sheet (powers already added to the sheet)
         const knownClassPowers =
-          simulatedSheet.classPowers?.map((p) => p.name) || [];
+          sheetForPowerSelection.classPowers?.map((p) => p.name) || [];
         const knownGeneralPowers = [
-          ...(simulatedSheet.generalPowers?.map((p) => p.name) || []),
-          ...(simulatedSheet.raca.abilities?.map((a) => a.name) || []),
+          ...(sheetForPowerSelection.generalPowers?.map((p) => p.name) || []),
+          ...(sheetForPowerSelection.raca.abilities?.map((a) => a.name) || []),
         ];
 
         // Alma Livre detection: check if the character has a pre-selected power
         // that hasn't been acquired yet
-        const almaLivrePower = simulatedSheet.almaLivrePower || null;
-        const almaLivreClassName = simulatedSheet.almaLivreClass;
-        const almaLivrePowerAcquired = simulatedSheet.classPowers?.some(
+        const almaLivrePower = sheetForPowerSelection.almaLivrePower || null;
+        const almaLivreClassName = sheetForPowerSelection.almaLivreClass;
+        const almaLivrePowerAcquired = sheetForPowerSelection.classPowers?.some(
           (p) => p.name === almaLivrePower?.name
         );
         const showAlmaLivre =
@@ -959,7 +1009,7 @@ const LevelUpWizardModal: React.FC<LevelUpWizardModalProps> = ({
         let almaLivrePowerAvailable = false;
         if (showAlmaLivre && almaLivrePower) {
           const almaLivreSheet = {
-            ...simulatedSheet,
+            ...sheetForPowerSelection,
             nivel: Math.max(1, currentLevel - 4),
           };
           almaLivrePowerAvailable = isPowerAvailable(

--- a/src/components/LevelUpWizard/LevelUpWizardModal.tsx
+++ b/src/components/LevelUpWizard/LevelUpWizardModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -272,6 +272,14 @@ const LevelUpWizardModal: React.FC<LevelUpWizardModalProps> = ({
     };
   };
 
+  // O cálculo acima faz um `cloneDeep` da ficha por habilidade (via
+  // `applyPower`); memoizado para não rodar duas vezes no mesmo render
+  // (aqui e em `getAvailablePowers`) nem a cada re-render sem mudança real.
+  const sheetWithCurrentLevelAbilities = useMemo(
+    () => getSheetWithCurrentLevelAbilities(sheetForCurrentLevel),
+    [sheetForCurrentLevel, selectedClassName, selectedClassLevel]
+  );
+
   // Companheiro com os truques pendentes da OUTRA razão (auto/power) deste
   // nível projetados sobre os truques já refletidos no simulatedSheet — evita
   // escolher o mesmo truque não-repetível nos dois steps do mesmo nível
@@ -304,14 +312,13 @@ const LevelUpWizardModal: React.FC<LevelUpWizardModalProps> = ({
     classNeedsFirstLevelSetup(selectedClassDesc);
 
   // Get available powers for current simulated sheet
-  const getAvailablePowers = (): {
+  const getAvailablePowers = (
+    sheetForPowerSelection: CharacterSheet
+  ): {
     classPowers: ClassPower[];
     generalPowers: GeneralPower[];
     unavailableGeneralPowers: string[];
   } => {
-    const sheetForPowerSelection =
-      getSheetWithCurrentLevelAbilities(sheetForCurrentLevel);
-
     // Get class with merged supplement powers from registry
     // Use the SELECTED class for power filtering (multiclass support)
     const classNameForPowers = selectedClassName;
@@ -982,10 +989,9 @@ const LevelUpWizardModal: React.FC<LevelUpWizardModalProps> = ({
       }
 
       case 'Escolha de Poder': {
+        const sheetForPowerSelection = sheetWithCurrentLevelAbilities;
         const { classPowers, generalPowers, unavailableGeneralPowers } =
-          getAvailablePowers();
-        const sheetForPowerSelection =
-          getSheetWithCurrentLevelAbilities(sheetForCurrentLevel);
+          getAvailablePowers(sheetForPowerSelection);
 
         // Get known powers from simulated sheet (powers already added to the sheet)
         const knownClassPowers =

--- a/src/functions/powers.ts
+++ b/src/functions/powers.ts
@@ -52,7 +52,11 @@ export function getPowerCountInCurrentTier(
 }
 
 /**
- * Reúne todos os poderes que o personagem possui (gerais, de origem e de classe).
+ * Reúne todos os poderes que o personagem possui (gerais, de origem, de
+ * classe escolhidos e habilidades de classe concedidas automaticamente —
+ * ex.: Briga do Lutador, referenciada como pré-requisito PODER em Briga de
+ * Rua). `classe.abilities` já vem filtrada pelo nível da classe em
+ * `applyClassAbilities`, então não inclui habilidades futuras.
  * Retorna apenas o que os checadores de requisito consomem (o nome).
  */
 function getAllCharacterPowers(sheet: CharacterSheet): { name: string }[] {
@@ -60,6 +64,7 @@ function getAllCharacterPowers(sheet: CharacterSheet): { name: string }[] {
     ...sheet.generalPowers,
     ...(sheet.origin?.powers || []),
     ...(sheet.classPowers || []),
+    ...(sheet.classe.abilities || []),
   ];
 }
 

--- a/src/functions/powers.ts
+++ b/src/functions/powers.ts
@@ -90,6 +90,22 @@ export function applyRequirementNot(rule: Requirement, met: boolean): boolean {
   return rule.not ? !met : met;
 }
 
+function getTrainedSkillNames(sheet: CharacterSheet): string[] {
+  const skillNames = new Set<string>();
+  const completeSkillNames = new Set<string>();
+
+  sheet.completeSkills?.forEach((skill) => {
+    completeSkillNames.add(skill.name);
+    if ((skill.training ?? 0) > 0) skillNames.add(skill.name);
+  });
+
+  sheet.skills
+    .filter((skill) => !completeSkillNames.has(skill))
+    .forEach((skill) => skillNames.add(skill));
+
+  return [...skillNames];
+}
+
 /** Avalia um único requisito, ignorando a flag `not` (aplicada por quem chama). */
 function evaluateRule(sheet: CharacterSheet, rule: Requirement): boolean {
   switch (rule.type) {
@@ -123,14 +139,16 @@ function evaluateRule(sheet: CharacterSheet, rule: Requirement): boolean {
       return !!rule.name && sheet.atributos[attr].value >= (rule?.value || 0);
     }
     case RequirementType.PERICIA: {
+      const trainedSkills = getTrainedSkillNames(sheet);
+
       if (isGenericOficio(rule.name)) {
         // isOficioSkill (e não a lista fechada) para que um Ofício
         // customizado também satisfaça o pré-requisito genérico
-        return sheet.skills.some(isOficioSkill);
+        return trainedSkills.some(isOficioSkill);
       }
 
       const pericia = rule.name as Skill;
-      if (rule.name && sheet.skills.includes(pericia)) return true;
+      if (rule.name && trainedSkills.includes(pericia)) return true;
 
       // Artesão Criativo: Ofício (Artesão) substitui qualquer outro Ofício
       // específico para fins de pré-requisito.
@@ -140,7 +158,7 @@ function evaluateRule(sheet: CharacterSheet, rule: Requirement): boolean {
         );
         if (
           hasArtesaoCriativo &&
-          sheet.skills.includes(Skill.OFICIO_ARTESANATO)
+          trainedSkills.includes(Skill.OFICIO_ARTESANATO)
         ) {
           return true;
         }

--- a/src/functions/powers.ts
+++ b/src/functions/powers.ts
@@ -92,16 +92,17 @@ export function applyRequirementNot(rule: Requirement, met: boolean): boolean {
 
 function getTrainedSkillNames(sheet: CharacterSheet): string[] {
   const skillNames = new Set<string>();
-  const completeSkillNames = new Set<string>();
+
+  // Base da criação de personagem. Vários caminhos (poderes raciais, origens,
+  // escolhas de classe) fazem `skills.push` sem tocar em `completeSkills`.
+  sheet.skills.forEach((skill) => skillNames.add(skill));
 
   sheet.completeSkills?.forEach((skill) => {
-    completeSkillNames.add(skill.name);
+    // Treino manual pelo SkillsEditDrawer, que só escreve em `completeSkills`.
     if ((skill.training ?? 0) > 0) skillNames.add(skill.name);
+    // Destreino manual explícito vence a base da criação.
+    else if (skill.manuallyUntrained) skillNames.delete(skill.name);
   });
-
-  sheet.skills
-    .filter((skill) => !completeSkillNames.has(skill))
-    .forEach((skill) => skillNames.add(skill));
 
   return [...skillNames];
 }


### PR DESCRIPTION
Fix para https://github.com/YuriAlessandro/fichas-de-nimb-backend/issues/94

## 📋 Descrição

Fix: Habilidades adquiridas automaticamente no nível up não serviam de requerimento pra outros poderes na criação de personagem
Fix: Adicionar perícias numa ficha já construída não liberava poderes que tinham essa perícia como pré-requisito. Ex: Adicionar Religião a um Cavaleiro não liberava Cavaleiro Sagrado

## 🎯 Tipo de Mudança

- [x] Bug fix
- [ ] Nova funcionalidade
- [ ] Melhoria de código
- [ ] Documentação

## 🧪 Testes

- [x] Testes passando
- [x] Novos testes adicionados
- [x] Testado manualmente
