### PR TITLE
fix(aspirante-a-heroi): +1 de atributo não disputa a restrição do Aumento de Atributo

### DIFF
--- a/src/components/LevelUpWizard/LevelUpWizardModal.tsx
+++ b/src/components/LevelUpWizard/LevelUpWizardModal.tsx
@@ -1489,6 +1489,13 @@ const LevelUpWizardModal: React.FC<LevelUpWizardModalProps> = ({
             const plateau = getCurrentPlateau({
               nivel: currentLevel,
             } as CharacterSheet);
+            // Aumentos de fontes sem a restrição de 1×/patamar não podem
+            // bloquear o atributo para o poder Aumento de Atributo.
+            const oncePerTier = !selectedPower.sheetActions?.some(
+              (sheetAction) =>
+                sheetAction.action.type === 'increaseAttribute' &&
+                sheetAction.action.oncePerTier === false
+            );
             const newHistoryEntries: SheetActionHistoryEntry[] =
               powerEffects.attributes.map((attr) => ({
                 source: { type: 'power' as const, name: selectedPower.name },
@@ -1498,6 +1505,7 @@ const LevelUpWizardModal: React.FC<LevelUpWizardModalProps> = ({
                     type: 'AttributeIncreasedByAumentoDeAtributo' as const,
                     attribute: attr as Atributo,
                     plateau,
+                    oncePerTier,
                   },
                 ],
               }));

--- a/src/data/systems/tormenta20/atlas-de-arton/powers/originPowers.ts
+++ b/src/data/systems/tormenta20/atlas-de-arton/powers/originPowers.ts
@@ -126,7 +126,9 @@ const atlasOriginPowers: Record<string, OriginPower> = {
     sheetActions: [
       {
         source: { type: 'power', name: 'Aspirante a Herói' },
-        action: { type: 'increaseAttribute' },
+        // Não é o poder Aumento de Atributo: pode cair no mesmo atributo que
+        // já recebeu o aumento do patamar.
+        action: { type: 'increaseAttribute', oncePerTier: false },
       },
     ],
   },

--- a/src/data/systems/tormenta20/deuses-de-arton/races/suragelAbilities.ts
+++ b/src/data/systems/tormenta20/deuses-de-arton/races/suragelAbilities.ts
@@ -200,6 +200,9 @@ export const SURAGEL_ALTERNATIVE_ABILITIES: SuragelAlternativeAbility[] = [
         source: { type: 'power', name: 'Herança de Al-Gazara' },
         action: {
           type: 'increaseAttribute',
+          // Bônus racial, não o poder Aumento de Atributo: não disputa a
+          // restrição de 1×/patamar.
+          oncePerTier: false,
         },
       },
     ],

--- a/src/functions/__tests__/aspiranteAHeroiAumentoAtributo.spec.ts
+++ b/src/functions/__tests__/aspiranteAHeroiAumentoAtributo.spec.ts
@@ -1,0 +1,83 @@
+import { Atributo } from '../../data/systems/tormenta20/atributos';
+import atlasOriginPowers from '../../data/systems/tormenta20/atlas-de-arton/powers/originPowers';
+import CharacterSheet from '../../interfaces/CharacterSheet';
+import { getAttributeIncreasesInSamePlateau } from '../powers/general';
+import {
+  getFilteredAvailableOptions,
+  getPowerSelectionRequirements,
+} from '../powers/manualPowerSelection';
+
+/**
+ * Aspirante a Herói (Atlas de Arton) concede +1 em um atributo, mas NÃO é o
+ * poder Aumento de Atributo — logo não está sujeito à regra de "um atributo
+ * diferente por patamar" nem consome o atributo do Aumento de Atributo.
+ */
+describe('Aspirante a Herói x Aumento de Atributo', () => {
+  const sheetWith = (
+    increases: { attribute: Atributo; oncePerTier?: boolean; power?: string }[]
+  ): CharacterSheet =>
+    ({
+      nivel: 2,
+      sheetActionHistory: increases.map((inc) => ({
+        source: { type: 'power' as const, name: inc.power ?? 'x' },
+        powerName: inc.power ?? 'x',
+        changes: [
+          {
+            type: 'AttributeIncreasedByAumentoDeAtributo' as const,
+            attribute: inc.attribute,
+            plateau: 1,
+            ...(inc.oncePerTier === undefined
+              ? {}
+              : { oncePerTier: inc.oncePerTier }),
+          },
+        ],
+      })),
+    } as unknown as CharacterSheet);
+
+  it('marca o aumento do poder como sem restrição de patamar', () => {
+    const [action] = atlasOriginPowers.ASPIRANTE_A_HEROI.sheetActions ?? [];
+    expect(action.action).toMatchObject({
+      type: 'increaseAttribute',
+      oncePerTier: false,
+    });
+  });
+
+  it('não conta no limite do patamar um aumento sem a restrição', () => {
+    expect(
+      getAttributeIncreasesInSamePlateau(
+        sheetWith([{ attribute: Atributo.FORCA, oncePerTier: false }])
+      )
+    ).toEqual([]);
+
+    // Fichas antigas (sem o campo) e o próprio Aumento de Atributo continuam
+    // bloqueando o atributo no patamar.
+    expect(
+      getAttributeIncreasesInSamePlateau(
+        sheetWith([{ attribute: Atributo.FORCA }])
+      )
+    ).toEqual([Atributo.FORCA]);
+  });
+
+  it('ignora o bloqueio gravado em fichas antigas (sem o campo)', () => {
+    expect(
+      getAttributeIncreasesInSamePlateau(
+        sheetWith([{ attribute: Atributo.FORCA, power: 'Aspirante a Herói' }])
+      )
+    ).toEqual([]);
+  });
+
+  it('oferece todos os atributos mesmo com o aumento do patamar já usado', () => {
+    const requirements = getPowerSelectionRequirements(
+      atlasOriginPowers.ASPIRANTE_A_HEROI
+    );
+    const requirement = requirements?.requirements.find(
+      (req) => req.type === 'increaseAttribute'
+    );
+    expect(requirement?.metadata?.oncePerTier).toBe(false);
+
+    const sheet = sheetWith([{ attribute: Atributo.FORCA }]);
+    const options = getFilteredAvailableOptions(requirement!, sheet);
+    expect(options).toContain(Atributo.FORCA);
+    expect(options).toHaveLength(Object.values(Atributo).length);
+  });
+});

--- a/src/functions/general.ts
+++ b/src/functions/general.ts
@@ -2472,6 +2472,9 @@ export const applyPower = (
                 type: 'AttributeIncreasedByAumentoDeAtributo',
                 attribute: targetAttribute,
                 plateau: getCurrentPlateau(sheet),
+                // Aumentos sem a restrição (ex.: Aspirante a Herói) não podem
+                // bloquear o atributo para o Aumento de Atributo do patamar.
+                oncePerTier,
               },
             ],
           });

--- a/src/functions/powers/general.ts
+++ b/src/functions/powers/general.ts
@@ -144,6 +144,16 @@ export function getDeitySpellCircleWarning(
   );
 }
 
+/**
+ * Fichas criadas antes do campo `oncePerTier` no histórico: nelas o aumento
+ * destes poderes foi gravado igual ao do Aumento de Atributo e bloqueava
+ * indevidamente o atributo no patamar. Identificados pelo nome do poder.
+ */
+const LEGACY_UNRESTRICTED_INCREASE_POWERS = [
+  'Aspirante a Herói',
+  'Herança de Al-Gazara',
+];
+
 export function getAttributeIncreasesInSamePlateau(
   sheet: CharacterSheet
 ): Atributo[] {
@@ -151,9 +161,15 @@ export function getAttributeIncreasesInSamePlateau(
 
   const attibutesIncreasedInSamePlateau: Atributo[] = [];
   sheet.sheetActionHistory.forEach((sah) => {
+    if (
+      sah.powerName &&
+      LEGACY_UNRESTRICTED_INCREASE_POWERS.includes(sah.powerName)
+    )
+      return;
     sah.changes.forEach((change) => {
       if (
         change.type === 'AttributeIncreasedByAumentoDeAtributo' &&
+        change.oncePerTier !== false &&
         change.plateau === plateau
       ) {
         attibutesIncreasedInSamePlateau.push(change.attribute);

--- a/src/functions/powers/manualPowerSelection.ts
+++ b/src/functions/powers/manualPowerSelection.ts
@@ -218,6 +218,11 @@ export function getPowerSelectionRequirements(
           availableOptions: [], // Will be populated dynamically in getFilteredAvailableOptions
           pick: 1, // Always pick 1 attribute
           label: 'Selecione 1 atributo para aumentar',
+          metadata: {
+            // Fontes sem a restrição de 1×/patamar (ex.: Aspirante a Herói)
+            // podem repetir um atributo já aumentado no patamar.
+            oncePerTier: action.oncePerTier !== false,
+          },
         });
       }
 
@@ -810,8 +815,13 @@ export function getFilteredAvailableOptions(
     }
 
     case 'increaseAttribute': {
-      // Get attributes that haven't been increased in the current plateau
-      const usedAttributes = getAttributeIncreasesInSamePlateau(sheet);
+      // Get attributes that haven't been increased in the current plateau.
+      // Só vale para fontes com a restrição do poder Aumento de Atributo —
+      // Aspirante a Herói e afins listam todos os atributos.
+      const usedAttributes =
+        requirement.metadata?.oncePerTier === false
+          ? []
+          : getAttributeIncreasesInSamePlateau(sheet);
       // Idades Variadas (Heróis de Arton, p. 290): Velhos e Anciões "não podem
       // escolher o poder Aumento de Atributo para nenhum atributo físico".
       // Filtrar aqui cobre de uma vez o assistente de criação, o de evolução e

--- a/src/interfaces/CharacterSheet.ts
+++ b/src/interfaces/CharacterSheet.ts
@@ -325,6 +325,10 @@ export type SheetActionReceipt =
       type: 'AttributeIncreasedByAumentoDeAtributo';
       attribute: Atributo;
       plateau: number; // Plateau number for the increase
+      // `false` quando o aumento veio de uma fonte sem a restrição de 1×/patamar
+      // do poder Aumento de Atributo (ex.: Aspirante a Herói). Ausente em fichas
+      // antigas e nos aumentos do próprio Aumento de Atributo — ambos contam.
+      oncePerTier?: boolean;
     }
   | {
       type: 'ClassAbilityLearned';

--- a/src/interfaces/PowerSelections.ts
+++ b/src/interfaces/PowerSelections.ts
@@ -107,6 +107,9 @@ export interface PowerSelectionRequirement {
     // piso `minPick`. Só quem tem a ficha consegue resolver.
     pickByAttribute?: Atributo;
     minPick?: number;
+    // For increaseAttribute: `false` quando a fonte não tem a restrição de
+    // 1×/patamar do poder Aumento de Atributo (ex.: Aspirante a Herói).
+    oncePerTier?: boolean;
   };
 }
 


### PR DESCRIPTION
## Bug

Reportado por usuário: ao pegar **Aspirante a Herói** (origem, Atlas de Arton) e o **Aumento de Atributo** do patamar iniciante, não dava para escolher o mesmo atributo nos dois.

## Causa

Aspirante a Herói declara `action: { type: 'increaseAttribute' }` sem flag, e o motor assume `oncePerTier = true` por padrão — aplicando a regra do poder *Aumento de Atributo* ("não pode aumentar o mesmo atributo mais de uma vez por patamar"), que Aspirante a Herói **não** tem. O bloqueio era mútuo: a listagem de opções (`getFilteredAvailableOptions`) ignorava a flag e o histórico gravava a entrada de patamar sem distinguir a fonte.

## Correção

- `oncePerTier` agora chega até a UI: vira `metadata.oncePerTier` no requisito de seleção, e `getFilteredAvailableOptions` só filtra atributos já usados no patamar quando a fonte tem a restrição.
- O histórico (`AttributeIncreasedByAumentoDeAtributo`) passa a gravar `oncePerTier`, e `getAttributeIncreasesInSamePlateau` ignora os `false` — funciona nas duas ordens de escolha. O `LevelUpWizardModal`, que grava a entrada por conta própria, deriva a flag do poder selecionado.
- **Aspirante a Herói** e **Herança de Al-Gazara** (Suragel — mesmo caso: +1 racial, sem a regra) marcados como `oncePerTier: false`.
- Fichas antigas: entradas desses dois poderes já salvas (sem o campo novo) são ignoradas por nome no cálculo do patamar, senão continuariam bloqueando.

## Testes

- Novo `src/functions/__tests__/aspiranteAHeroiAumentoAtributo.spec.ts` (4 casos): flag no dado, histórico sem restrição não conta no patamar, ficha antiga destravada, e listagem oferecendo todos os atributos.
- Suíte completa: 2825 testes passando. `npx tsc --noEmit` e ESLint limpos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)