### PR TITLE
fix: PV/PM multiclasse corrompidos ao salvar informações básicas

### DIFF
--- a/src/components/SheetResult/EditDrawers/SheetInfoEditDrawer.tsx
+++ b/src/components/SheetResult/EditDrawers/SheetInfoEditDrawer.tsx
@@ -31,7 +31,11 @@ import {
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import CharacterSheet, { Step, SubStep } from '@/interfaces/CharacterSheet';
+import CharacterSheet, {
+  ClassLevelEntry,
+  Step,
+  SubStep,
+} from '@/interfaces/CharacterSheet';
 import { AttributeVariant } from '@/interfaces/Race';
 import { dataRegistry } from '@/data/registry';
 import Divindade from '@/interfaces/Divindade';
@@ -104,6 +108,7 @@ import {
   calculateMulticlassPM,
   findClassDescription,
   reconcileClassLevels,
+  setClassLevelCounts,
 } from '@/functions/multiclass';
 import NumberField from '@/components/common/NumberField';
 import OriginEditDrawer from './OriginEditDrawer';
@@ -209,6 +214,9 @@ interface EditedData {
   manualMaxPM: number | undefined; // Manual max PM override
   tradicaoPerdidaPmAttribute: Atributo | undefined; // Tradição Perdida: atributo do PM (undefined = atributo da classe)
   imageUrl: string;
+  // Só em fichas multiclasse: distribuição de níveis por classe, editável campo
+  // a campo. `nivel` acompanha o total.
+  classLevels: ClassLevelEntry[] | undefined;
 }
 
 // Detecta se a configuração do Duende foi de fato editada em relação ao estado
@@ -345,6 +353,7 @@ const SheetInfoEditDrawer: React.FC<SheetInfoEditDrawerProps> = ({
     manualMaxPM: sheet.manualMaxPM,
     tradicaoPerdidaPmAttribute: sheet.tradicaoPerdidaPmAttribute,
     imageUrl: sheet.imageUrl || '',
+    classLevels: sheet.classLevels,
   });
 
   // State for image preview error
@@ -431,6 +440,7 @@ const SheetInfoEditDrawer: React.FC<SheetInfoEditDrawerProps> = ({
       manualMaxPM: sheet.manualMaxPM,
       tradicaoPerdidaPmAttribute: sheet.tradicaoPerdidaPmAttribute,
       imageUrl: sheet.imageUrl || '',
+      classLevels: sheet.classLevels,
     });
     setImagePreviewError(false);
     setNameSuggestions(
@@ -787,6 +797,37 @@ const SheetInfoEditDrawer: React.FC<SheetInfoEditDrawerProps> = ({
     onClose();
   };
 
+  // Contagem de níveis por classe da ficha multiclasse, na ordem em que as
+  // classes aparecem (a primeira é a primária, a única que soma o PV base).
+  const classLevelCounts = React.useMemo(() => {
+    const counts = new Map<string, number>();
+    (editedData.classLevels ?? []).forEach((cl) => {
+      counts.set(cl.className, (counts.get(cl.className) ?? 0) + 1);
+    });
+    return counts;
+  }, [editedData.classLevels]);
+
+  const handleClassLevelChange = (className: string, value: number | null) => {
+    const current = editedData.classLevels;
+    if (!current) return;
+
+    const next = new Map(classLevelCounts);
+    // Mínimo 1: zerar uma classe a removeria da ficha sem reverter o que ela
+    // concedeu (habilidades, magias, perícias). Remoção de classe é trabalho do
+    // assistente, não deste campo.
+    next.set(className, Math.max(value ?? 1, 1));
+
+    const total = Array.from(next.values()).reduce((sum, n) => sum + n, 0);
+    if (total > 20) return;
+
+    const rebuilt = setClassLevelCounts(current, next);
+    setEditedData((prev) => ({
+      ...prev,
+      classLevels: rebuilt,
+      nivel: rebuilt.length,
+    }));
+  };
+
   const handleSave = () => {
     // Escolha embutida da herança de Suraggel. Gravar em `optionChoices` ANTES do
     // recálculo é o que faz a escolha valer: o replay de `chooseFromOptions`
@@ -1068,12 +1109,15 @@ const SheetInfoEditDrawer: React.FC<SheetInfoEditDrawerProps> = ({
     const attributesChanged =
       JSON.stringify(editedData.attributes) !== JSON.stringify(sheet.atributos);
 
-    // Check if custom PV/PM values changed
+    // Check if custom PV/PM values changed.
+    // `bonusPV`/`bonusPM` são semeados no editedData como `sheet.bonusX || 0`,
+    // então comparar direto com o sheet acusa mudança em toda ficha que tem o
+    // campo `undefined` — abrir e salvar sem editar nada já disparava recálculo.
     const customPVPMChanged =
       editedData.customPVPerLevel !== sheet.customPVPerLevel ||
       editedData.customPMPerLevel !== sheet.customPMPerLevel ||
-      editedData.bonusPV !== sheet.bonusPV ||
-      editedData.bonusPM !== sheet.bonusPM;
+      editedData.bonusPV !== (sheet.bonusPV || 0) ||
+      editedData.bonusPM !== (sheet.bonusPM || 0);
 
     // Track custom PV/PM changes in steps
     if (customPVPMChanged) {
@@ -1158,44 +1202,12 @@ const SheetInfoEditDrawer: React.FC<SheetInfoEditDrawerProps> = ({
       }
     }
 
-    // Recalculate level-dependent values if level changed
+    // Recalculate level-dependent values if level changed.
+    // PV/PM ficam por conta do `recalculateSheet` no fim do save: `recalculatePV`
+    // e `recalculatePM` só sabem a fórmula mono-classe (classe primária × nível
+    // total) e devolveriam o número errado numa ficha multiclasse.
     if (editedData.nivel !== sheet.nivel) {
       updates.completeSkills = recalculateSkills(editedData.nivel);
-      updates.pv = recalculatePV(
-        editedData.nivel,
-        editedData.className,
-        editedData.attributes,
-        editedData.customPVPerLevel,
-        editedData.bonusPV
-      );
-      updates.pm = recalculatePM(
-        editedData.nivel,
-        editedData.className,
-        editedData.attributes,
-        editedData.customPMPerLevel,
-        editedData.bonusPM
-      );
-    }
-
-    // Recalculate PV/PM if attributes or custom values changed (even if level didn't change)
-    if (
-      (attributesChanged || customPVPMChanged) &&
-      editedData.nivel === sheet.nivel
-    ) {
-      updates.pv = recalculatePV(
-        editedData.nivel,
-        editedData.className,
-        editedData.attributes,
-        editedData.customPVPerLevel,
-        editedData.bonusPV
-      );
-      updates.pm = recalculatePM(
-        editedData.nivel,
-        editedData.className,
-        editedData.attributes,
-        editedData.customPMPerLevel,
-        editedData.bonusPM
-      );
     }
 
     // Find and update race if changed OR sex changed (for sex-dependent races like Nagah) OR heritage changed (for Moreau) OR Golem Desperto customization changed OR Suraggel ability changed
@@ -1471,10 +1483,21 @@ const SheetInfoEditDrawer: React.FC<SheetInfoEditDrawerProps> = ({
     const heritageChanged =
       editedData.raceName === 'Moreau' &&
       editedData.raceHeritage !== sheet.raceHeritage;
-    // Mantém classLevels em sincronia com o nível editado (multiclasse).
-    // Sem isso, baixar o nível deixaria entradas a mais, que um level-up futuro
-    // transformaria num nível fantasma da classe primária.
-    if (levelChanged && sheet.classLevels) {
+    // Numa ficha multiclasse a distribuição vem dos campos por classe — que já
+    // mantêm `nivel` como a soma. Vale também quando o total não muda (trocar um
+    // nível de uma classe por outra).
+    const classLevelsChanged =
+      sheetIsMulticlass &&
+      JSON.stringify(editedData.classLevels) !==
+        JSON.stringify(sheet.classLevels);
+
+    if (classLevelsChanged) {
+      updates.classLevels = editedData.classLevels;
+    } else if (levelChanged && sheet.classLevels) {
+      // Mono-classe (ou ficha com classLevels de uma classe só): mantém
+      // classLevels em sincronia com o nível editado. Sem isso, baixar o nível
+      // deixaria entradas a mais, que um level-up futuro transformaria num
+      // nível fantasma da classe primária.
       updates.classLevels = reconcileClassLevels(
         sheet.classLevels,
         editedData.nivel,
@@ -1500,7 +1523,9 @@ const SheetInfoEditDrawer: React.FC<SheetInfoEditDrawerProps> = ({
       raceChanged ||
       deityChanged ||
       levelChanged ||
+      classLevelsChanged ||
       manualMaxChanged ||
+      customPVPMChanged ||
       heritageChanged ||
       suragelChanged ||
       moreauSapienciaSpellChanged ||
@@ -1568,6 +1593,7 @@ const SheetInfoEditDrawer: React.FC<SheetInfoEditDrawerProps> = ({
       manualMaxPM: sheet.manualMaxPM,
       tradicaoPerdidaPmAttribute: sheet.tradicaoPerdidaPmAttribute,
       imageUrl: sheet.imageUrl || '',
+      classLevels: sheet.classLevels,
     });
     setImagePreviewError(false);
     setNameSuggestions(
@@ -2086,6 +2112,12 @@ const SheetInfoEditDrawer: React.FC<SheetInfoEditDrawerProps> = ({
                       }
                       min={1}
                       max={20}
+                      disabled={sheetIsMulticlass}
+                      helperText={
+                        sheetIsMulticlass
+                          ? 'Ajuste os níveis por classe abaixo'
+                          : undefined
+                      }
                     />
                     <Tooltip
                       title={
@@ -2110,6 +2142,50 @@ const SheetInfoEditDrawer: React.FC<SheetInfoEditDrawerProps> = ({
                       </span>
                     </Tooltip>
                   </Stack>
+
+                  {sheetIsMulticlass && (
+                    <Box>
+                      <Typography
+                        variant='caption'
+                        sx={{ color: 'text.secondary' }}
+                      >
+                        Níveis por classe (o nível total é a soma)
+                      </Typography>
+                      <Stack
+                        direction='row'
+                        spacing={1}
+                        sx={{ mt: 1, flexWrap: 'wrap', gap: 1 }}
+                      >
+                        {Array.from(classLevelCounts.entries()).map(
+                          ([className, count]) => (
+                            <NumberField
+                              key={className}
+                              label={className}
+                              value={count}
+                              onValueChange={(v) =>
+                                handleClassLevelChange(className, v)
+                              }
+                              min={1}
+                              max={20}
+                              sx={{ minWidth: 140, flex: '1 1 140px' }}
+                            />
+                          )
+                        )}
+                      </Stack>
+                      <Typography
+                        variant='caption'
+                        sx={{
+                          display: 'block',
+                          mt: 1,
+                          color: 'text.secondary',
+                        }}
+                      >
+                        Ajuste manual: não concede habilidades, magias nem
+                        poderes novos. Para subir de nível de verdade, use o
+                        Subir Nível.
+                      </Typography>
+                    </Box>
+                  )}
 
                   <FormControl fullWidth>
                     <InputLabel>Gênero</InputLabel>

--- a/src/data/systems/tormenta20/races/anao.ts
+++ b/src/data/systems/tormenta20/races/anao.ts
@@ -107,14 +107,14 @@ const ANAO: Race = {
       ],
     },
     {
-      name: 'Duro com Pedra',
+      name: 'Duro como Pedra',
       description:
         'Você recebe +3 pontos de vida no 1º nível e +1 por nível seguinte.',
       sheetBonuses: [
         {
           source: {
             type: 'power',
-            name: 'Duro com Pedra',
+            name: 'Duro como Pedra',
           },
           target: {
             type: 'PV',

--- a/src/functions/__tests__/multiclass.spec.ts
+++ b/src/functions/__tests__/multiclass.spec.ts
@@ -9,6 +9,7 @@ import {
   getClassLevelsMap,
   initializeClassLevels,
   reconcileClassLevels,
+  setClassLevelCounts,
   getMulticlassDisplayName,
   calculateMulticlassPV,
   calculateMulticlassPM,
@@ -239,6 +240,82 @@ describe('reconcileClassLevels', () => {
       { level: 1, className: 'Arcanista', classSubname: 'Mago' },
       { level: 2, className: 'Arcanista', classSubname: 'Mago' },
     ]);
+  });
+});
+
+// ===== setClassLevelCounts =====
+describe('setClassLevelCounts', () => {
+  const E = (className: string, level: number) => ({ level, className });
+  const names = (arr: { className: string }[]) => arr.map((c) => c.className);
+  // Guerreiro 1 / Necromante 4
+  const base = [
+    E('Guerreiro', 1),
+    E('Necromante', 2),
+    E('Necromante', 3),
+    E('Necromante', 4),
+    E('Necromante', 5),
+  ];
+
+  test('cresce uma classe adicionando os níveis no fim', () => {
+    const out = setClassLevelCounts(
+      base,
+      new Map([
+        ['Guerreiro', 2],
+        ['Necromante', 4],
+      ])
+    );
+    expect(names(out)).toEqual([
+      'Guerreiro',
+      'Necromante',
+      'Necromante',
+      'Necromante',
+      'Necromante',
+      'Guerreiro',
+    ]);
+    expect(out.map((cl) => cl.level)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  test('encolhe removendo os níveis mais altos da classe', () => {
+    const out = setClassLevelCounts(
+      base,
+      new Map([
+        ['Guerreiro', 1],
+        ['Necromante', 2],
+      ])
+    );
+    expect(names(out)).toEqual(['Guerreiro', 'Necromante', 'Necromante']);
+    expect(out.map((cl) => cl.level)).toEqual([1, 2, 3]);
+  });
+
+  test('mantém a classe primária na primeira posição', () => {
+    const out = setClassLevelCounts(
+      base,
+      new Map([
+        ['Guerreiro', 1],
+        ['Necromante', 9],
+      ])
+    );
+    expect(out[0].className).toBe('Guerreiro');
+    expect(out).toHaveLength(10);
+  });
+
+  test('preserva classSubname nos níveis criados', () => {
+    const withSub = [
+      { level: 1, className: 'Arcanista', classSubname: 'Mago' },
+    ];
+    const out = setClassLevelCounts(withSub, new Map([['Arcanista', 3]]));
+    expect(out.every((cl) => cl.classSubname === 'Mago')).toBe(true);
+  });
+
+  test('é no-op quando as contagens não mudam', () => {
+    const out = setClassLevelCounts(
+      base,
+      new Map([
+        ['Guerreiro', 1],
+        ['Necromante', 4],
+      ])
+    );
+    expect(out).toEqual(base);
   });
 });
 

--- a/src/functions/__tests__/multiclassPVOnSave.spec.ts
+++ b/src/functions/__tests__/multiclassPVOnSave.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { cloneDeep } from 'lodash';
+import CharacterSheet from '@/interfaces/CharacterSheet';
+import { Atributo } from '@/data/systems/tormenta20/atributos';
+import { createMockCharacterSheet } from '@/__mocks__/characterSheet';
+import {
+  calculateMulticlassPV,
+  findClassDescription,
+} from '@/functions/multiclass';
+import { recalculateSheet } from '@/functions/recalculateSheet';
+
+// Anão CON +2, Guerreiro 1 / Necromante 4, +7 de PV vindo de bônus (Duro como Pedra)
+function makeSheet(): CharacterSheet {
+  const base = createMockCharacterSheet();
+  base.classe = cloneDeep(findClassDescription('Guerreiro')!);
+  base.nivel = 5;
+  base.atributos[Atributo.CONSTITUICAO].value = 2;
+  base.bonusPV = 7;
+  base.classLevels = [
+    { level: 1, className: 'Guerreiro' },
+    { level: 2, className: 'Necromante' },
+    { level: 3, className: 'Necromante' },
+    { level: 4, className: 'Necromante' },
+    { level: 5, className: 'Necromante' },
+  ];
+  base.pv = calculateMulticlassPV(base);
+  return base;
+}
+
+describe('PV multiclasse Guerreiro 1 / Necromante 4', () => {
+  it('preview e valor recalculado batem em 45', () => {
+    const sheet = makeSheet();
+    expect(calculateMulticlassPV(sheet)).toBe(45);
+
+    // O que o save faz agora: delega PV/PM ao recalculateSheet
+    const saved = recalculateSheet(cloneDeep(sheet));
+    expect(saved.pv).toBe(45);
+  });
+
+  it('nao cai na formula mono-classe (57)', () => {
+    const sheet = makeSheet();
+    const saved = recalculateSheet(cloneDeep(sheet));
+    // 57 = 20 (base Guerreiro) + 2 (CON) + 7*4 (niveis como Guerreiro) + 7
+    expect(saved.pv).not.toBe(57);
+  });
+});

--- a/src/functions/multiclass.ts
+++ b/src/functions/multiclass.ts
@@ -104,6 +104,45 @@ export function reconcileClassLevels(
 }
 
 /**
+ * Reconstrói `classLevels` a partir da quantidade desejada de níveis por classe.
+ *
+ * Preserva a ordem original das entradas (e, com ela, a classe primária — a
+ * primeira entrada, a única que soma o PV base). Quando uma classe encolhe, saem
+ * os níveis mais altos dela; quando cresce, os novos entram no fim.
+ *
+ * Usado pelo editor de níveis por classe da ficha multiclasse.
+ */
+export function setClassLevelCounts(
+  classLevels: ClassLevelEntry[],
+  counts: Map<string, number>
+): ClassLevelEntry[] {
+  const kept: ClassLevelEntry[] = [];
+  const keptPerClass = new Map<string, number>();
+
+  classLevels.forEach((cl) => {
+    const target = counts.get(cl.className) ?? 0;
+    const soFar = keptPerClass.get(cl.className) ?? 0;
+    if (soFar < target) {
+      kept.push(cl);
+      keptPerClass.set(cl.className, soFar + 1);
+    }
+  });
+
+  counts.forEach((target, className) => {
+    const existing = classLevels.find((cl) => cl.className === className);
+    for (let i = keptPerClass.get(className) ?? 0; i < target; i += 1) {
+      kept.push({
+        level: 0, // renumerado abaixo
+        className,
+        classSubname: existing?.classSubname,
+      });
+    }
+  });
+
+  return kept.map((cl, i) => ({ ...cl, level: i + 1 }));
+}
+
+/**
  * Retorna string de display para multiclasse.
  * Ex: "Arcanista 3 / Paladino 1" ou "Guerreiro 5" (mono-classe).
  */


### PR DESCRIPTION
## 📋 Descrição

Ver: https://fichasdenimb.com.br/forum/bug-ao-anexar-imagem-de-url-na-ficha-depois-de-criar-o-personagem

Abrir "Informações Básicas" de uma ficha multiclasse e clicar em salvar **sem editar nada** corrompia o PV/PM: o valor pulava do correto para o da fórmula mono-classe (Guerreiro 1 / Necromante 4, anão CON +2: 45 → 57). A preview no próprio drawer mostrava o valor certo, porque usa um cálculo diferente do que o save gravava.

Duas causas somadas:

- `customPVPMChanged` comparava `editedData.bonusPV` — semeado como `sheet.bonusPV || 0` — direto com `sheet.bonusPV`. Em toda ficha com o campo `undefined`, `0 !== undefined` acusava mudança sem ninguém ter editado nada.
- Disparada a flag, o save escrevia `updates.pv/pm` via `recalculatePV`/`recalculatePM`, que só conhecem a fórmula mono-classe (classe primária × nível total). Como `customPVPMChanged` não entrava em `shouldUseRecalculateSheet`, o valor errado ia direto para a ficha sem passar pelo `recalculateSheet`, que trata multiclasse corretamente.

### Mudanças

- PV/PM no save passam a ser sempre responsabilidade do `recalculateSheet`; removidos os cálculos mono-classe duplicados no drawer.
- `customPVPMChanged` normaliza `bonusPV`/`bonusPM` com `|| 0`, igual ao resto da função.
- Em ficha multiclasse, o campo de nível único dá lugar a **um campo por classe** (`setClassLevelCounts`): dá para ajustar a distribuição — e o nível total — sem jogar os níveis novos na classe primária, que era o que a edição direta do nível fazia silenciosamente. Mínimo de 1 nível por classe (zerar removeria a classe sem reverter o que ela concedeu).
- Corrige o nome do poder do Anão: "Duro com Pedra" → "Duro como Pedra".

## 🎯 Tipo de Mudança

- [x] Bug fix
- [ ] Nova funcionalidade
- [x] Melhoria de código
- [ ] Documentação

## 🧪 Testes

- [x] Testes passando (2828 testes, 220 arquivos)
- [x] Novos testes adicionados (regressão do caso relatado + 5 casos de `setClassLevelCounts`)
- [x] Testado manualmente

Verificado à parte que a fórmula mono-classe do `recalculateSheet` bate com a que o drawer usava (Guerreiro nv 1 e 5, Arcanista nv 3 e 10, Bárbaro nv 7, incluindo CON negativo e bônus), então fichas de classe única — todas as geradas aleatoriamente — não mudam de comportamento.