### PR TITLE
Fix: Adicionar mais rolagens para magias

### DIFF
--- a/src/components/SpellCastDialog.tsx
+++ b/src/components/SpellCastDialog.tsx
@@ -886,9 +886,13 @@ const SpellCastDialog: React.FC<SpellCastDialogProps> = ({
                           </Typography>
                           {roll.isAugmented && (
                             <Chip
-                              label={`${roll.baseDice} ${
-                                roll.addedSummary ?? ''
-                              }`.trim()}
+                              label={`${roll.baseDice}${
+                                roll.replacementDice
+                                  ? ` -> ${roll.replacementDice}`
+                                  : ''
+                              }${
+                                roll.addedSummary ? ` ${roll.addedSummary}` : ''
+                              }`}
                               size='small'
                               color='primary'
                               variant='outlined'

--- a/src/data/systems/tormenta20/ameacas-de-arton/spells.ts
+++ b/src/data/systems/tormenta20/ameacas-de-arton/spells.ts
@@ -1,3 +1,4 @@
+import { v4 as uuid } from 'uuid';
 import { Spell, spellsCircles } from '../../../../interfaces/Spells';
 import { SupplementSpells } from '../core';
 
@@ -25,6 +26,13 @@ const AMEACAS_ARTON_ARCANE_SPELLS: Spell[] = [
         text: 'aumenta o número de alvos em +1 (total de alvos limitado pelo círculo máximo de magia que você pode lançar).',
       },
     ],
+    rolls: [
+      {
+        id: uuid(),
+        label: 'Dano de Fogo',
+        dice: '2d6',
+      },
+    ],
   },
   {
     nome: 'Dardo Gélido',
@@ -41,10 +49,18 @@ const AMEACAS_ARTON_ARCANE_SPELLS: Spell[] = [
       {
         addPm: 1,
         text: 'aumenta o dano em +1d6.',
+        damageBonus: [{ dicePerActivation: '1d6' }],
       },
       {
         addPm: 1,
         text: 'aumenta o número de alvos em +1 (total de alvos limitado pelo círculo máximo de magia que você pode lançar).',
+      },
+    ],
+    rolls: [
+      {
+        id: uuid(),
+        label: 'Dano de Frio',
+        dice: '2d6',
       },
     ],
   },
@@ -60,6 +76,13 @@ const AMEACAS_ARTON_ARCANE_SPELLS: Spell[] = [
     description:
       'Você dispara um jato, que causa 2d6 pontos de dano de ácido às criaturas na área. Contra construtos e objetos soltos, a magia causa +1 ponto de dano por dado.',
     aprimoramentos: [],
+    rolls: [
+      {
+        id: uuid(),
+        label: 'Dano de Ácido',
+        dice: '2d6',
+      },
+    ],
   },
 
   // 2º CÍRCULO (1 magia)
@@ -99,6 +122,7 @@ const AMEACAS_ARTON_ARCANE_SPELLS: Spell[] = [
       {
         addPm: 2,
         text: 'aumenta o dano do sopro em +1d6+1.',
+        damageBonus: [{ dicePerActivation: '1d6+1' }],
       },
       {
         addPm: 2,
@@ -115,6 +139,13 @@ const AMEACAS_ARTON_ARCANE_SPELLS: Spell[] = [
       {
         addPm: 3,
         text: 'o bônus em atributos se torna +4.',
+      },
+    ],
+    rolls: [
+      {
+        id: uuid(),
+        label: 'Sopro Dracônico',
+        dice: '8d6+8',
       },
     ],
   },
@@ -138,10 +169,26 @@ const AMEACAS_ARTON_DIVINE_SPELLS: Spell[] = [
       {
         addPm: 3,
         text: 'aumenta o dano em +2d8 (ou +2d12 contra mortos-vivos).',
+        damageBonus: [
+          { targetRollLabel: 'normal', dicePerActivation: '2d8' },
+          { targetRollLabel: 'mortos-vivos', dicePerActivation: '2d12' },
+        ],
       },
       {
         addPm: 6,
         text: 'muda a área para uma linha de 120m ou quatro linhas de 30m em direções opostas, formando um "X".',
+      },
+    ],
+    rolls: [
+      {
+        id: uuid(),
+        label: 'Dano de Luz (normal)',
+        dice: '12d8',
+      },
+      {
+        id: uuid(),
+        label: 'Dano de Luz (mortos-vivos)',
+        dice: '12d12',
       },
     ],
   },
@@ -165,6 +212,12 @@ const AMEACAS_ARTON_UNIVERSAL_SPELLS: Spell[] = [
       {
         addPm: 3,
         text: 'aumenta o dano em +1 dado do mesmo tipo.',
+        damageBonus: [
+          { targetRollLabel: 'chuva ácida', dicePerActivation: '1d4' },
+          { targetRollLabel: 'neblina venenosa', dicePerActivation: '1d12' },
+          { targetRollLabel: 'raios escarlates', dicePerActivation: '1d8' },
+          { targetRollLabel: 'pesadelos reais', dicePerActivation: '1d6' },
+        ],
       },
       {
         addPm: 5,
@@ -173,6 +226,32 @@ const AMEACAS_ARTON_UNIVERSAL_SPELLS: Spell[] = [
       {
         addPm: 5,
         text: '(Apenas Devotos de Aharadak): muda a área para círculo de 1km de raio.',
+      },
+    ],
+    rolls: [
+      {
+        id: uuid(),
+        label: 'Chuva Ácida',
+        dice: '6d4',
+        damageType: 'ácido',
+      },
+      {
+        id: uuid(),
+        label: 'Neblina Venenosa',
+        dice: '2d12',
+        damageType: 'veneno',
+      },
+      {
+        id: uuid(),
+        label: 'Raios Escarlates',
+        dice: '6d8',
+        damageType: 'eletricidade',
+      },
+      {
+        id: uuid(),
+        label: 'Pesadelos Reais',
+        dice: '4d6',
+        damageType: 'psíquico',
       },
     ],
   },

--- a/src/data/systems/tormenta20/ameacas-de-arton/spells.ts
+++ b/src/data/systems/tormenta20/ameacas-de-arton/spells.ts
@@ -49,7 +49,7 @@ const AMEACAS_ARTON_ARCANE_SPELLS: Spell[] = [
       {
         addPm: 1,
         text: 'aumenta o dano em +1d6.',
-        damageBonus: [{ dicePerActivation: '1d6' }],
+        damageBonus: [{ diceCount: 1 }],
       },
       {
         addPm: 1,
@@ -122,7 +122,7 @@ const AMEACAS_ARTON_ARCANE_SPELLS: Spell[] = [
       {
         addPm: 2,
         text: 'aumenta o dano do sopro em +1d6+1.',
-        damageBonus: [{ dicePerActivation: '1d6+1' }],
+        damageBonus: [{ diceCount: 1, flatPerActivation: 1 }],
       },
       {
         addPm: 2,
@@ -170,8 +170,8 @@ const AMEACAS_ARTON_DIVINE_SPELLS: Spell[] = [
         addPm: 3,
         text: 'aumenta o dano em +2d8 (ou +2d12 contra mortos-vivos).',
         damageBonus: [
-          { targetRollLabel: 'normal', dicePerActivation: '2d8' },
-          { targetRollLabel: 'mortos-vivos', dicePerActivation: '2d12' },
+          { targetRollLabel: 'normal', diceCount: 2 },
+          { targetRollLabel: 'mortos-vivos', diceCount: 2 },
         ],
       },
       {
@@ -213,10 +213,10 @@ const AMEACAS_ARTON_UNIVERSAL_SPELLS: Spell[] = [
         addPm: 3,
         text: 'aumenta o dano em +1 dado do mesmo tipo.',
         damageBonus: [
-          { targetRollLabel: 'chuva ácida', dicePerActivation: '1d4' },
-          { targetRollLabel: 'neblina venenosa', dicePerActivation: '1d12' },
-          { targetRollLabel: 'raios escarlates', dicePerActivation: '1d8' },
-          { targetRollLabel: 'pesadelos reais', dicePerActivation: '1d6' },
+          { targetRollLabel: 'chuva ácida', diceCount: 1 },
+          { targetRollLabel: 'neblina venenosa', diceCount: 1 },
+          { targetRollLabel: 'raios escarlates', diceCount: 1 },
+          { targetRollLabel: 'pesadelos reais', diceCount: 1 },
         ],
       },
       {

--- a/src/data/systems/tormenta20/deuses-de-arton/spells.ts
+++ b/src/data/systems/tormenta20/deuses-de-arton/spells.ts
@@ -541,7 +541,11 @@ const DEUSES_ARTON_DIVINE_SPELLS: Spell[] = [
       {
         addPm: 1,
         text: 'muda o tipo de dano para luz.',
-        damageBonus: [{ replaceDamageType: 'luz' }],
+        damageBonus: [
+          { targetRollLabel: 'sem armadura', replaceDamageType: 'luz' },
+          { targetRollLabel: 'armadura leve', replaceDamageType: 'luz' },
+          { targetRollLabel: 'armadura pesada', replaceDamageType: 'luz' },
+        ],
       },
       {
         addPm: 1,
@@ -803,6 +807,7 @@ const DEUSES_ARTON_UNIVERSAL_SPELLS: Spell[] = [
     ],
     rolls: [
       {
+        id: uuid(),
         label: 'Dano de Luz',
         dice: '2d8+2',
         damageType: 'luz',

--- a/src/data/systems/tormenta20/deuses-de-arton/spells.ts
+++ b/src/data/systems/tormenta20/deuses-de-arton/spells.ts
@@ -541,6 +541,7 @@ const DEUSES_ARTON_DIVINE_SPELLS: Spell[] = [
       {
         addPm: 1,
         text: 'muda o tipo de dano para luz.',
+        damageBonus: [{ replaceDamageType: 'luz' }],
       },
       {
         addPm: 1,
@@ -771,11 +772,12 @@ const DEUSES_ARTON_UNIVERSAL_SPELLS: Spell[] = [
       {
         addPm: 1,
         text: 'muda o alvo para uma criatura que tenha causado dano a você ou a seus aliados na última rodada e os dados de dano da magia para d10.',
+        damageBonus: [{ replaceWith: '2d10+2' }],
       },
       {
         addPm: 2,
         text: 'aumenta o dano em +1d8+1.',
-        damageBonus: [{ dicePerActivation: '1d8+1' }],
+        damageBonus: [{ diceCount: 1, flatPerActivation: 1 }],
       },
       {
         addPm: 2,
@@ -792,6 +794,7 @@ const DEUSES_ARTON_UNIVERSAL_SPELLS: Spell[] = [
       {
         addPm: 1,
         text: '(Apenas Elfos): muda o alvo para 1 duyshidakk ou 1 devoto de Aharadak, Tauron ou Thwor. Muda os dados de dano para d10.',
+        damageBonus: [{ replaceWith: '2d10+2' }],
       },
       {
         addPm: 2,

--- a/src/data/systems/tormenta20/deuses-de-arton/spells.ts
+++ b/src/data/systems/tormenta20/deuses-de-arton/spells.ts
@@ -1,3 +1,4 @@
+import { v4 as uuid } from 'uuid';
 import { Spell, spellsCircles } from '../../../../interfaces/Spells';
 import { SupplementSpells } from '../core';
 
@@ -227,10 +228,28 @@ const DEUSES_ARTON_DIVINE_SPELLS: Spell[] = [
       {
         addPm: 4,
         text: 'aumenta o dano psíquico e de luz em +1d6 cada.',
+        damageBonus: [
+          { targetRollLabel: 'psíquico', dicePerActivation: '1d6' },
+          { targetRollLabel: 'luz', dicePerActivation: '1d6' },
+        ],
       },
       {
         addPm: 0,
         text: '(Apenas Devotos de Lin-Wu): muda o alvo para 1 criatura inteligente (Int –3 ou maior).',
+      },
+    ],
+    rolls: [
+      {
+        id: uuid(),
+        label: 'Dano Psíquico',
+        dice: '1d6',
+        damageType: 'psíquico',
+      },
+      {
+        id: uuid(),
+        label: 'Dano de Luz',
+        dice: '1d6',
+        damageType: 'luz',
       },
     ],
   },
@@ -513,6 +532,11 @@ const DEUSES_ARTON_DIVINE_SPELLS: Spell[] = [
       {
         addPm: 1,
         text: 'aumenta o dano em +1d6.',
+        damageBonus: [
+          { targetRollLabel: 'sem armadura', dicePerActivation: '1d6' },
+          { targetRollLabel: 'armadura leve', dicePerActivation: '1d6' },
+          { targetRollLabel: 'armadura pesada', dicePerActivation: '1d6' },
+        ],
       },
       {
         addPm: 1,
@@ -525,6 +549,26 @@ const DEUSES_ARTON_DIVINE_SPELLS: Spell[] = [
       {
         addPm: 1,
         text: '(Apenas Devotos de Azgher): além do normal, criaturas que falhem na resistência ficam em chamas e sangrando.',
+      },
+    ],
+    rolls: [
+      {
+        id: uuid(),
+        label: 'Dano (sem armadura)',
+        dice: '3d6',
+        damageType: 'corte',
+      },
+      {
+        id: uuid(),
+        label: 'Dano (armadura leve)',
+        dice: '2d6',
+        damageType: 'corte',
+      },
+      {
+        id: uuid(),
+        label: 'Dano (armadura pesada)',
+        dice: '1d6',
+        damageType: 'corte',
       },
     ],
   },
@@ -657,6 +701,7 @@ const DEUSES_ARTON_DIVINE_SPELLS: Spell[] = [
       {
         addPm: 2,
         text: 'aumenta o dano em +2d8.',
+        damageBonus: [{ dicePerActivation: '2d8' }],
       },
       {
         addPm: 2,
@@ -665,6 +710,14 @@ const DEUSES_ARTON_DIVINE_SPELLS: Spell[] = [
       {
         addPm: 3,
         text: 'muda o alvo para criaturas escolhidas. Requer 3º círculo.',
+      },
+    ],
+    rolls: [
+      {
+        id: uuid(),
+        label: 'Dano de Impacto',
+        dice: '6d8',
+        damageType: 'impacto',
       },
     ],
   },
@@ -722,6 +775,7 @@ const DEUSES_ARTON_UNIVERSAL_SPELLS: Spell[] = [
       {
         addPm: 2,
         text: 'aumenta o dano em +1d8+1.',
+        damageBonus: [{ dicePerActivation: '1d8+1' }],
       },
       {
         addPm: 2,
@@ -742,6 +796,13 @@ const DEUSES_ARTON_UNIVERSAL_SPELLS: Spell[] = [
       {
         addPm: 2,
         text: '(Apenas Divinos): além do normal, para cada alvo que falhar na resistência, o próximo aliado que causar dano a ele recebe uma quantidade de PV temporários igual à metade do dano causado pela magia. Requer 2º círculo.',
+      },
+    ],
+    rolls: [
+      {
+        label: 'Dano de Luz',
+        dice: '2d8+2',
+        damageType: 'luz',
       },
     ],
   },
@@ -787,6 +848,21 @@ const DEUSES_ARTON_UNIVERSAL_SPELLS: Spell[] = [
       {
         addPm: 3,
         text: 'muda a resistência para nenhuma. Requer 3º círculo.',
+      },
+    ],
+    rolls: [
+      {
+        id: uuid(),
+        label: 'Dano por Círculo de Magia',
+        dice: '1d8',
+        damageType: 'essência',
+        description: 'Role uma vez por círculo de magia afetando o alvo.',
+      },
+      {
+        id: uuid(),
+        label: 'Dano (Velocidade e Voo)',
+        dice: '5d8',
+        damageType: 'essência',
       },
     ],
   },

--- a/src/data/systems/tormenta20/deuses-de-arton/spells.ts
+++ b/src/data/systems/tormenta20/deuses-de-arton/spells.ts
@@ -229,8 +229,8 @@ const DEUSES_ARTON_DIVINE_SPELLS: Spell[] = [
         addPm: 4,
         text: 'aumenta o dano psíquico e de luz em +1d6 cada.',
         damageBonus: [
-          { targetRollLabel: 'psíquico', dicePerActivation: '1d6' },
-          { targetRollLabel: 'luz', dicePerActivation: '1d6' },
+          { targetRollLabel: 'psíquico', diceCount: 1 },
+          { targetRollLabel: 'luz', diceCount: 1 },
         ],
       },
       {
@@ -533,9 +533,9 @@ const DEUSES_ARTON_DIVINE_SPELLS: Spell[] = [
         addPm: 1,
         text: 'aumenta o dano em +1d6.',
         damageBonus: [
-          { targetRollLabel: 'sem armadura', dicePerActivation: '1d6' },
-          { targetRollLabel: 'armadura leve', dicePerActivation: '1d6' },
-          { targetRollLabel: 'armadura pesada', dicePerActivation: '1d6' },
+          { targetRollLabel: 'sem armadura', diceCount: 1 },
+          { targetRollLabel: 'armadura leve', diceCount: 1 },
+          { targetRollLabel: 'armadura pesada', diceCount: 1 },
         ],
       },
       {
@@ -702,7 +702,7 @@ const DEUSES_ARTON_DIVINE_SPELLS: Spell[] = [
       {
         addPm: 2,
         text: 'aumenta o dano em +2d8.',
-        damageBonus: [{ dicePerActivation: '2d8' }],
+        damageBonus: [{ diceCount: 2 }],
       },
       {
         addPm: 2,

--- a/src/data/systems/tormenta20/herois-de-arton/spells.ts
+++ b/src/data/systems/tormenta20/herois-de-arton/spells.ts
@@ -115,7 +115,7 @@ const HEROIS_ARTON_ARCANE_SPELLS: Spell[] = [
       {
         addPm: 2,
         text: 'aumenta o dano em um dado do mesmo tipo (total de dados limitado pelo círculo máximo de magia que você pode lançar).',
-        damageBonus: [{ dicePerActivation: '1d6' }],
+        damageBonus: [{ diceCount: 1 }],
       },
       {
         addPm: 2,

--- a/src/data/systems/tormenta20/herois-de-arton/spells.ts
+++ b/src/data/systems/tormenta20/herois-de-arton/spells.ts
@@ -1,3 +1,4 @@
+import { v4 as uuid } from 'uuid';
 import { Spell, spellsCircles } from '../../../../interfaces/Spells';
 import { SupplementSpells } from '../core';
 
@@ -114,6 +115,7 @@ const HEROIS_ARTON_ARCANE_SPELLS: Spell[] = [
       {
         addPm: 2,
         text: 'aumenta o dano em um dado do mesmo tipo (total de dados limitado pelo círculo máximo de magia que você pode lançar).',
+        damageBonus: [{ dicePerActivation: '1d6' }],
       },
       {
         addPm: 2,
@@ -126,6 +128,15 @@ const HEROIS_ARTON_ARCANE_SPELLS: Spell[] = [
       {
         addPm: 3,
         text: '(Apenas Golem [energia elemental], Qareen ou Kallyanach): muda o dado de dano para d8 e o tipo de dano para o tipo escolhido para sua habilidade racial elemental.',
+        damageBonus: [{ replaceWith: '1d8+1', replaceDamageType: 'elemental' }],
+      },
+    ],
+    rolls: [
+      {
+        id: uuid(),
+        label: 'Dano de Perfuração',
+        dice: '1d6+1',
+        damageType: 'perfuração',
       },
     ],
   },

--- a/src/data/systems/tormenta20/magias/generalSpells.ts
+++ b/src/data/systems/tormenta20/magias/generalSpells.ts
@@ -307,7 +307,7 @@ export const spellsCircle1: Record<spellsCircle1Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano em +1d6.',
-        damageBonus: [{ dicePerActivation: '1d6' }],
+        damageBonus: [{ diceCount: 1 }],
       },
     ],
     rolls: [
@@ -432,7 +432,7 @@ export const spellsCircle1: Record<spellsCircle1Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano causado pela arma em +1d6 (bônus máximo limitado pelo círculo máximo de magia que você pode lançar).',
-        damageBonus: [{ dicePerActivation: '1d6' }],
+        damageBonus: [{ diceCount: 1 }],
       },
       {
         addPm: 5,
@@ -849,7 +849,7 @@ export const spellsCircle1: Record<spellsCircle1Names, Spell> = {
       {
         addPm: 1,
         text: 'se escolheu fogo, aumenta o dano inicial de cada chama em +1d6.',
-        damageBonus: [{ targetRollLabel: 'fogo', dicePerActivation: '1d6' }],
+        damageBonus: [{ targetRollLabel: 'fogo', diceCount: 1 }],
       },
     ],
   },
@@ -931,7 +931,7 @@ export const spellsCircle1: Record<spellsCircle1Names, Spell> = {
         addPm: 1,
         text: 'aumenta a cura em +1d8+1.',
         damageBonus: [
-          { targetRollLabel: 'recuperar', dicePerActivation: '1d8+1' },
+          { targetRollLabel: 'recuperar', diceCount: 1, flatPerActivation: 1 },
         ],
       },
       {
@@ -970,7 +970,7 @@ export const spellsCircle1: Record<spellsCircle1Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano em +1d8+2.',
-        damageBonus: [{ dicePerActivation: '1d8+2' }],
+        damageBonus: [{ diceCount: 1, flatPerActivation: 2 }],
       },
       {
         addPm: 2,
@@ -1170,7 +1170,7 @@ export const spellsCircle1: Record<spellsCircle1Names, Spell> = {
       {
         addPm: 1,
         text: 'aumenta o dano em +1d6.',
-        damageBonus: [{ dicePerActivation: '1d6' }],
+        damageBonus: [{ diceCount: 1 }],
       },
       {
         addPm: 1,
@@ -1264,7 +1264,7 @@ export const spellsCircle1: Record<spellsCircle1Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano em 1d8+1.',
-        damageBonus: [{ dicePerActivation: '1d8+1' }],
+        damageBonus: [{ diceCount: 1, flatPerActivation: 1 }],
       },
       {
         addPm: 2,
@@ -1381,7 +1381,7 @@ export const spellsCircle1: Record<spellsCircle1Names, Spell> = {
       {
         addPm: 3,
         text: 'aumenta o dano de ácido em +2d4.',
-        damageBonus: [{ dicePerActivation: '2d4' }],
+        damageBonus: [{ diceCount: 2 }],
       },
       {
         addPm: 5,
@@ -1755,7 +1755,7 @@ export const spellsCircle1: Record<spellsCircle1Names, Spell> = {
       {
         addPm: 1,
         text: 'aumenta o dano em 1d8+1.',
-        damageBonus: [{ dicePerActivation: '1d8+1' }],
+        damageBonus: [{ diceCount: 1, flatPerActivation: 1 }],
       },
       {
         addPm: 2,
@@ -1907,7 +1907,7 @@ export const spellsCircle1: Record<spellsCircle1Names, Spell> = {
       {
         addPm: 2,
         text: ' aumenta os PV temporários recebidos em +1d10. Caso a magia cause dano, em vez disso aumenta o dano causado em +1d10.',
-        damageBonus: [{ dicePerActivation: '1d10' }],
+        damageBonus: [{ diceCount: 1 }],
       },
       {
         addPm: 5,
@@ -2074,7 +2074,7 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 1,
         text: 'aumenta o dano em +2d6.',
-        damageBonus: [{ dicePerActivation: '2d6' }],
+        damageBonus: [{ diceCount: 2 }],
       },
       {
         addPm: 1,
@@ -2321,7 +2321,7 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano em +2d6.',
-        damageBonus: [{ dicePerActivation: '2d6' }],
+        damageBonus: [{ diceCount: 2 }],
       },
       {
         addPm: 2,
@@ -2369,8 +2369,8 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
         addPm: 2,
         text: 'aumenta o dano inicial e o dano por rodada em +1d6.',
         damageBonus: [
-          { targetRollLabel: 'inicial', dicePerActivation: '1d6' },
-          { targetRollLabel: 'por rodada', dicePerActivation: '1d6' },
+          { targetRollLabel: 'inicial', diceCount: 1 },
+          { targetRollLabel: 'por rodada', diceCount: 1 },
         ],
       },
     ],
@@ -2397,7 +2397,7 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano em +2d6.',
-        damageBonus: [{ dicePerActivation: '2d6' }],
+        damageBonus: [{ diceCount: 2 }],
       },
       {
         addPm: 3,
@@ -2432,7 +2432,7 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano de frio em +2d6.',
-        damageBonus: [{ targetRollLabel: 'frio', dicePerActivation: '2d6' }],
+        damageBonus: [{ targetRollLabel: 'frio', diceCount: 2 }],
       },
       {
         addPm: 3,
@@ -2572,7 +2572,7 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano em +1d8+1.',
-        damageBonus: [{ dicePerActivation: '1d8+1' }],
+        damageBonus: [{ diceCount: 1, flatPerActivation: 1 }],
       },
       {
         addPm: 2,
@@ -2606,7 +2606,7 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano em +2d6.',
-        damageBonus: [{ dicePerActivation: '2d6' }],
+        damageBonus: [{ diceCount: 2 }],
       },
       {
         addPm: 2,
@@ -2882,7 +2882,7 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano em +1d12.',
-        damageBonus: [{ dicePerActivation: '1d12' }],
+        damageBonus: [{ diceCount: 1 }],
       },
       {
         addPm: 3,
@@ -2924,7 +2924,7 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano em +1d6.',
-        damageBonus: [{ dicePerActivation: '1d6' }],
+        damageBonus: [{ diceCount: 1 }],
       },
       {
         addPm: 4,
@@ -3021,8 +3021,8 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
         addPm: 2,
         text: 'aumenta o dano em +1d6 (exceto do efeito chamejar).',
         damageBonus: [
-          { targetRollLabel: 'esquentar', dicePerActivation: '1d6' },
-          { targetRollLabel: 'modelar', dicePerActivation: '1d6' },
+          { targetRollLabel: 'esquentar', diceCount: 1 },
+          { targetRollLabel: 'modelar', diceCount: 1 },
         ],
       },
       {
@@ -3075,8 +3075,13 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
     rolls: [
       {
         id: uuid(),
-        label: 'Dano de Luz',
+        label: 'Dano de Luz (normal)',
         dice: '4d8',
+      },
+      {
+        id: uuid(),
+        label: 'Dano de Luz (mortos-vivos)',
+        dice: '4d12',
       },
     ],
     aprimoramentos: [
@@ -3088,7 +3093,10 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano ou cura em +1d8 (ou +1d12 em mortos-vivos).',
-        damageBonus: [{ dicePerActivation: '1d8' }],
+        damageBonus: [
+          { targetRollLabel: 'normal', diceCount: 1 },
+          { targetRollLabel: 'mortos-vivos', diceCount: 1 },
+        ],
       },
       {
         addPm: 3,
@@ -3186,7 +3194,7 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano em +1d6.',
-        damageBonus: [{ dicePerActivation: '1d6' }],
+        damageBonus: [{ diceCount: 1 }],
       },
       {
         addPm: 3,
@@ -3458,7 +3466,7 @@ export const spellsCircle3: Record<spellsCircle3Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano em +1d12.',
-        damageBonus: [{ dicePerActivation: '1d12' }],
+        damageBonus: [{ diceCount: 1 }],
       },
       {
         addPm: 2,
@@ -3575,8 +3583,8 @@ export const spellsCircle3: Record<spellsCircle3Names, Spell> = {
         addPm: 3,
         text: 'aumenta o dano de frio em +2d6 e o dano de corte em +2d6.',
         damageBonus: [
-          { targetRollLabel: 'frio', dicePerActivation: '2d6' },
-          { targetRollLabel: 'corte', dicePerActivation: '2d6' },
+          { targetRollLabel: 'frio', diceCount: 2 },
+          { targetRollLabel: 'corte', diceCount: 2 },
         ],
       },
       {
@@ -3618,8 +3626,8 @@ export const spellsCircle3: Record<spellsCircle3Names, Spell> = {
         addPm: 3,
         text: 'aumenta o dano inicial em +2d6 e o dano do efeito em chamas em +1d6.',
         damageBonus: [
-          { targetRollLabel: 'fogo inicial', dicePerActivation: '2d6' },
-          { targetRollLabel: 'em chamas', dicePerActivation: '1d6' },
+          { targetRollLabel: 'fogo inicial', diceCount: 2 },
+          { targetRollLabel: 'em chamas', diceCount: 1 },
         ],
       },
       {
@@ -3656,8 +3664,8 @@ export const spellsCircle3: Record<spellsCircle3Names, Spell> = {
         addPm: 2,
         text: 'aumenta o dano por atravessar a muralha em +2d6.',
         damageBonus: [
-          { targetRollLabel: 'fogo', dicePerActivation: '2d6' },
-          { targetRollLabel: 'frio', dicePerActivation: '2d6' },
+          { targetRollLabel: 'fogo', diceCount: 2 },
+          { targetRollLabel: 'frio', diceCount: 2 },
         ],
       },
       {
@@ -3692,7 +3700,7 @@ export const spellsCircle3: Record<spellsCircle3Names, Spell> = {
       {
         addPm: 3,
         text: 'aumenta o dano em +2d6.',
-        damageBonus: [{ dicePerActivation: '2d6' }],
+        damageBonus: [{ diceCount: 2 }],
       },
       {
         addPm: 4,
@@ -3766,9 +3774,7 @@ export const spellsCircle3: Record<spellsCircle3Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano em +1d8.',
-        damageBonus: [
-          { targetRollLabel: 'por rodada', dicePerActivation: '1d8' },
-        ],
+        damageBonus: [{ targetRollLabel: 'por rodada', diceCount: 1 }],
       },
       {
         addPm: 9,
@@ -3802,7 +3808,7 @@ export const spellsCircle3: Record<spellsCircle3Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano dos tentáculos em +2d6.',
-        damageBonus: [{ dicePerActivation: '2d6' }],
+        damageBonus: [{ diceCount: 2 }],
       },
     ],
   },
@@ -4101,12 +4107,12 @@ export const spellsCircle3: Record<spellsCircle3Names, Spell> = {
       {
         addPm: 1,
         text: 'aumenta o dano de fogo em +1d6.',
-        damageBonus: [{ targetRollLabel: 'fogo', dicePerActivation: '1d6' }],
+        damageBonus: [{ targetRollLabel: 'fogo', diceCount: 1 }],
       },
       {
         addPm: 1,
         text: 'aumenta o dano de luz em +1d6.',
-        damageBonus: [{ targetRollLabel: 'luz', dicePerActivation: '1d6' }],
+        damageBonus: [{ targetRollLabel: 'luz', diceCount: 1 }],
       },
     ],
   },
@@ -4161,7 +4167,7 @@ export const spellsCircle3: Record<spellsCircle3Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta a cura em +1d8+2.',
-        damageBonus: [{ dicePerActivation: '1d8+2' }],
+        damageBonus: [{ diceCount: 1, flatPerActivation: 2 }],
       },
       {
         addPm: 4,
@@ -4220,7 +4226,7 @@ export const spellsCircle3: Record<spellsCircle3Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano em 1d8+4.',
-        damageBonus: [{ dicePerActivation: '1d8+4' }],
+        damageBonus: [{ diceCount: 1, flatPerActivation: 4 }],
       },
     ],
   },
@@ -4271,7 +4277,7 @@ export const spellsCircle3: Record<spellsCircle3Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano em +2d8.',
-        damageBonus: [{ dicePerActivation: '2d8' }],
+        damageBonus: [{ diceCount: 2 }],
       },
     ],
   },
@@ -4470,7 +4476,7 @@ export const spellsCircle4: Record<spellsCircle4Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano em +1d6+5.',
-        damageBonus: [{ dicePerActivation: '1d6+5' }],
+        damageBonus: [{ diceCount: 1, flatPerActivation: 5 }],
       },
       {
         addPm: 5,
@@ -4553,7 +4559,7 @@ export const spellsCircle4: Record<spellsCircle4Names, Spell> = {
       {
         addPm: 3,
         text: 'aumenta o dano em +2d8.',
-        damageBonus: [{ dicePerActivation: '2d8' }],
+        damageBonus: [{ diceCount: 2 }],
       },
       {
         addPm: 5,
@@ -4594,9 +4600,9 @@ export const spellsCircle4: Record<spellsCircle4Names, Spell> = {
         addPm: 2,
         text: 'aumenta o dano das rajadas em +1d6 e o dano da rajada mista em +2d12.',
         damageBonus: [
-          { targetRollLabel: 'bola de fogo', dicePerActivation: '1d6' },
-          { targetRollLabel: 'relâmpago', dicePerActivation: '1d6' },
-          { targetRollLabel: 'misto', dicePerActivation: '2d12' },
+          { targetRollLabel: 'bola de fogo', diceCount: 1 },
+          { targetRollLabel: 'relâmpago', diceCount: 1 },
+          { targetRollLabel: 'misto', diceCount: 2 },
         ],
       },
     ],
@@ -4623,7 +4629,7 @@ export const spellsCircle4: Record<spellsCircle4Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano em +2d8.',
-        damageBonus: [{ dicePerActivation: '2d8' }],
+        damageBonus: [{ diceCount: 2 }],
       },
       {
         addPm: 2,
@@ -4766,8 +4772,8 @@ export const spellsCircle4: Record<spellsCircle4Names, Spell> = {
         addPm: 4,
         text: 'aumenta o dano total em +2d12 e o dano mínimo em +1d12.',
         damageBonus: [
-          { targetRollLabel: 'total', dicePerActivation: '2d12' },
-          { targetRollLabel: 'mínimo', dicePerActivation: '1d12' },
+          { targetRollLabel: 'total', diceCount: 2 },
+          { targetRollLabel: 'mínimo', diceCount: 1 },
         ],
       },
     ],
@@ -4891,15 +4897,23 @@ export const spellsCircle4: Record<spellsCircle4Names, Spell> = {
     rolls: [
       {
         id: uuid(),
-        label: 'Dano de Fogo',
+        label: 'Dano de Fogo (normal)',
         dice: '10d6',
+      },
+      {
+        id: uuid(),
+        label: 'Dano de Fogo (mortos-vivos)',
+        dice: '10d8',
       },
     ],
     aprimoramentos: [
       {
         addPm: 2,
         text: 'aumenta o dano em +2d6 (+2d8 contra mortos-vivos).',
-        damageBonus: [{ dicePerActivation: '2d6' }],
+        damageBonus: [
+          { targetRollLabel: 'normal', diceCount: 2 },
+          { targetRollLabel: 'mortos-vivos', diceCount: 2 },
+        ],
       },
       {
         addPm: 2,
@@ -5320,8 +5334,8 @@ export const spellsCircle5: Record<spellsCircle5Names, Spell> = {
         addPm: 2,
         text: 'aumenta o número de meteoros que atingem a área, o que aumenta o dano em +2d6 de impacto e +2d6 de fogo.',
         damageBonus: [
-          { targetRollLabel: 'impacto', dicePerActivation: '2d6' },
-          { targetRollLabel: 'fogo', dicePerActivation: '2d6' },
+          { targetRollLabel: 'impacto', diceCount: 2 },
+          { targetRollLabel: 'fogo', diceCount: 2 },
         ],
       },
     ],
@@ -5429,10 +5443,10 @@ export const spellsCircle5: Record<spellsCircle5Names, Spell> = {
         addPm: 5,
         text: 'aumenta o dano de cada esfera em +2d6.',
         damageBonus: [
-          { targetRollLabel: 'ácido', dicePerActivation: '2d6' },
-          { targetRollLabel: 'eletricidade', dicePerActivation: '2d6' },
-          { targetRollLabel: 'fogo', dicePerActivation: '2d6' },
-          { targetRollLabel: 'frio', dicePerActivation: '2d6' },
+          { targetRollLabel: 'ácido', diceCount: 2 },
+          { targetRollLabel: 'eletricidade', diceCount: 2 },
+          { targetRollLabel: 'fogo', diceCount: 2 },
+          { targetRollLabel: 'frio', diceCount: 2 },
         ],
       },
       {
@@ -5485,7 +5499,7 @@ export const spellsCircle5: Record<spellsCircle5Names, Spell> = {
       {
         addPm: 1,
         text: 'aumenta o dano em 1d12.',
-        damageBonus: [{ dicePerActivation: '1d12' }],
+        damageBonus: [{ diceCount: 1 }],
       },
     ],
   },

--- a/src/data/systems/tormenta20/magias/generalSpells.ts
+++ b/src/data/systems/tormenta20/magias/generalSpells.ts
@@ -3160,6 +3160,7 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 2,
         text: 'aumenta o dano de raios (veja acima) em +1d8.',
+        damageBonus: [{ targetRollLabel: 'raio', dicePerActivation: '1d8' }],
       },
       {
         addPm: 3,

--- a/src/data/systems/tormenta20/magias/generalSpells.ts
+++ b/src/data/systems/tormenta20/magias/generalSpells.ts
@@ -1649,6 +1649,16 @@ export const spellsCircle1: Record<spellsCircle1Names, Spell> = {
       {
         addPm: 2,
         text: 'muda as setas para lanças de energia que surgem e caem do céu. Cada lança causa 1d8+1 pontos de dano de essência. Requer 2º círculo.',
+        damageBonus: [
+          {
+            targetRollLabel: '1 seta',
+            replaceWith: '1d8+1',
+          },
+          {
+            targetRollLabel: '2 setas',
+            replaceWith: '2d8+2',
+          },
+        ],
       },
       {
         addPm: 2,
@@ -2296,6 +2306,16 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 3,
         text: 'sempre que o alvo fizer o teste de Vontade e falhar, a marca causa 3d6 pontos de dano psíquico. Requer 3º círculo.',
+        damageBonus: [
+          {
+            additionalRoll: {
+              id: uuid(),
+              label: 'Dano Psíquico (marca)',
+              dice: '3d6',
+              damageType: 'psíquico',
+            },
+          },
+        ],
       },
     ],
   },
@@ -2326,6 +2346,7 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 2,
         text: 'muda a área para efeito de esfera flamejante com tamanho Médio e a duração para cena. Em vez do normal, cria uma esfera flamejante com 1,5m de diâmetro que causa 3d6 pontos de dano a qualquer criatura no mesmo espaço. Você pode gastar uma ação de movimento para fazer a esfera voar 9m em qualquer direção. Ela é imune a dano, mas pode ser apagada com água. Uma criatura só pode sofrer dano da esfera uma vez por rodada.',
+        damageBonus: [{ replaceWith: '3d6' }],
       },
       {
         addPm: 3,
@@ -2611,6 +2632,7 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 2,
         text: 'muda o alcance para pessoal, o alvo para você e a duração para cena. Em vez do normal, a cada rodada você pode gastar uma ação padrão para tocar 1 criatura e causar 3d6 pontos de dano. Você recupera pontos de vida iguais à metade do dano causado. Requer 3º círculo.',
+        damageBonus: [{ replaceWith: '3d6' }],
       },
     ],
   },
@@ -2887,6 +2909,7 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 3,
         text: 'muda a resistência para Reflexos reduz à metade e o enxame para criaturas maiores, como gatos, guaxinins, compsognatos ou kobolds. Ele causa 3d12 pontos de dano (a sua escolha entre corte, impacto ou perfuração). O resto da magia segue normal.',
+        damageBonus: [{ replaceWith: '3d12' }],
       },
       {
         addPm: 5,
@@ -2895,6 +2918,7 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 7,
         text: 'muda a resistência para Reflexos reduz à metade e o enxame para criaturas elementais. Ele causa 5d12 pontos do dano (a sua escolha entre ácido, eletricidade, fogo ou frio). O resto da magia segue normal. Requer 4º círculo.',
+        damageBonus: [{ replaceWith: '5d12' }],
       },
     ],
   },
@@ -3122,6 +3146,16 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 1,
         text: 'além do normal, uma vez por rodada você pode gastar uma ação padrão para fazer um raio cair sobre um alvo na área, causando 3d8 pontos de dano de eletricidade (Reflexos reduz à metade).',
+        damageBonus: [
+          {
+            additionalRoll: {
+              id: uuid(),
+              label: 'Dano de Eletricidade (raio)',
+              dice: '3d8',
+              damageType: 'eletricidade',
+            },
+          },
+        ],
       },
       {
         addPm: 2,
@@ -3134,10 +3168,30 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 3,
         text: 'se escolheu causar granizo, muda o dano para 2d6 por rodada.',
+        damageBonus: [
+          {
+            additionalRoll: {
+              id: uuid(),
+              label: 'Dano de Impacto (granizo)',
+              dice: '2d6',
+              damageType: 'impacto',
+            },
+          },
+        ],
       },
       {
         addPm: 3,
         text: 'se escolheu causar neve, criaturas na área sofrem 2d6 pontos de dano de frio no início de seus turnos.',
+        damageBonus: [
+          {
+            additionalRoll: {
+              id: uuid(),
+              label: 'Dano de Frio (neve)',
+              dice: '2d6',
+              damageType: 'frio',
+            },
+          },
+        ],
       },
       {
         addPm: 3,
@@ -3242,6 +3296,16 @@ export const spellsCircle2: Record<spellsCircle2Names, Spell> = {
       {
         addPm: 3,
         text: 'muda o alvo para área de quadrado com 9m de lado e a duração para cena. Em vez do normal, qualquer vegetação na área fica rígida e afiada. A área é considerada terreno difícil e criaturas que andem nela sofrem 1d6 pontos de dano de corte para cada 1,5m que avancem.',
+        damageBonus: [
+          {
+            additionalRoll: {
+              id: uuid(),
+              label: 'Dano de Corte (vegetação)',
+              dice: '1d6',
+              damageType: 'corte',
+            },
+          },
+        ],
       },
       {
         addPm: 7,
@@ -3590,6 +3654,18 @@ export const spellsCircle3: Record<spellsCircle3Names, Spell> = {
       {
         addPm: 4,
         text: 'muda a área para cilindro com 6m de raio e 6m de altura e a duração para sustentada. Em vez do normal, a magia cria uma tempestade de granizo que causa 3d6 pontos de dano de impacto e 3d6 pontos de dano de frio em todas as criaturas na área (sem teste de resistência). A tempestade fornece camuflagem leve às criaturas dentro dela e deixa o piso escorregadio. Piso escorregadio conta como terreno difícil e obriga criaturas na área a fazer testes de Acrobacia para equilíbrio (veja o Capítulo 2). Requer 4º círculo.',
+        damageBonus: [
+          {
+            targetRollLabel: 'corte',
+            replaceWith: '3d6',
+            replaceDamageType: 'impacto',
+            replaceLabel: 'Dano de Impacto',
+          },
+          {
+            targetRollLabel: 'frio',
+            replaceWith: '3d6',
+          },
+        ],
       },
     ],
   },

--- a/src/functions/__tests__/spellRollAugmentation.spec.ts
+++ b/src/functions/__tests__/spellRollAugmentation.spec.ts
@@ -122,6 +122,57 @@ describe('augmentSpellRolls — vínculo estruturado', () => {
     expect(result[0].dice).toBe('8d6+1');
   });
 
+  test('substitui a notação base sem somar a versão anterior', () => {
+    const base = [roll('Dano de Luz', '2d8+2')];
+    const variant = apr('muda os dados de dano para d10.', {
+      damageBonus: [{ replaceWith: '2d10+2' }],
+    });
+    const result = augmentSpellRolls(base, [select(variant, 1)]);
+
+    expect(result[0].dice).toBe('2d10+2');
+    expect(result[0].baseDice).toBe('2d8+2');
+    expect(result[0].replacementDice).toBe('2d10+2');
+    expect(result[0].isAugmented).toBe(true);
+  });
+
+  test('usa o dado substituído para aumentos por quantidade de dados', () => {
+    const base = [roll('Dano de Luz', '2d8+2')];
+    const replacement = apr('muda os dados de dano para d10.', {
+      damageBonus: [{ replaceWith: '2d10+2' }],
+    });
+    const increase = apr('aumenta o dano em um dado e +1.', {
+      damageBonus: [{ diceCount: 1, flatPerActivation: 1 }],
+    });
+    const result = augmentSpellRolls(base, [
+      select(replacement, 1),
+      select(increase, 1),
+    ]);
+
+    expect(result[0].dice).toBe('3d10+3');
+  });
+
+  test('mantém suporte ao aumento literal quando necessário', () => {
+    const base = [roll('Dano', '2d10')];
+    const bonus = apr('aumenta o dano em +1d8+2.', {
+      damageBonus: [{ dicePerActivation: '1d8+2' }],
+    });
+    const result = augmentSpellRolls(base, [select(bonus, 1)]);
+
+    expect(result[0].dice).toBe('2d10+1d8+2');
+  });
+
+  test('substitui o tipo de dano mantendo a notação', () => {
+    const base = [{ ...roll('Dano', '3d6'), damageType: 'corte' }];
+    const variant = apr('muda o tipo de dano para luz.', {
+      damageBonus: [{ replaceDamageType: 'luz' }],
+    });
+    const result = augmentSpellRolls(base, [select(variant, 1)]);
+
+    expect(result[0].dice).toBe('3d6');
+    expect(result[0].damageType).toBe('luz');
+    expect(result[0].isAugmented).toBe(true);
+  });
+
   test('flatPerActivation soma modificador fixo', () => {
     const base = [roll('Dano', '6d6')];
     const bonus = apr('aumenta o dano em 10.', {

--- a/src/functions/__tests__/spellRollAugmentation.spec.ts
+++ b/src/functions/__tests__/spellRollAugmentation.spec.ts
@@ -411,6 +411,22 @@ describe('integração com dados reais (generalSpells)', () => {
     expect(dice).toEqual(['3d6', '5d6']);
   });
 
+  test('Raio Solar: o aumento acompanha o dado de cada variante', () => {
+    const spell = findByNome(spellsCircle2, 'Raio Solar');
+    const sel = selectApr(spell, (a) => /aumenta o dano/i.test(a.text));
+    const result = augmentSpellRolls(spell.rolls ?? [], [sel]);
+
+    expect(result.map((r) => r.dice).sort()).toEqual(['5d12', '5d8']);
+  });
+
+  test('Cólera de Azgher: o aumento acompanha o dado de mortos-vivos', () => {
+    const spell = findByNome(spellsCircle4, 'Cólera de Azgher');
+    const sel = selectApr(spell, (a) => /aumenta o dano/i.test(a.text));
+    const result = augmentSpellRolls(spell.rolls ?? [], [sel]);
+
+    expect(result.map((r) => r.dice).sort()).toEqual(['12d6', '12d8']);
+  });
+
   test('Chuva de Meteoros ganhou rolagens de dano', () => {
     const spell = findByNome(spellsCircle5, 'Chuva de Meteoros');
     expect((spell.rolls ?? []).length).toBeGreaterThan(0);

--- a/src/functions/__tests__/spellRollAugmentation.spec.ts
+++ b/src/functions/__tests__/spellRollAugmentation.spec.ts
@@ -12,6 +12,7 @@ import {
   spellsCircle4,
   spellsCircle5,
 } from '@/data/systems/tormenta20/magias/generalSpells';
+import DEUSES_ARTON_SPELLS from '@/data/systems/tormenta20/deuses-de-arton/spells';
 import {
   AprimoramentoSelection,
   augmentSpellRolls,
@@ -537,5 +538,18 @@ describe('integração com dados reais (generalSpells)', () => {
   test('Chuva de Meteoros ganhou rolagens de dano', () => {
     const spell = findByNome(spellsCircle5, 'Chuva de Meteoros');
     expect((spell.rolls ?? []).length).toBeGreaterThan(0);
+  });
+
+  test('Siroco de Azgher: muda o tipo de dano das três rolagens para luz', () => {
+    const spell = (DEUSES_ARTON_SPELLS.divine ?? []).find(
+      (s) => s.nome === 'Siroco de Azgher'
+    );
+    if (!spell) throw new Error('Magia "Siroco de Azgher" não encontrada');
+    const sel = selectApr(spell, (a) => /muda o tipo de dano/.test(a.text));
+
+    const result = augmentSpellRolls(spell.rolls ?? [], [sel]);
+
+    expect(result).toHaveLength(3);
+    result.forEach((r) => expect(r.damageType).toBe('luz'));
   });
 });

--- a/src/functions/__tests__/spellRollAugmentation.spec.ts
+++ b/src/functions/__tests__/spellRollAugmentation.spec.ts
@@ -151,6 +151,22 @@ describe('augmentSpellRolls — vínculo estruturado', () => {
     expect(result[0].dice).toBe('3d10+3');
   });
 
+  test('usa o dado substituído mesmo quando o aumento foi selecionado antes', () => {
+    const base = [roll('Dano de Luz', '2d8+2')];
+    const replacement = apr('muda os dados de dano para d10.', {
+      damageBonus: [{ replaceWith: '2d10+2' }],
+    });
+    const increase = apr('aumenta o dano em um dado e +1.', {
+      damageBonus: [{ diceCount: 1, flatPerActivation: 1 }],
+    });
+    const result = augmentSpellRolls(base, [
+      select(increase, 1),
+      select(replacement, 1),
+    ]);
+
+    expect(result[0].dice).toBe('3d10+3');
+  });
+
   test('mantém suporte ao aumento literal quando necessário', () => {
     const base = [roll('Dano', '2d10')];
     const bonus = apr('aumenta o dano em +1d8+2.', {

--- a/src/functions/__tests__/spellRollAugmentation.spec.ts
+++ b/src/functions/__tests__/spellRollAugmentation.spec.ts
@@ -405,9 +405,20 @@ describe('integridade das anotações damageBonus em generalSpells', () => {
     const problems: string[] = [];
 
     allSpells.forEach((spell) => {
+      // Rótulos das rolagens base + das criadas por `additionalRoll` de
+      // qualquer aprimoramento da mesma magia (ex.: o raio da Tempestade
+      // Divina), já que um bônus de outro aprimoramento pode mirar nelas.
+      const rolls = [
+        ...(spell.rolls ?? []),
+        ...(spell.aprimoramentos ?? []).flatMap((a) =>
+          (a.damageBonus ?? [])
+            .map((b) => b.additionalRoll)
+            .filter((r): r is DiceRoll => Boolean(r))
+        ),
+      ];
+
       (spell.aprimoramentos ?? []).forEach((aprimoramento) => {
         (aprimoramento.damageBonus ?? []).forEach((bonus) => {
-          const rolls = spell.rolls ?? [];
           if (bonus.additionalRoll) return;
           if (bonus.targetRollLabel) {
             const needle = normalizeLabel(bonus.targetRollLabel);
@@ -517,6 +528,20 @@ describe('integração com dados reais (generalSpells)', () => {
     const result = augmentSpellRolls(spell.rolls ?? [], selections);
 
     expect(result.map((r) => r.dice).sort()).toEqual(['2d6', '2d6', '3d8']);
+  });
+
+  test('Tempestade Divina: "aumenta o dano de raios" alcança a rolagem criada pelo raio', () => {
+    const spell = findByNome(spellsCircle2, 'Tempestade Divina');
+    const raioSel = selectApr(spell, (a) => /fazer um raio/.test(a.text));
+    const bonusSel = selectApr(spell, (a) =>
+      /aumenta o dano de raios/.test(a.text)
+    );
+
+    const result = augmentSpellRolls(spell.rolls ?? [], [raioSel, bonusSel]);
+    const raio = result.find((r) => /raio/i.test(r.label));
+
+    expect(raio?.dice).toBe('4d8');
+    expect(raio?.isAugmented).toBe(true);
   });
 
   test('Marca da Obediência e Controlar Madeira adicionam danos opcionais', () => {

--- a/src/functions/__tests__/spellRollAugmentation.spec.ts
+++ b/src/functions/__tests__/spellRollAugmentation.spec.ts
@@ -173,6 +173,43 @@ describe('augmentSpellRolls — vínculo estruturado', () => {
     expect(result[0].isAugmented).toBe(true);
   });
 
+  test('substitui o rótulo da rolagem junto com dano e tipo', () => {
+    const base = [{ ...roll('Dano de Corte', '4d6'), damageType: 'corte' }];
+    const variant = apr('muda o dano de corte para impacto.', {
+      damageBonus: [
+        {
+          replaceWith: '3d6',
+          replaceDamageType: 'impacto',
+          replaceLabel: 'Dano de Impacto',
+        },
+      ],
+    });
+    const result = augmentSpellRolls(base, [select(variant, 1)]);
+
+    expect(result[0].dice).toBe('3d6');
+    expect(result[0].damageType).toBe('impacto');
+    expect(result[0].label).toBe('Dano de Impacto');
+  });
+
+  test('adiciona uma rolagem extra criada pelo aprimoramento', () => {
+    const base = [roll('Dano Base', '1d6')];
+    const bonus = apr('adiciona um efeito que causa 3d8.', {
+      damageBonus: [
+        {
+          additionalRoll: {
+            id: 'extra-roll',
+            label: 'Dano Extra',
+            dice: '3d8',
+          },
+        },
+      ],
+    });
+    const result = augmentSpellRolls(base, [select(bonus, 1)]);
+
+    expect(result.map((r) => r.dice)).toEqual(['1d6', '3d8']);
+    expect(result[1].label).toBe('Dano Extra');
+  });
+
   test('flatPerActivation soma modificador fixo', () => {
     const base = [roll('Dano', '6d6')];
     const bonus = apr('aumenta o dano em 10.', {
@@ -354,6 +391,7 @@ describe('integridade das anotações damageBonus em generalSpells', () => {
       (spell.aprimoramentos ?? []).forEach((aprimoramento) => {
         (aprimoramento.damageBonus ?? []).forEach((bonus) => {
           const rolls = spell.rolls ?? [];
+          if (bonus.additionalRoll) return;
           if (bonus.targetRollLabel) {
             const needle = normalizeLabel(bonus.targetRollLabel);
             const matched = rolls.some((r) =>
@@ -402,6 +440,33 @@ describe('integração com dados reais (generalSpells)', () => {
     expect(result[0].isAugmented).toBe(true);
   });
 
+  test('Bola de Fogo: esfera flamejante substitui o dano por 3d6', () => {
+    const spell = findByNome(spellsCircle2, 'Bola de Fogo');
+    const sel = selectApr(spell, (a) => /esfera flamejante/.test(a.text));
+    const result = augmentSpellRolls(spell.rolls ?? [], [sel]);
+    expect(result[0].dice).toBe('3d6');
+  });
+
+  test('Seta de Talude: lanças substituem o dado das setas', () => {
+    const spell = findByNome(spellsCircle1, 'Seta Infalível de Talude');
+    const sel = selectApr(spell, (a) => /muda as setas/.test(a.text));
+    const result = augmentSpellRolls(spell.rolls ?? [], [sel]);
+    expect(result.map((r) => r.dice).sort()).toEqual(['1d8+1', '2d8+2']);
+  });
+
+  test('Enxame: formas maiores substituem a quantidade de dados', () => {
+    const spell = findByNome(spellsCircle2, 'Enxame de Pestes');
+    const larger = selectApr(spell, (a) => /criaturas maiores/.test(a.text));
+    const elemental = selectApr(spell, (a) =>
+      /criaturas elementais/.test(a.text)
+    );
+
+    expect(augmentSpellRolls(spell.rolls ?? [], [larger])[0].dice).toBe('3d12');
+    expect(augmentSpellRolls(spell.rolls ?? [], [elemental])[0].dice).toBe(
+      '5d12'
+    );
+  });
+
   test('Flecha Ácida: um aprimoramento aumenta as duas rolagens (dado real)', () => {
     const spell = findByNome(spellsCircle2, 'Flecha Ácida');
     const sel = selectApr(spell, (a) => (a.damageBonus?.length ?? 0) === 2);
@@ -425,6 +490,32 @@ describe('integração com dados reais (generalSpells)', () => {
     const result = augmentSpellRolls(spell.rolls ?? [], [sel]);
 
     expect(result.map((r) => r.dice).sort()).toEqual(['12d6', '12d8']);
+  });
+
+  test('Tempestade Divina: aprimoramentos adicionam rolagens opcionais', () => {
+    const spell = findByNome(spellsCircle2, 'Tempestade Divina');
+    const selections = (spell.aprimoramentos ?? [])
+      .filter((a) => /fazer um raio|granizo|causar neve/.test(a.text))
+      .map((aprimoramento) => ({ aprimoramento, count: 1 }));
+    const result = augmentSpellRolls(spell.rolls ?? [], selections);
+
+    expect(result.map((r) => r.dice).sort()).toEqual(['2d6', '2d6', '3d8']);
+  });
+
+  test('Marca da Obediência e Controlar Madeira adicionam danos opcionais', () => {
+    const mark = findByNome(spellsCircle2, 'Marca da Obediência');
+    const wood = findByNome(spellsCircle2, 'Controlar Madeira');
+    const markSelection = selectApr(mark, (a) =>
+      /marca causa 3d6/.test(a.text)
+    );
+    const woodSelection = selectApr(wood, (a) => /vegetação.*1d6/.test(a.text));
+
+    expect(
+      augmentSpellRolls(mark.rolls ?? [], [markSelection]).at(-1)?.dice
+    ).toBe('3d6');
+    expect(
+      augmentSpellRolls(wood.rolls ?? [], [woodSelection]).at(-1)?.dice
+    ).toBe('1d6');
   });
 
   test('Chuva de Meteoros ganhou rolagens de dano', () => {

--- a/src/functions/spellRollAugmentation.ts
+++ b/src/functions/spellRollAugmentation.ts
@@ -298,29 +298,27 @@ export function augmentSpellRolls(
         });
       }
 
-      const activeDieSides = bonus.diceCount
-        ? getSingleDieSides(baseAcc[targetIndexes[0]])
-        : undefined;
-      const literalDice = bonus.dicePerActivation ?? '';
-      const parsedBonus =
-        bonus.diceCount && activeDieSides
-          ? {
-              diceGroups: [{ count: bonus.diceCount, sides: activeDieSides }],
-              modifier: 0,
-            }
-          : parseDamage(literalDice);
-      const perActivationModifier =
-        (parsedBonus?.modifier ?? 0) + (bonus.flatPerActivation ?? 0);
-      const scaledGroups = (parsedBonus?.diceGroups ?? []).map((group) => ({
-        count: group.count * count,
-        sides: group.sides,
-      }));
-      const scaledModifier = perActivationModifier * count;
-
-      // Nada a somar (ex.: bônus só de texto não numérico).
-      if (scaledGroups.length === 0 && scaledModifier === 0) return;
-
       targetIndexes.forEach((index) => {
+        const activeDieSides = bonus.diceCount
+          ? getSingleDieSides(baseAcc[index])
+          : undefined;
+        const parsedBonus =
+          bonus.diceCount && activeDieSides
+            ? {
+                diceGroups: [{ count: bonus.diceCount, sides: activeDieSides }],
+                modifier: 0,
+              }
+            : parseDamage(bonus.dicePerActivation ?? '');
+        const perActivationModifier =
+          (parsedBonus?.modifier ?? 0) + (bonus.flatPerActivation ?? 0);
+        const scaledGroups = (parsedBonus?.diceGroups ?? []).map((group) => ({
+          count: group.count * count,
+          sides: group.sides,
+        }));
+        const scaledModifier = perActivationModifier * count;
+
+        // Nada a somar (ex.: bônus só de texto não numérico).
+        if (scaledGroups.length === 0 && scaledModifier === 0) return;
         addGroups(addedAcc[index], scaledGroups, scaledModifier);
       });
     });

--- a/src/functions/spellRollAugmentation.ts
+++ b/src/functions/spellRollAugmentation.ts
@@ -382,9 +382,11 @@ export function augmentSpellRolls(
         dice: isAugmented ? composeNotation(total) : roll.dice,
         damageType: replacementDamageTypes[index] ?? roll.damageType,
         label: replacementLabels[index] ?? roll.label,
-        replacementDice: replacementApplied[index]
-          ? composeNotation(baseAcc[index])
-          : undefined,
+        replacementDice:
+          replacementApplied[index] &&
+          composeNotation(baseAcc[index]) !== roll.dice
+            ? composeNotation(baseAcc[index])
+            : undefined,
         isAugmented,
         addedSummary,
       };

--- a/src/functions/spellRollAugmentation.ts
+++ b/src/functions/spellRollAugmentation.ts
@@ -29,6 +29,8 @@ export interface AugmentedRoll extends DiceRoll {
   isAugmented: boolean;
   /** Resumo do que foi somado, ex.: "+2d6" (undefined quando não aumentada). */
   addedSummary?: string;
+  /** Notação resultante de uma substituição, antes dos bônus aditivos. */
+  replacementDice?: string;
 }
 
 interface DiceAccumulator {
@@ -101,6 +103,12 @@ function hasAny(acc: DiceAccumulator): boolean {
     if (count > 0) hasDice = true;
   });
   return hasDice || acc.modifier !== 0;
+}
+
+function getSingleDieSides(acc?: DiceAccumulator): number | undefined {
+  if (!acc) return undefined;
+  const groups = accToGroups(acc);
+  return groups.length === 1 ? groups[0].sides : undefined;
 }
 
 function extractLabel(part: string): string | undefined {
@@ -258,13 +266,49 @@ export function augmentSpellRolls(
     return acc;
   });
   const addedAcc = baseRolls.map(() => newAccumulator());
+  const replacementApplied = baseRolls.map(() => false);
+  const replacementDamageTypes: Array<string | undefined> = baseRolls.map(
+    () => undefined
+  );
 
   selections.forEach(({ aprimoramento, count }) => {
     if (count <= 0) return;
     const bonuses = resolveBonuses(aprimoramento);
 
     bonuses.forEach((bonus) => {
-      const parsedBonus = parseDamage(bonus.dicePerActivation);
+      const targetIndexes = resolveTargetIndexes(baseRolls, bonus);
+
+      if (bonus.replaceWith || bonus.replaceDamageType) {
+        targetIndexes.forEach((index) => {
+          if (bonus.replaceWith) {
+            const replacement = parseDamage(bonus.replaceWith);
+            if (replacement) {
+              baseAcc[index] = newAccumulator();
+              addGroups(
+                baseAcc[index],
+                replacement.diceGroups,
+                replacement.modifier
+              );
+            }
+          }
+          if (bonus.replaceDamageType) {
+            replacementDamageTypes[index] = bonus.replaceDamageType;
+          }
+          replacementApplied[index] = true;
+        });
+      }
+
+      const activeDieSides = bonus.diceCount
+        ? getSingleDieSides(baseAcc[targetIndexes[0]])
+        : undefined;
+      const literalDice = bonus.dicePerActivation ?? '';
+      const parsedBonus =
+        bonus.diceCount && activeDieSides
+          ? {
+              diceGroups: [{ count: bonus.diceCount, sides: activeDieSides }],
+              modifier: 0,
+            }
+          : parseDamage(literalDice);
       const perActivationModifier =
         (parsedBonus?.modifier ?? 0) + (bonus.flatPerActivation ?? 0);
       const scaledGroups = (parsedBonus?.diceGroups ?? []).map((group) => ({
@@ -276,7 +320,6 @@ export function augmentSpellRolls(
       // Nada a somar (ex.: bônus só de texto não numérico).
       if (scaledGroups.length === 0 && scaledModifier === 0) return;
 
-      const targetIndexes = resolveTargetIndexes(baseRolls, bonus);
       targetIndexes.forEach((index) => {
         addGroups(addedAcc[index], scaledGroups, scaledModifier);
       });
@@ -285,7 +328,7 @@ export function augmentSpellRolls(
 
   return baseRolls.map((roll, index) => {
     const added = addedAcc[index];
-    const isAugmented = hasAny(added);
+    const isAugmented = replacementApplied[index] || hasAny(added);
 
     const total = newAccumulator();
     addGroups(total, accToGroups(baseAcc[index]), baseAcc[index].modifier);
@@ -294,16 +337,22 @@ export function augmentSpellRolls(
     let addedSummary: string | undefined;
     if (isAugmented) {
       const summary = composeNotation(added);
-      addedSummary =
-        summary.startsWith('+') || summary.startsWith('-')
-          ? summary
-          : `+${summary}`;
+      if (hasAny(added)) {
+        addedSummary =
+          summary.startsWith('+') || summary.startsWith('-')
+            ? summary
+            : `+${summary}`;
+      }
     }
 
     return {
       ...roll,
       baseDice: roll.dice,
       dice: isAugmented ? composeNotation(total) : roll.dice,
+      damageType: replacementDamageTypes[index] ?? roll.damageType,
+      replacementDice: replacementApplied[index]
+        ? composeNotation(baseAcc[index])
+        : undefined,
       isAugmented,
       addedSummary,
     };

--- a/src/functions/spellRollAugmentation.ts
+++ b/src/functions/spellRollAugmentation.ts
@@ -231,22 +231,33 @@ function resolveBonuses(
 }
 
 /**
- * Índices das rolagens base atingidas por um bônus: casa por label
- * (substring normalizada); sem label, cai na única rolagem existente; se houver
- * mais de uma e nenhum label casar, o bônus é ignorado (nunca chuta).
+ * Índices dos labels atingidos por um bônus: casa por label (substring
+ * normalizada); sem label, cai no único candidato existente; se houver mais
+ * de um e nenhum label casar, o bônus é ignorado (nunca chuta).
  */
-function resolveTargetIndexes(
-  baseRolls: DiceRoll[],
+function resolveIndexesByLabel(
+  labels: string[],
   bonus: AprimoramentoDamageBonus
 ): number[] {
   if (bonus.targetRollLabel) {
     const needle = normalizeLabel(bonus.targetRollLabel);
-    return baseRolls.reduce<number[]>((acc, roll, index) => {
-      if (normalizeLabel(roll.label).includes(needle)) acc.push(index);
+    return labels.reduce<number[]>((acc, label, index) => {
+      if (normalizeLabel(label).includes(needle)) acc.push(index);
       return acc;
     }, []);
   }
-  return baseRolls.length === 1 ? [0] : [];
+  return labels.length === 1 ? [0] : [];
+}
+
+/** Índices das rolagens base (sem contar `additionalRoll`) atingidas por um bônus. */
+function resolveTargetIndexes(
+  baseRolls: DiceRoll[],
+  bonus: AprimoramentoDamageBonus
+): number[] {
+  return resolveIndexesByLabel(
+    baseRolls.map((roll) => roll.label),
+    bonus
+  );
 }
 
 /**
@@ -273,8 +284,6 @@ export function augmentSpellRolls(
   const replacementLabels: Array<string | undefined> = baseRolls.map(
     () => undefined
   );
-  const additionalRolls: AugmentedRoll[] = [];
-
   selections.forEach(({ aprimoramento, count }) => {
     if (count <= 0) return;
     resolveBonuses(aprimoramento).forEach((bonus) => {
@@ -310,29 +319,61 @@ export function augmentSpellRolls(
     });
   });
 
+  // Rolagens extras criadas por `additionalRoll` (ex.: o raio da Tempestade
+  // Divina) não existem em `baseRolls` — coletamos todas primeiro, antes do
+  // passe de aumento, para que outros aprimoramentos selecionados na mesma
+  // magia (ex.: "aumenta o dano de raios em +1d8") consigam mirar nelas
+  // independentemente da ordem de seleção.
+  interface AdditionalRollDef {
+    roll: DiceRoll;
+    acc: DiceAccumulator;
+    addedAcc: DiceAccumulator;
+  }
+  const additionalDefs: AdditionalRollDef[] = [];
+  selections.forEach(({ aprimoramento, count }) => {
+    if (count <= 0) return;
+    resolveBonuses(aprimoramento).forEach((bonus) => {
+      if (!bonus.additionalRoll) return;
+      const parsed = parseDamage(bonus.additionalRoll.dice);
+      const acc = newAccumulator();
+      if (parsed) addGroups(acc, parsed.diceGroups, parsed.modifier);
+      additionalDefs.push({
+        roll: bonus.additionalRoll,
+        acc,
+        addedAcc: newAccumulator(),
+      });
+    });
+  });
+
+  const combinedLabels = [
+    ...baseRolls.map((roll) => roll.label),
+    ...additionalDefs.map((def) => def.roll.label),
+  ];
+
   selections.forEach(({ aprimoramento, count }) => {
     if (count <= 0) return;
     const bonuses = resolveBonuses(aprimoramento);
 
     bonuses.forEach((bonus) => {
-      const targetIndexes = resolveTargetIndexes(baseRolls, bonus);
-
-      if (bonus.additionalRoll) {
-        additionalRolls.push({
-          ...bonus.additionalRoll,
-          baseDice: bonus.additionalRoll.dice,
-          isAugmented: false,
-        });
-        return;
-      }
-
+      if (bonus.additionalRoll) return;
       if (bonus.replaceWith || bonus.replaceDamageType || bonus.replaceLabel) {
         return;
       }
 
+      const targetIndexes = resolveIndexesByLabel(combinedLabels, bonus);
+
       targetIndexes.forEach((index) => {
+        const acc =
+          index < baseRolls.length
+            ? baseAcc[index]
+            : additionalDefs[index - baseRolls.length].acc;
+        const targetAddedAcc =
+          index < baseRolls.length
+            ? addedAcc[index]
+            : additionalDefs[index - baseRolls.length].addedAcc;
+
         const activeDieSides = bonus.diceCount
-          ? getSingleDieSides(baseAcc[index])
+          ? getSingleDieSides(acc)
           : undefined;
         const parsedBonus =
           bonus.diceCount && activeDieSides
@@ -351,7 +392,7 @@ export function augmentSpellRolls(
 
         // Nada a somar (ex.: bônus só de texto não numérico).
         if (scaledGroups.length === 0 && scaledModifier === 0) return;
-        addGroups(addedAcc[index], scaledGroups, scaledModifier);
+        addGroups(targetAddedAcc, scaledGroups, scaledModifier);
       });
     });
   });
@@ -391,7 +432,31 @@ export function augmentSpellRolls(
         addedSummary,
       };
     }),
-    ...additionalRolls,
+    ...additionalDefs.map((def) => {
+      const added = def.addedAcc;
+      const isAugmented = hasAny(added);
+
+      const total = newAccumulator();
+      addGroups(total, accToGroups(def.acc), def.acc.modifier);
+      addGroups(total, accToGroups(added), added.modifier);
+
+      let addedSummary: string | undefined;
+      if (isAugmented) {
+        const summary = composeNotation(added);
+        addedSummary =
+          summary.startsWith('+') || summary.startsWith('-')
+            ? summary
+            : `+${summary}`;
+      }
+
+      return {
+        ...def.roll,
+        baseDice: def.roll.dice,
+        dice: isAugmented ? composeNotation(total) : def.roll.dice,
+        isAugmented,
+        addedSummary,
+      };
+    }),
   ];
 }
 

--- a/src/functions/spellRollAugmentation.ts
+++ b/src/functions/spellRollAugmentation.ts
@@ -277,6 +277,41 @@ export function augmentSpellRolls(
 
   selections.forEach(({ aprimoramento, count }) => {
     if (count <= 0) return;
+    resolveBonuses(aprimoramento).forEach((bonus) => {
+      if (
+        !bonus.replaceWith &&
+        !bonus.replaceDamageType &&
+        !bonus.replaceLabel
+      ) {
+        return;
+      }
+
+      const targetIndexes = resolveTargetIndexes(baseRolls, bonus);
+      targetIndexes.forEach((index) => {
+        if (bonus.replaceWith) {
+          const replacement = parseDamage(bonus.replaceWith);
+          if (replacement) {
+            baseAcc[index] = newAccumulator();
+            addGroups(
+              baseAcc[index],
+              replacement.diceGroups,
+              replacement.modifier
+            );
+          }
+        }
+        if (bonus.replaceDamageType) {
+          replacementDamageTypes[index] = bonus.replaceDamageType;
+        }
+        if (bonus.replaceLabel) {
+          replacementLabels[index] = bonus.replaceLabel;
+        }
+        replacementApplied[index] = true;
+      });
+    });
+  });
+
+  selections.forEach(({ aprimoramento, count }) => {
+    if (count <= 0) return;
     const bonuses = resolveBonuses(aprimoramento);
 
     bonuses.forEach((bonus) => {
@@ -292,26 +327,7 @@ export function augmentSpellRolls(
       }
 
       if (bonus.replaceWith || bonus.replaceDamageType || bonus.replaceLabel) {
-        targetIndexes.forEach((index) => {
-          if (bonus.replaceWith) {
-            const replacement = parseDamage(bonus.replaceWith);
-            if (replacement) {
-              baseAcc[index] = newAccumulator();
-              addGroups(
-                baseAcc[index],
-                replacement.diceGroups,
-                replacement.modifier
-              );
-            }
-          }
-          if (bonus.replaceDamageType) {
-            replacementDamageTypes[index] = bonus.replaceDamageType;
-          }
-          if (bonus.replaceLabel) {
-            replacementLabels[index] = bonus.replaceLabel;
-          }
-          replacementApplied[index] = true;
-        });
+        return;
       }
 
       targetIndexes.forEach((index) => {

--- a/src/functions/spellRollAugmentation.ts
+++ b/src/functions/spellRollAugmentation.ts
@@ -270,6 +270,10 @@ export function augmentSpellRolls(
   const replacementDamageTypes: Array<string | undefined> = baseRolls.map(
     () => undefined
   );
+  const replacementLabels: Array<string | undefined> = baseRolls.map(
+    () => undefined
+  );
+  const additionalRolls: AugmentedRoll[] = [];
 
   selections.forEach(({ aprimoramento, count }) => {
     if (count <= 0) return;
@@ -278,7 +282,16 @@ export function augmentSpellRolls(
     bonuses.forEach((bonus) => {
       const targetIndexes = resolveTargetIndexes(baseRolls, bonus);
 
-      if (bonus.replaceWith || bonus.replaceDamageType) {
+      if (bonus.additionalRoll) {
+        additionalRolls.push({
+          ...bonus.additionalRoll,
+          baseDice: bonus.additionalRoll.dice,
+          isAugmented: false,
+        });
+        return;
+      }
+
+      if (bonus.replaceWith || bonus.replaceDamageType || bonus.replaceLabel) {
         targetIndexes.forEach((index) => {
           if (bonus.replaceWith) {
             const replacement = parseDamage(bonus.replaceWith);
@@ -293,6 +306,9 @@ export function augmentSpellRolls(
           }
           if (bonus.replaceDamageType) {
             replacementDamageTypes[index] = bonus.replaceDamageType;
+          }
+          if (bonus.replaceLabel) {
+            replacementLabels[index] = bonus.replaceLabel;
           }
           replacementApplied[index] = true;
         });
@@ -324,37 +340,41 @@ export function augmentSpellRolls(
     });
   });
 
-  return baseRolls.map((roll, index) => {
-    const added = addedAcc[index];
-    const isAugmented = replacementApplied[index] || hasAny(added);
+  return [
+    ...baseRolls.map((roll, index) => {
+      const added = addedAcc[index];
+      const isAugmented = replacementApplied[index] || hasAny(added);
 
-    const total = newAccumulator();
-    addGroups(total, accToGroups(baseAcc[index]), baseAcc[index].modifier);
-    addGroups(total, accToGroups(added), added.modifier);
+      const total = newAccumulator();
+      addGroups(total, accToGroups(baseAcc[index]), baseAcc[index].modifier);
+      addGroups(total, accToGroups(added), added.modifier);
 
-    let addedSummary: string | undefined;
-    if (isAugmented) {
-      const summary = composeNotation(added);
-      if (hasAny(added)) {
-        addedSummary =
-          summary.startsWith('+') || summary.startsWith('-')
-            ? summary
-            : `+${summary}`;
+      let addedSummary: string | undefined;
+      if (isAugmented) {
+        const summary = composeNotation(added);
+        if (hasAny(added)) {
+          addedSummary =
+            summary.startsWith('+') || summary.startsWith('-')
+              ? summary
+              : `+${summary}`;
+        }
       }
-    }
 
-    return {
-      ...roll,
-      baseDice: roll.dice,
-      dice: isAugmented ? composeNotation(total) : roll.dice,
-      damageType: replacementDamageTypes[index] ?? roll.damageType,
-      replacementDice: replacementApplied[index]
-        ? composeNotation(baseAcc[index])
-        : undefined,
-      isAugmented,
-      addedSummary,
-    };
-  });
+      return {
+        ...roll,
+        baseDice: roll.dice,
+        dice: isAugmented ? composeNotation(total) : roll.dice,
+        damageType: replacementDamageTypes[index] ?? roll.damageType,
+        label: replacementLabels[index] ?? roll.label,
+        replacementDice: replacementApplied[index]
+          ? composeNotation(baseAcc[index])
+          : undefined,
+        isAugmented,
+        addedSummary,
+      };
+    }),
+    ...additionalRolls,
+  ];
 }
 
 // Reexport para testes que queiram varrer todos os tokens de dado num texto.

--- a/src/interfaces/Spells.ts
+++ b/src/interfaces/Spells.ts
@@ -18,10 +18,16 @@ export interface AprimoramentoDamageBonus {
    * (o vínculo resolve para ela automaticamente).
    */
   targetRollLabel?: string;
-  /** Dado somado por ativação, ex.: "1d6", "2d6", "1d8+2". */
-  dicePerActivation: string;
+  /** Dado literal somado por ativação, ex.: "1d6", "2d6", "1d8+2". */
+  dicePerActivation?: string;
+  /** Quantidade de dados usando o tipo de dado vigente na rolagem. */
+  diceCount?: number;
   /** Bônus fixo por ativação, para "aumenta o dano em 10" (sem dado). */
   flatPerActivation?: number;
+  /** Notação completa que substitui a rolagem base enquanto o aprimoramento está ativo. */
+  replaceWith?: string;
+  /** Tipo de dano que substitui o tipo da rolagem base enquanto ativo. */
+  replaceDamageType?: string;
 }
 
 export interface Aprimoramento {

--- a/src/interfaces/Spells.ts
+++ b/src/interfaces/Spells.ts
@@ -28,6 +28,10 @@ export interface AprimoramentoDamageBonus {
   replaceWith?: string;
   /** Tipo de dano que substitui o tipo da rolagem base enquanto ativo. */
   replaceDamageType?: string;
+  /** Rótulo que substitui o nome da rolagem enquanto o aprimoramento está ativo. */
+  replaceLabel?: string;
+  /** Rolagem extra criada pelo aprimoramento, em vez de alterar a rolagem base. */
+  additionalRoll?: DiceRoll;
 }
 
 export interface Aprimoramento {


### PR DESCRIPTION
https://fichasdenimb.com.br/forum/magia-flecha-de-luz

## 📋 Descrição

* Adicionadas rolagens para magias que não tinham antes, como Flecha de Luz e várias dos suplementos.
* Adicionado mecanismo para rolar dados extras do mesmo tipo e também trocar todos os dados por um dado diferente, compatível com modificações de "aumenta" (como flecha de luz trocando todos os 1d8 por 1d10)
* Adicionado mecanismo pra trocar o nome do dano de uma magia, como em certas magias que trocam o dano de corte pra impacto

## 🎯 Tipo de Mudança

- [x] Bug fix
- [x] Nova funcionalidade
- [x] Melhoria de código
- [ ] Documentação

## 🧪 Testes

- [x] Testes passando
- [x] Novos testes adicionados
- [x] Testado manualmente
