### PR TITLE
fix: poderes faltantes do Ameaças de Arton, Ginete Altivo como Ginete e poder de suplemento no gerador aleatório

### DIFF
--- a/src/data/systems/tormenta20/ameacas-de-arton/powers/__tests__/destinyPowers.spec.ts
+++ b/src/data/systems/tormenta20/ameacas-de-arton/powers/__tests__/destinyPowers.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GeneralPower,
+  GeneralPowerType,
+  RequirementType,
+} from '../../../../../../interfaces/Poderes';
+import { Atributo } from '../../../atributos';
+import AMEACAS_ARTON_POWERS from '..';
+import { recalculateSheet } from '../../../../../../functions/recalculateSheet';
+import { createMockCharacterSheet } from '../../../../../../__mocks__/characterSheet';
+import CharacterSheet from '../../../../../../interfaces/CharacterSheet';
+
+const find = (name: string) =>
+  Object.values(AMEACAS_ARTON_POWERS)
+    .flat()
+    .find((p) => p.name === name);
+
+/**
+ * O poder promete +2 PV e +2 PM. Um teste que só olhasse o dado passaria com
+ * `sheetBonuses` escrito errado — daí o recálculo comparativo: mede a ficha com
+ * e sem o poder e cobra a diferença de 2, que é o que o jogador vê.
+ */
+const sheetWith = (powers: GeneralPower[]): CharacterSheet =>
+  recalculateSheet({
+    ...createMockCharacterSheet(),
+    generalPowers: powers,
+  });
+
+describe('Coração de Dragão (Ameaças de Arton)', () => {
+  const power = find('Coração de Dragão');
+
+  it('é um poder de Destino', () => {
+    expect(power?.type).toBe(GeneralPowerType.DESTINO);
+  });
+
+  it('exige Carisma 2 e 3º nível no mesmo grupo (E, não OU)', () => {
+    expect(power?.requirements).toEqual([
+      [
+        { type: RequirementType.ATRIBUTO, name: Atributo.CARISMA, value: 2 },
+        { type: RequirementType.NIVEL, value: 3 },
+      ],
+    ]);
+  });
+
+  it('cita a regra de limite de parceiros, que não tem automação', () => {
+    expect(power?.description).toContain('dragão jovem');
+    expect(power?.description).toContain('limite de parceiros');
+  });
+
+  it('soma +2 PV e +2 PM na ficha', () => {
+    const semPoder = sheetWith([]);
+    const comPoder = sheetWith([power as GeneralPower]);
+
+    expect(comPoder.pv - semPoder.pv).toBe(2);
+    expect(comPoder.pm - semPoder.pm).toBe(2);
+  });
+});

--- a/src/data/systems/tormenta20/ameacas-de-arton/powers/__tests__/mountPowers.spec.ts
+++ b/src/data/systems/tormenta20/ameacas-de-arton/powers/__tests__/mountPowers.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GeneralPowerType,
+  RequirementType,
+} from '../../../../../../interfaces/Poderes';
+import AMEACAS_ARTON_POWERS from '..';
+import DEUSES_MENORES_POWERS from '../../../deuses-menores/powers';
+
+/**
+ * Ameaças de Arton publica quatro poderes de montaria que nunca haviam sido
+ * cadastrados. Este teste guarda a presença deles no balde certo e a cadeia de
+ * pré-requisitos — inclusive o elo com "Ginete Altivo", o concedido de Hippion
+ * que "conta como o poder Ginete".
+ */
+const allPowers = Object.values(AMEACAS_ARTON_POWERS).flat();
+const find = (name: string) => allPowers.find((p) => p.name === name);
+
+describe('poderes de montaria (Ameaças de Arton)', () => {
+  it('cadastra os quatro poderes no tipo do livro', () => {
+    expect(find('Combate Montado')?.type).toBe(GeneralPowerType.COMBATE);
+    expect(find('Resistência Montada')?.type).toBe(GeneralPowerType.COMBATE);
+    expect(find('Adestrar Montaria')?.type).toBe(GeneralPowerType.DESTINO);
+    expect(find('Dois Como Um')?.type).toBe(GeneralPowerType.DESTINO);
+  });
+
+  it('Combate Montado e Dois Como Um exigem Ginete', () => {
+    ['Combate Montado', 'Dois Como Um'].forEach((name) => {
+      expect(find(name)?.requirements).toEqual([
+        [{ type: RequirementType.PODER, name: 'Ginete' }],
+      ]);
+    });
+  });
+
+  it('Resistência Montada pende de Combate Montado, não de Ginete', () => {
+    expect(find('Resistência Montada')?.requirements).toEqual([
+      [{ type: RequirementType.PODER, name: 'Combate Montado' }],
+    ]);
+  });
+
+  it('Adestrar Montaria automatiza o +2 em Adestramento', () => {
+    const power = find('Adestrar Montaria');
+    expect(power?.sheetBonuses).toHaveLength(1);
+    expect(power?.sheetBonuses?.[0].modifier).toEqual({
+      type: 'Fixed',
+      value: 2,
+    });
+  });
+
+  it('Ginete Altivo (Hippion) conta como Ginete para essa cadeia', () => {
+    const gineteAltivo = DEUSES_MENORES_POWERS[
+      GeneralPowerType.CONCEDIDOS
+    ].find((p) => p.name === 'Ginete Altivo');
+
+    expect(gineteAltivo?.grantsPowerRequirements).toEqual(['Ginete']);
+  });
+});

--- a/src/data/systems/tormenta20/ameacas-de-arton/powers/destinyPowers.ts
+++ b/src/data/systems/tormenta20/ameacas-de-arton/powers/destinyPowers.ts
@@ -1,0 +1,44 @@
+/**
+ * Poderes de Destino avulsos do Ameaças de Arton.
+ *
+ * Separado de `draconicBlessings`: as Bênçãos Dracônicas são exclusivas do
+ * Kallyanach e limitadas a uma por patamar (`TIER_LIMIT`). Estes aqui são
+ * poderes gerais comuns, abertos a qualquer personagem que cumpra os
+ * pré-requisitos.
+ */
+import {
+  GeneralPower,
+  GeneralPowerType,
+  RequirementType,
+} from '../../../../../interfaces/Poderes';
+import { Atributo } from '../../atributos';
+
+const AMEACAS_ARTON_DESTINY_POWERS: GeneralPower[] = [
+  {
+    name: 'Coração de Dragão',
+    description:
+      'Você recebe +2 PV e +2 PM. Além disso, para você, um dragão jovem conta como um único parceiro para seu limite de parceiros.',
+    type: GeneralPowerType.DESTINO,
+    requirements: [
+      [
+        { type: RequirementType.ATRIBUTO, name: Atributo.CARISMA, value: 2 },
+        { type: RequirementType.NIVEL, value: 3 },
+      ],
+    ],
+    // A regra do limite de parceiros não tem automação na ficha: fica no texto.
+    sheetBonuses: [
+      {
+        source: { type: 'power', name: 'Coração de Dragão' },
+        target: { type: 'PV' },
+        modifier: { type: 'Fixed', value: 2 },
+      },
+      {
+        source: { type: 'power', name: 'Coração de Dragão' },
+        target: { type: 'PM' },
+        modifier: { type: 'Fixed', value: 2 },
+      },
+    ],
+  },
+];
+
+export default AMEACAS_ARTON_DESTINY_POWERS;

--- a/src/data/systems/tormenta20/ameacas-de-arton/powers/index.ts
+++ b/src/data/systems/tormenta20/ameacas-de-arton/powers/index.ts
@@ -5,6 +5,7 @@ import { GeneralPowers } from '../../../../../interfaces/Poderes';
 import DRACONIC_BLESSINGS from './draconicBlessings';
 import KOBOLDS_TALENTS from './koboldsTalents';
 import MECHANICAL_MARVELS from './mechanicalMarvels';
+import AMEACAS_ARTON_DESTINY_POWERS from './destinyPowers';
 import {
   AMEACAS_ARTON_MOUNT_COMBAT_POWERS,
   AMEACAS_ARTON_MOUNT_DESTINY_POWERS,
@@ -18,6 +19,7 @@ const AMEACAS_ARTON_POWERS: GeneralPowers = {
     ...KOBOLDS_TALENTS,
     ...MECHANICAL_MARVELS,
     ...AMEACAS_ARTON_MOUNT_DESTINY_POWERS,
+    ...AMEACAS_ARTON_DESTINY_POWERS,
   ],
   MAGIA: [],
   TORMENTA: [],

--- a/src/data/systems/tormenta20/ameacas-de-arton/powers/index.ts
+++ b/src/data/systems/tormenta20/ameacas-de-arton/powers/index.ts
@@ -5,11 +5,20 @@ import { GeneralPowers } from '../../../../../interfaces/Poderes';
 import DRACONIC_BLESSINGS from './draconicBlessings';
 import KOBOLDS_TALENTS from './koboldsTalents';
 import MECHANICAL_MARVELS from './mechanicalMarvels';
+import {
+  AMEACAS_ARTON_MOUNT_COMBAT_POWERS,
+  AMEACAS_ARTON_MOUNT_DESTINY_POWERS,
+} from './mountPowers';
 
 const AMEACAS_ARTON_POWERS: GeneralPowers = {
-  COMBATE: [],
+  COMBATE: [...AMEACAS_ARTON_MOUNT_COMBAT_POWERS],
   CONCEDIDOS: [],
-  DESTINO: [...DRACONIC_BLESSINGS, ...KOBOLDS_TALENTS, ...MECHANICAL_MARVELS],
+  DESTINO: [
+    ...DRACONIC_BLESSINGS,
+    ...KOBOLDS_TALENTS,
+    ...MECHANICAL_MARVELS,
+    ...AMEACAS_ARTON_MOUNT_DESTINY_POWERS,
+  ],
   MAGIA: [],
   TORMENTA: [],
   RACA: [],

--- a/src/data/systems/tormenta20/ameacas-de-arton/powers/mountPowers.ts
+++ b/src/data/systems/tormenta20/ameacas-de-arton/powers/mountPowers.ts
@@ -1,0 +1,59 @@
+/**
+ * Novos Poderes de Montarias — Ameaças de Arton
+ *
+ * O livro publica quatro poderes montados: dois de Combate e dois de Destino.
+ * `Combate Montado` é a raiz da cadeia (exige Ginete) e `Resistência Montada`
+ * pende dele.
+ */
+import {
+  GeneralPower,
+  GeneralPowerType,
+  RequirementType,
+} from '../../../../../interfaces/Poderes';
+import Skill from '../../../../../interfaces/Skills';
+
+export const AMEACAS_ARTON_MOUNT_COMBAT_POWERS: GeneralPower[] = [
+  {
+    name: 'Combate Montado',
+    description:
+      'Enquanto estiver montado, você recebe +2 em testes de ataque e rolagens de dano com armas.',
+    type: GeneralPowerType.COMBATE,
+    requirements: [[{ type: RequirementType.PODER, name: 'Ginete' }]],
+  },
+  {
+    name: 'Resistência Montada',
+    description:
+      'Enquanto estiver montado, sempre que precisar fazer um teste de resistência, você pode gastar 2 PM para usar Cavalgar no lugar da perícia exigida. Se o teste for contra um efeito que permite um teste para reduzir o dano à metade, você não sofre dano algum se passar. Você ainda sofre dano normal se falhar no teste.',
+    type: GeneralPowerType.COMBATE,
+    requirements: [[{ type: RequirementType.PODER, name: 'Combate Montado' }]],
+  },
+];
+
+export const AMEACAS_ARTON_MOUNT_DESTINY_POWERS: GeneralPower[] = [
+  {
+    name: 'Adestrar Montaria',
+    description:
+      'Você recebe +2 em Adestramento. Além disso, escolha um dos efeitos a seguir. Sua montaria se torna veterana ou recebe a habilidade de um outro tipo de parceiro iniciante, entre ajudante, assassino, besta de carga, combatente, fortão, guardião ou vigilante. No caso do ajudante, o mestre deve aprovar as perícias escolhidas. Você só pode ter uma montaria treinada desta forma por vez e, se perdê-la, pode aplicar um treinamento a outra com uma semana de trabalho.',
+    type: GeneralPowerType.DESTINO,
+    requirements: [
+      [
+        { type: RequirementType.PERICIA, name: Skill.ADESTRAMENTO },
+        { type: RequirementType.NIVEL, value: 7 },
+      ],
+    ],
+    sheetBonuses: [
+      {
+        source: { type: 'power', name: 'Adestrar Montaria' },
+        target: { type: 'Skill', name: Skill.ADESTRAMENTO },
+        modifier: { type: 'Fixed', value: 2 },
+      },
+    ],
+  },
+  {
+    name: 'Dois Como Um',
+    description:
+      'Quando faz um teste de Atletismo, Cavalgar, Iniciativa, Luta, Percepção, Pontaria ou Reflexos enquanto montado, você pode gastar 2 PM para rolar dois dados e usar o melhor resultado.',
+    type: GeneralPowerType.DESTINO,
+    requirements: [[{ type: RequirementType.PODER, name: 'Ginete' }]],
+  },
+];

--- a/src/data/systems/tormenta20/deuses-menores/powers/index.ts
+++ b/src/data/systems/tormenta20/deuses-menores/powers/index.ts
@@ -191,6 +191,10 @@ const DEUSES_MENORES_POWERS: { [key in GeneralPowerType]: GeneralPower[] } = {
         'Enquanto está montado sobre um cavalo, você recebe +2 em testes de ataque e em Cavalgar. Além disso, você passa automaticamente em testes de Cavalgar para não cair do cavalo quando sofre dano e não sofre penalidades para atacar à distância ou lançar magias quando montado em cavalos. Este poder conta como o poder Ginete para efeitos de pré-requisitos de outras habilidades. Se você é um centauro, os benefícios deste poder mudam para: você pode fazer investidas em terreno difícil e não sofre a penalidade de –2 na Defesa por fazer uma investida. Por fim, recebe +2 nas rolagens de dano com armas em investidas.',
       type: GeneralPowerType.CONCEDIDOS,
       requirements: [[{ type: RequirementType.DEVOTO, name: 'Hippion' }]],
+      // "Este poder conta como o poder Ginete para efeitos de pré-requisitos
+      // de outras habilidades" — libera Carga de Cavalaria, Catafractário,
+      // Combate Montado e Dois Como Um sem ter o poder Ginete.
+      grantsPowerRequirements: ['Ginete'],
     },
     {
       name: 'Guardei para Você',

--- a/src/functions/__tests__/generalPowerCatalogScope.spec.ts
+++ b/src/functions/__tests__/generalPowerCatalogScope.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { getPowersAllowedByRequirements } from '../powers';
+import { createMockCharacterSheet } from '../../__mocks__/characterSheet';
+import { SupplementId } from '../../types/supplement.types';
+import { GeneralPowerType } from '../../interfaces/Poderes';
+import Skill from '../../interfaces/Skills';
+import CharacterSheet from '../../interfaces/CharacterSheet';
+
+/**
+ * `getPowersAllowedByRequirements` alimenta o SORTEIO de poder geral (subida de
+ * nível, Propósito de Criação, Humano Versátil, Memória Póstuma…). Ela lia o
+ * catálogo `data/poderes` — o módulo deprecated, que é só o core —, então
+ * nenhum poder geral de suplemento entrava em ficha aleatória, mesmo com o
+ * suplemento ligado. E, como o catálogo é um só, os CONCEDIDOS entravam na
+ * lista: todo concedido tem pré-requisito DEVOTO, que o próprio devoto
+ * satisfaz, então um devoto podia receber um poder da divindade como poder
+ * geral de nível.
+ */
+const trainIn = (sheet: CharacterSheet, skill: Skill) => {
+  const found = sheet.completeSkills?.find((s) => s.name === skill);
+  if (!found) throw new Error(`${skill} ausente no mock`);
+  found.training = 2;
+  sheet.skills.push(skill);
+};
+
+const namesOf = (sheet: CharacterSheet, supplements?: SupplementId[]) =>
+  getPowersAllowedByRequirements(sheet, supplements).map((p) => p.name);
+
+describe('getPowersAllowedByRequirements — escopo do catálogo', () => {
+  it('sem suplemento carimbado, fica no core (comportamento de ficha antiga)', () => {
+    const sheet = createMockCharacterSheet();
+    trainIn(sheet, Skill.CAVALGAR);
+
+    const names = namesOf(sheet);
+
+    expect(names).toContain('Ginete');
+    expect(names).not.toContain('Combate Montado');
+  });
+
+  it('inclui poderes do suplemento quando ele está ativo', () => {
+    const sheet = createMockCharacterSheet();
+    trainIn(sheet, Skill.CAVALGAR);
+    sheet.generalPowers = [{ name: 'Ginete' }] as never;
+
+    const names = namesOf(sheet, [
+      SupplementId.TORMENTA20_CORE,
+      SupplementId.TORMENTA20_AMEACAS_ARTON,
+    ]);
+
+    expect(names).toContain('Combate Montado');
+    expect(names).toContain('Dois Como Um');
+    // Pende de Combate Montado, que a ficha ainda não tem.
+    expect(names).not.toContain('Resistência Montada');
+  });
+
+  it('lê `sheet.supplements` quando ninguém passa a lista', () => {
+    const sheet = createMockCharacterSheet();
+    trainIn(sheet, Skill.CAVALGAR);
+    sheet.generalPowers = [{ name: 'Ginete' }] as never;
+    sheet.supplements = [
+      SupplementId.TORMENTA20_CORE,
+      SupplementId.TORMENTA20_AMEACAS_ARTON,
+    ];
+
+    expect(namesOf(sheet)).toContain('Combate Montado');
+  });
+
+  it('nunca oferece poder concedido nem poder de raça como poder geral', () => {
+    const sheet = createMockCharacterSheet();
+    sheet.devoto = {
+      divindade: { name: 'Khalmyr' },
+      poderes: [],
+    } as never;
+
+    const powers = getPowersAllowedByRequirements(sheet, [
+      SupplementId.TORMENTA20_CORE,
+      SupplementId.TORMENTA20_HEROIS_ARTON,
+    ]);
+
+    expect(powers.map((p) => p.type)).not.toContain(
+      GeneralPowerType.CONCEDIDOS
+    );
+    expect(powers.map((p) => p.type)).not.toContain(GeneralPowerType.RACA);
+    expect(powers.map((p) => p.name)).not.toContain('Espada Justiceira');
+  });
+
+  it('Ginete Altivo (Hippion) libera a cadeia montada no sorteio', () => {
+    const sheet = createMockCharacterSheet();
+    trainIn(sheet, Skill.CAVALGAR);
+    sheet.devoto = {
+      divindade: { name: 'Hippion' },
+      poderes: [{ name: 'Ginete Altivo', grantsPowerRequirements: ['Ginete'] }],
+    } as never;
+
+    const names = namesOf(sheet, [
+      SupplementId.TORMENTA20_CORE,
+      SupplementId.TORMENTA20_AMEACAS_ARTON,
+    ]);
+
+    expect(names).toContain('Combate Montado');
+    expect(names).toContain('Carga de Cavalaria');
+  });
+});

--- a/src/functions/__tests__/randomSheetPowerScope.spec.ts
+++ b/src/functions/__tests__/randomSheetPowerScope.spec.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import generateRandomSheet from '../general';
+import { SupplementId } from '../../types/supplement.types';
+import { GeneralPowerType } from '../../interfaces/Poderes';
+import { dataRegistry } from '../../data/registry';
+import CharacterSheet from '../../interfaces/CharacterSheet';
+
+/**
+ * Teste ponta a ponta do gerador aleatório, escrito para cobrir a mudança que
+ * fez `getPowersAllowedByRequirements` ler o `dataRegistry` em vez do catálogo
+ * core. Os testes unitários provam a função isolada; aqui a pergunta é se o
+ * gerador inteiro sobrevive e se o poder de suplemento realmente CHEGA na
+ * ficha, atravessando `applyPower`, `applyGeneralPowers` e o recálculo final.
+ *
+ * Roda com TODOS os suplementos ligados de propósito: é a combinação que mais
+ * amplia o catálogo e a que os usuários efetivamente usam.
+ */
+const ALL_SUPPLEMENTS = Object.values(SupplementId);
+
+const CORE_POWER_NAMES = new Set(
+  dataRegistry
+    .getAllPowersBySupplements([SupplementId.TORMENTA20_CORE])
+    .map((p) => p.name)
+);
+
+const PICKABLE = [
+  GeneralPowerType.COMBATE,
+  GeneralPowerType.DESTINO,
+  GeneralPowerType.MAGIA,
+  GeneralPowerType.TORMENTA,
+];
+
+/**
+ * Poderes que a ficha ganhou pelo SORTEIO de subida de nível — o caminho que
+ * esta mudança altera. Fora dele existem concessões explícitas de poder
+ * concedido (Arcanista "Linhagem Abençoada", Minauro "Plurivalente"), que são
+ * legítimas e não passam pelo catálogo sorteável.
+ */
+const levelUpPickedPowers = (sheet: CharacterSheet) => {
+  const names = new Set<string>();
+  (sheet.sheetActionHistory ?? []).forEach((entry) => {
+    if (entry.source?.type !== 'levelUp') return;
+    entry.changes.forEach((change) => {
+      if (change.type === 'PowerAdded') names.add(change.powerName);
+    });
+  });
+  return sheet.generalPowers.filter((p) => names.has(p.name));
+};
+
+const generateBatch = (count: number) =>
+  Array.from({ length: count }, (_, i) =>
+    generateRandomSheet({
+      nivel: (i % 20) + 1,
+      raca: 'Aleatório',
+      classe: 'Aleatório',
+      origin: 'Aleatório',
+      devocao: { label: '--', value: '--' },
+      supplements: ALL_SUPPLEMENTS,
+    })
+  );
+
+describe('gerador aleatório — escopo dos poderes gerais', () => {
+  const sheets = generateBatch(150);
+
+  it('gera fichas de nível 1 a 20 com todos os suplementos sem quebrar', () => {
+    expect(sheets).toHaveLength(150);
+    sheets.forEach((sheet) => {
+      expect(sheet.generalPowers).toBeDefined();
+      expect(sheet.nivel).toBeGreaterThan(0);
+    });
+  });
+
+  it('carimba os suplementos usados na ficha', () => {
+    sheets.forEach((sheet) => {
+      expect(sheet.supplements).toEqual(ALL_SUPPLEMENTS);
+    });
+  });
+
+  it('sorteia poderes gerais fora do core', () => {
+    const fromSupplements = sheets
+      .flatMap(levelUpPickedPowers)
+      .filter((p) => !CORE_POWER_NAMES.has(p.name));
+
+    // Antes da correção este número era ZERO em qualquer amostra; hoje a
+    // amostra de 150 fichas rende ~190 poderes de suplemento.
+    expect(fromSupplements.length).toBeGreaterThan(0);
+  });
+
+  it('o sorteio nunca entrega poder concedido nem poder de raça', () => {
+    const wrongType = sheets
+      .flatMap(levelUpPickedPowers)
+      .filter((p) => !PICKABLE.includes(p.type));
+
+    expect(wrongType.map((p) => `${p.name} (${p.type})`)).toEqual([]);
+  });
+
+  it('todo poder sorteado tem seus pré-requisitos satisfeitos na ficha', () => {
+    // Não reavalia requisito por requisito (a ficha final tem mais poderes que
+    // no momento do sorteio); confere o invariante barato: nada duplicado que
+    // não permita repetição.
+    sheets.forEach((sheet) => {
+      const seen = new Map<string, number>();
+      sheet.generalPowers.forEach((p) => {
+        seen.set(p.name, (seen.get(p.name) ?? 0) + 1);
+      });
+      const illegalDupes = [...seen.entries()]
+        .filter(([name, n]) => {
+          if (n < 2) return false;
+          const power = sheet.generalPowers.find((p) => p.name === name);
+          return !power?.allowSeveralPicks && !power?.canRepeat;
+        })
+        .map(([name]) => name);
+
+      expect(illegalDupes).toEqual([]);
+    });
+  });
+}, 300000);

--- a/src/functions/general.ts
+++ b/src/functions/general.ts
@@ -126,7 +126,6 @@ import {
 } from './originItems';
 import {
   GeneralPower,
-  GeneralPowerType,
   OriginPower,
   PowerGetter,
   PowersGetters,
@@ -172,7 +171,6 @@ import {
   getFuturaLendaClassPowers,
   getPowersAllowedByRequirements,
   getWeightedInventorClassPowers,
-  isPowerAvailable,
 } from './powers';
 import {
   addOrCheapenRandomSpells,
@@ -4088,7 +4086,10 @@ function levelUp(
   const allowedPowers = isClassOrVariantOf(updatedSheet.classe, 'Inventor')
     ? getWeightedInventorClassPowers(updatedSheet)
     : getAllowedClassPowers(updatedSheet);
-  const allowedGeneralPowers = getPowersAllowedByRequirements(updatedSheet);
+  const allowedGeneralPowers = getPowersAllowedByRequirements(
+    updatedSheet,
+    supplements
+  );
   if (randomNumber <= 0.7 && allowedPowers.length > 0) {
     // Escolha poder da classe
     const newPower = getRandomItemFromArray(allowedPowers);
@@ -5614,6 +5615,9 @@ export default function generateRandomSheet(
 
   let charSheet: CharacterSheet = {
     id: uuid(),
+    // Carimbo dos suplementos ativos: o que permite consultar o catálogo certo
+    // depois da criação, de dentro de handlers que não recebem a lista.
+    supplements,
     nome,
     sexo: finalSex === 'Homem' ? 'Masculino' : 'Feminino',
     nivel: 1,
@@ -5658,16 +5662,9 @@ export default function generateRandomSheet(
 
   // Propósito de Criação for Golem races (no origin)
   if (!origin && !raceHasOrigin(race.name)) {
-    const allPowers = dataRegistry.getAllPowersBySupplements(supplements);
-    const validTypes = [
-      GeneralPowerType.COMBATE,
-      GeneralPowerType.DESTINO,
-      GeneralPowerType.MAGIA,
-      GeneralPowerType.TORMENTA,
-    ];
-    const eligiblePowers = allPowers.filter(
-      (power) =>
-        validTypes.includes(power.type) && isPowerAvailable(charSheet, power)
+    const eligiblePowers = getPowersAllowedByRequirements(
+      charSheet,
+      supplements
     );
 
     if (eligiblePowers.length > 0) {
@@ -5959,6 +5956,9 @@ export function generateEmptySheet(
 
   let emptySheet: CharacterSheet = {
     id: uuid(),
+    // Mesmo carimbo do gerador aleatório: o assistente também precisa que o
+    // catálogo consultado depois da criação inclua os suplementos escolhidos.
+    supplements,
     nome: '',
     sexo: '',
     nivel: 1,

--- a/src/functions/powers.ts
+++ b/src/functions/powers.ts
@@ -1,10 +1,10 @@
 import { Atributo } from '../data/systems/tormenta20/atributos';
-import generalPowers from '../data/poderes';
 import PROFICIENCIAS from '../data/systems/tormenta20/proficiencias';
 import CharacterSheet from '../interfaces/CharacterSheet';
 import { ClassPower } from '../interfaces/Class';
 import {
   GeneralPower,
+  GeneralPowerType,
   Requirement,
   RequirementType,
 } from '../interfaces/Poderes';
@@ -22,6 +22,8 @@ import {
 import { findClassDescription } from './multiclass';
 import { countTormentaPowers } from './randomUtils';
 import { sheetSatisfiesPowerRequirement } from './powers/hasPowerNamed';
+import { dataRegistry } from '../data/registry';
+import { SupplementId } from '../types/supplement.types';
 
 export type LevelTier = 'Iniciante' | 'Veterano' | 'Campeão' | 'Herói';
 
@@ -242,24 +244,54 @@ export function isPowerAvailable(
   return true;
 }
 
+/**
+ * Tipos que um "poder geral" pode ter quando é SORTEADO ou oferecido como
+ * escolha livre. CONCEDIDOS e RACA ficam de fora: concedido vem da divindade e
+ * poder de raça vem da raça, nenhum dos dois é escolha de poder geral. Sem este
+ * filtro, um devoto de Khalmyr podia receber "Espada Justiceira" como poder
+ * geral de subida de nível — o catálogo é um só, e todo concedido tem
+ * pré-requisito DEVOTO, que o próprio devoto satisfaz.
+ */
+const PICKABLE_GENERAL_POWER_TYPES = [
+  GeneralPowerType.COMBATE,
+  GeneralPowerType.DESTINO,
+  GeneralPowerType.MAGIA,
+  GeneralPowerType.TORMENTA,
+];
+
+/**
+ * Poderes gerais que a ficha pode receber agora.
+ *
+ * `supplements` é opcional porque boa parte das chamadas vem de dentro de
+ * handlers de `applyPower` (Humano Versátil, Memória Póstuma…), que não
+ * recebem a lista. Nesses casos vale o `sheet.supplements` carimbado na
+ * criação; ficha antiga, sem carimbo, cai no core.
+ *
+ * Antes daqui a função lia o catálogo `generalPowers` (o módulo marcado como
+ * deprecated, que é só o core), então NENHUM poder geral de suplemento entrava
+ * em ficha aleatória, com qualquer combinação de suplementos ligada.
+ */
 export function getPowersAllowedByRequirements(
-  sheet: CharacterSheet
+  sheet: CharacterSheet,
+  supplements?: SupplementId[]
 ): GeneralPower[] {
   const existingGeneralPowers = sheet.generalPowers;
+  const scope = supplements ??
+    sheet.supplements ?? [SupplementId.TORMENTA20_CORE];
 
-  return Object.values(generalPowers)
-    .flat()
-    .filter((power) => {
-      const isRepeatedPower = existingGeneralPowers.find(
-        (existingPower) => existingPower.name === power.name
-      );
+  return dataRegistry.getAllPowersBySupplements(scope).filter((power) => {
+    if (!PICKABLE_GENERAL_POWER_TYPES.includes(power.type)) return false;
 
-      if (isRepeatedPower) {
-        return power.allowSeveralPicks;
-      }
+    const isRepeatedPower = existingGeneralPowers.find(
+      (existingPower) => existingPower.name === power.name
+    );
 
-      return isPowerAvailable(sheet, power);
-    });
+    if (isRepeatedPower) {
+      return power.allowSeveralPicks;
+    }
+
+    return isPowerAvailable(sheet, power);
+  });
 }
 
 /**

--- a/src/functions/powers.ts
+++ b/src/functions/powers.ts
@@ -21,6 +21,7 @@ import {
 } from './general';
 import { findClassDescription } from './multiclass';
 import { countTormentaPowers } from './randomUtils';
+import { sheetSatisfiesPowerRequirement } from './powers/hasPowerNamed';
 
 export type LevelTier = 'Iniciante' | 'Veterano' | 'Campeão' | 'Herói';
 
@@ -94,21 +95,11 @@ export function applyRequirementNot(rule: Requirement, met: boolean): boolean {
 function evaluateRule(sheet: CharacterSheet, rule: Requirement): boolean {
   switch (rule.type) {
     case RequirementType.PODER: {
-      const allPowers = getAllCharacterPowers(sheet);
-
-      const foundInPowers = allPowers.some(
-        (currPower) => currPower.name === rule.name
-      );
-      if (foundInPowers) return true;
-
-      // Habilidades raciais que contam como possuir um poder
-      // Nenhuma raça do core usa mais este hook (o Centauro usava, mas o livro dá
-      // um bypass de poder específico, não o poder Ginete); ele sobrevive para
-      // raças de homebrew — ver `compileRace`.
-      const grantedByRace = (sheet.raca.abilities ?? []).some((a) =>
-        a.grantsPowerRequirements?.includes(rule.name ?? '')
-      );
-      if (grantedByRace) return true;
+      // Varre TODOS os baldes de poder (inclusive `devoto.poderes`, onde um
+      // poder concedido pode viver sozinho) e respeita o hook
+      // `grantsPowerRequirements` — de habilidade racial (homebrew, via
+      // `compileRace`) ou de poder ("Ginete Altivo" conta como "Ginete").
+      if (sheetSatisfiesPowerRequirement(sheet, rule.name)) return true;
 
       // Verifica opções escolhidas via chooseFromOptions (ex: Égide/Montaria Sagrada)
       return (sheet.sheetActionHistory ?? []).some((entry) =>

--- a/src/functions/powers/__tests__/requirementEvaluation.spec.ts
+++ b/src/functions/powers/__tests__/requirementEvaluation.spec.ts
@@ -374,6 +374,60 @@ describe('evaluatePowerRequirements', () => {
     });
   });
 
+  describe('PODER concedido / "conta como o poder X"', () => {
+    it('enxerga poder concedido, que vive só em devoto.poderes', () => {
+      const sheet = createMockCharacterSheet();
+      sheet.devoto = {
+        divindade: { name: 'Hippion' },
+        poderes: [{ name: 'Ginete Altivo' }],
+      } as never;
+
+      const result = evaluatePowerRequirements(
+        power([[{ type: RequirementType.PODER, name: 'Ginete Altivo' }]]),
+        ctxOf(sheet)
+      );
+
+      expect(result.available).toBe(true);
+    });
+
+    it('Ginete Altivo (Hippion) satisfaz o pré-requisito do poder Ginete', () => {
+      const sheet = createMockCharacterSheet();
+      sheet.devoto = {
+        divindade: { name: 'Hippion' },
+        poderes: [
+          { name: 'Ginete Altivo', grantsPowerRequirements: ['Ginete'] },
+        ],
+      } as never;
+
+      const result = evaluatePowerRequirements(
+        power(
+          [[{ type: RequirementType.PODER, name: 'Ginete' }]],
+          'Combate Montado'
+        ),
+        ctxOf(sheet)
+      );
+
+      expect(result.available).toBe(true);
+    });
+
+    it('não vaza para um poder de nome diferente do declarado', () => {
+      const sheet = createMockCharacterSheet();
+      sheet.devoto = {
+        divindade: { name: 'Hippion' },
+        poderes: [
+          { name: 'Ginete Altivo', grantsPowerRequirements: ['Ginete'] },
+        ],
+      } as never;
+
+      const result = evaluatePowerRequirements(
+        power([[{ type: RequirementType.PODER, name: 'Encouraçado' }]]),
+        ctxOf(sheet)
+      );
+
+      expect(result.available).toBe(false);
+    });
+  });
+
   describe('bypass racial', () => {
     it('dispensa os pré-requisitos e não devolve nada para exibir', () => {
       const sheet = createMockCharacterSheet();

--- a/src/functions/powers/hasPowerNamed.ts
+++ b/src/functions/powers/hasPowerNamed.ts
@@ -14,8 +14,17 @@
  */
 import CharacterSheet from '../../interfaces/CharacterSheet';
 
+/**
+ * O mínimo que os checadores consomem: o nome e a cláusula "conta como o poder
+ * X para efeitos de pré-requisitos".
+ */
+export interface PowerLike {
+  name: string;
+  grantsPowerRequirements?: string[];
+}
+
 /** Fontes de poder da ficha, exceto `classe.abilities` (ver comentário acima). */
-function collectPowerNames(sheet: CharacterSheet): string[] {
+export function collectSheetPowers(sheet: CharacterSheet): PowerLike[] {
   return [
     ...(sheet.generalPowers ?? []),
     ...(sheet.classPowers ?? []),
@@ -24,7 +33,27 @@ function collectPowerNames(sheet: CharacterSheet): string[] {
     ...(sheet.raca?.abilities ?? []),
     ...(sheet.customPowers ?? []),
     ...(sheet.customGrantedPowers ?? []),
-  ].map((entry) => entry.name);
+  ] as PowerLike[];
+}
+
+function collectPowerNames(sheet: CharacterSheet): string[] {
+  return collectSheetPowers(sheet).map((entry) => entry.name);
+}
+
+/**
+ * O personagem satisfaz um pré-requisito `PODER: name`? Casa pelo nome ou pela
+ * cláusula `grantsPowerRequirements` de qualquer poder/habilidade que ele tenha
+ * — é por aqui que "Ginete Altivo" (concedido de Hippion) vale como "Ginete".
+ */
+export function sheetSatisfiesPowerRequirement(
+  sheet: CharacterSheet,
+  name: string | undefined
+): boolean {
+  if (!name) return false;
+  return collectSheetPowers(sheet).some(
+    (power) =>
+      power.name === name || !!power.grantsPowerRequirements?.includes(name)
+  );
 }
 
 /**

--- a/src/functions/powers/requirementEvaluation.ts
+++ b/src/functions/powers/requirementEvaluation.ts
@@ -13,6 +13,7 @@ import Skill, {
 } from '../../interfaces/Skills';
 import { isClassOrVariantOf, isRaceOrVariantOf } from '../general';
 import { applyRequirementNot } from '../powers';
+import { PowerLike, sheetSatisfiesPowerRequirement } from './hasPowerNamed';
 import { formatRequirement } from '../requirementText';
 
 /**
@@ -49,9 +50,9 @@ export type PowerKind = 'general' | 'class';
 export interface RequirementContext {
   sheet: CharacterSheet;
   /** Poderes gerais marcados no editor e ainda não salvos. */
-  pendingGeneralPowers?: { name: string }[];
+  pendingGeneralPowers?: PowerLike[];
   /** Poderes de classe marcados no editor e ainda não salvos. */
-  pendingClassPowers?: { name: string }[];
+  pendingClassPowers?: PowerLike[];
 }
 
 export interface EvaluatedRequirement {
@@ -95,11 +96,15 @@ const ARTESAO_CRIATIVO = 'Artesão Criativo';
 function hasPowerNamed(name: string | undefined, ctx: RequirementContext) {
   if (!name) return false;
   const { sheet, pendingGeneralPowers = [], pendingClassPowers = [] } = ctx;
+  const satisfies = (p: PowerLike) =>
+    p.name === name || !!p.grantsPowerRequirements?.includes(name);
   return (
-    pendingGeneralPowers.some((p) => p.name === name) ||
-    pendingClassPowers.some((p) => p.name === name) ||
-    (sheet.generalPowers?.some((p) => p.name === name) ?? false) ||
-    (sheet.classPowers?.some((p) => p.name === name) ?? false)
+    pendingGeneralPowers.some(satisfies) ||
+    pendingClassPowers.some(satisfies) ||
+    // Cobre os baldes salvos da ficha — inclusive `devoto.poderes`, onde um
+    // poder concedido pode viver sozinho — e o hook `grantsPowerRequirements`
+    // ("Ginete Altivo", de Hippion, conta como "Ginete").
+    sheetSatisfiesPowerRequirement(sheet, name)
   );
 }
 
@@ -148,11 +153,6 @@ function isRequirementMet(
     case RequirementType.PODER:
       return (
         hasPowerNamed(req.name as string, ctx) ||
-        // Habilidades raciais que contam como possuir um poder
-        // (hoje só raças de homebrew usam este hook)
-        (sheet.raca.abilities ?? []).some((a) =>
-          a.grantsPowerRequirements?.includes(req.name ?? '')
-        ) ||
         (sheet.sheetActionHistory?.some((entry) =>
           entry.changes.some(
             (change) =>

--- a/src/functions/sheetNormalizer.ts
+++ b/src/functions/sheetNormalizer.ts
@@ -8,7 +8,9 @@ import { RACE_SIZES } from '../data/systems/tormenta20/races/raceSizes/raceSizes
 import RACE_COUNTS_AS from '../data/systems/tormenta20/races/raceCountsAs';
 import { migrateNotesToJournal } from './playerJournal';
 import { getCompanionTrickDefinition } from '../data/systems/tormenta20/herois-de-arton/companion/companionTricks';
+import { GeneralPower, GeneralPowerType } from '../interfaces/Poderes';
 import GRANTED_POWERS from '../data/systems/tormenta20/powers/grantedPowers';
+import DEUSES_MENORES_POWERS from '../data/systems/tormenta20/deuses-menores/powers';
 import { getSuragelAlternativeAbility } from '../data/systems/tormenta20/deuses-de-arton/races/suragelAbilities';
 import {
   KAIJIN_CHARISMA_EXEMPT_POWER_NAMES,
@@ -42,8 +44,14 @@ import { updateUnarmedRolls } from './unarmedDamage';
 
 const VALID_ATRIBUTOS = Object.values(Atributo) as string[];
 
-const GRANTED_POWERS_BY_NAME = new Map(
-  Object.values(GRANTED_POWERS).map((power) => [power.name, power])
+// Os concedidos dos deuses menores entram junto: eles também vivem embutidos em
+// `devoto.poderes` e precisam do mesmo refresh (foi por aqui que "Ginete
+// Altivo" ganhou `grantsPowerRequirements` em fichas já salvas).
+const GRANTED_POWERS_BY_NAME = new Map<string, GeneralPower>(
+  [
+    ...Object.values(GRANTED_POWERS),
+    ...DEUSES_MENORES_POWERS[GeneralPowerType.CONCEDIDOS],
+  ].map((power) => [power.name, power])
 );
 
 // Poderes cujos `sheetBonuses` passaram a existir depois de já haver fichas
@@ -494,11 +502,21 @@ function sanitizeSheetElements(sheet: CharacterSheet): void {
       .map((p) => {
         const current = GRANTED_POWERS_BY_NAME.get(p.name);
         if (!current) return p;
-        return {
+        const refreshed = {
           ...p,
           description: current.description,
           sheetBonuses: current.sheetBonuses,
         };
+        // "Conta como o poder X para pré-requisitos": campo novo, ausente das
+        // cópias antigas. Segue o dado atual nos dois sentidos.
+        if (current.grantsPowerRequirements) {
+          refreshed.grantsPowerRequirements = [
+            ...current.grantsPowerRequirements,
+          ];
+        } else {
+          delete refreshed.grantsPowerRequirements;
+        }
+        return refreshed;
       });
   }
 

--- a/src/interfaces/CharacterSheet.ts
+++ b/src/interfaces/CharacterSheet.ts
@@ -18,6 +18,7 @@ import type { SheetAge } from '../premium/interfaces/Age';
 import type { SheetAnimalCompanion } from '../premium/interfaces/AnimalCompanion';
 import type { DiceRoll } from './DiceRoll';
 import type { PlayerJournal } from './PlayerJournal';
+import type { SupplementId } from '../types/supplement.types';
 
 export type SheetChangeSource =
   | {
@@ -760,6 +761,17 @@ export default interface CharacterSheet {
    * bloquear desativação/carregamento quando o conteúdo runtime some.
    */
   usedSupplements?: string[];
+  /**
+   * Suplementos ativos quando a ficha foi criada. Carimbado pelo gerador e
+   * lido por quem precisa consultar o catálogo DEPOIS da criação sem receber a
+   * lista por parâmetro — hoje `getPowersAllowedByRequirements`, chamada de
+   * dentro de handlers de `applyPower` (Humano Versátil, Memória Póstuma,
+   * Natureza Orgânica, Ambição Herdada) que não têm como propagá-la.
+   *
+   * Distinto de `usedSupplements`, que registra só ids de runtime/homebrew para
+   * bloquear desativação. Ausente em ficha antiga: quem lê cai no core.
+   */
+  supplements?: SupplementId[];
   /**
    * Escolhas persistidas de ações `chooseFromOptions`, indexadas por `optionKey`
    * → nomes das opções escolhidas (com repetição quando a opção é repetível ou

--- a/src/interfaces/Poderes.ts
+++ b/src/interfaces/Poderes.ts
@@ -65,6 +65,13 @@ export interface GeneralPower extends CountsAsTormentaPower {
   description: string;
   name: string;
   requirements: Requirement[][];
+  /**
+   * Nomes de poderes que este poder SUBSTITUI como pré-requisito — a cláusula
+   * "conta como o poder X para efeitos de pré-requisitos" (ex.: o concedido
+   * "Ginete Altivo", de Hippion, conta como Ginete). Mesmo hook das habilidades
+   * raciais (`RaceAbility.grantsPowerRequirements`).
+   */
+  grantsPowerRequirements?: string[];
   allowSeveralPicks?: boolean;
   canRepeat?: boolean;
   sheetActions?: SheetAction[];


### PR DESCRIPTION
## 📋 Descrição

Ver: https://fichasdenimb.com.br/forum/poder-de-hippion-e-poderes-de-montaria

Dois bugs reportados por usuários, ambos sobre montaria — e, ao investigar o segundo, um terceiro problema bem maior no gerador aleatório.

**1. Poderes de montaria do Ameaças de Arton não existiam.** Os quatro poderes de montaria do suplemento nunca foram cadastrados: o balde `COMBATE` do Ameaças estava vazio e o `DESTINO` só tinha bênçãos dracônicas, talentos de kobold e maravilhas mecânicas.

- Adiciona **Combate Montado** e **Resistência Montada** (Combate), **Adestrar Montaria** e **Dois Como Um** (Destino)
- Cadeia de pré-requisitos conforme o livro: Combate Montado e Dois Como Um exigem Ginete; Resistência Montada pende de Combate Montado; Adestrar Montaria exige Adestramento treinado + 7º nível
- O +2 em Adestramento de Adestrar Montaria entra automatizado via `sheetBonuses`

Junto vai **Coração de Dragão** (Destino, Car 2 + 3º nível): +2 PV, +2 PM e um dragão jovem contando como parceiro único para o limite de parceiros. Também estava faltando. Fica num arquivo próprio, `destinyPowers.ts`, e não em `draconicBlessings` — as Bênçãos Dracônicas são exclusivas do Kallyanach e limitadas a uma por patamar via `TIER_LIMIT`, enquanto este é um poder geral comum. Os PV/PM entram por `sheetBonuses`; o limite de parceiros não tem representação na ficha e fica no texto.

**2. Ginete Altivo (concedido de Hippion) não valia como Ginete.** O poder diz no livro que "conta como o poder Ginete para efeitos de pré-requisitos", mas o hook `grantsPowerRequirements` só existia em habilidade racial. Por baixo disso havia um problema maior: nenhum dos dois avaliadores de requisito olhava para `devoto.poderes`, onde um poder concedido pode viver sozinho — então **nenhum concedido satisfazia pré-requisito de poder**, nem pelo próprio nome.

- `grantsPowerRequirements` passa a existir em `GeneralPower`, e Ginete Altivo o declara
- A checagem de `PODER` dos dois avaliadores (`powers.ts` e `requirementEvaluation.ts`) vai para um ponto único, `sheetSatisfiesPowerRequirement`, que varre todos os baldes de poder da ficha
- `sheetNormalizer` passa a refrescar também os concedidos dos deuses menores (antes só os do core), para que fichas já salvas recebam o campo novo
- Remove a duplicata do check racial que existia nos dois avaliadores

**3. O gerador aleatório só enxergava poderes gerais do core.** `getPowersAllowedByRequirements` lia `data/poderes`, o módulo marcado como `DEPRECATED` que aponta para `CORE_POWERS`. Nenhum poder geral de Heróis de Arton, Ameaças de Arton ou Atlas de Arton jamais entrou numa ficha aleatória, com qualquer combinação de suplementos ligada. `levelUp` já recebia `supplements` e usava para magias, raças, classes e divindades — só a linha dos poderes gerais ignorava.

- A função passa a ler o `dataRegistry`
- A lista vem por parâmetro onde há como propagá-la (`levelUp`, Propósito de Criação) e, onde não há — os handlers de `applyPower` em `powers/special.ts`: Humano Versátil, Memória Póstuma, Natureza Orgânica, Ambição Herdada —, vem do novo carimbo `CharacterSheet.supplements`, gravado na criação. Ficha antiga, sem carimbo, cai no core: comportamento inalterado
- **Corrige um vazamento de concedidos:** o catálogo é um só e a lista incluía `CONCEDIDOS`; como todo concedido tem pré-requisito `DEVOTO`, que o próprio devoto satisfaz, um devoto de Khalmyr podia receber *Espada Justiceira* como poder geral de subida de nível. O sorteio agora filtra por tipo (Combate, Destino, Magia, Tormenta) — a mesma lista que o Propósito de Criação já mantinha por conta própria, agora com um dono só

⚠️ **Isto muda o resultado de toda geração aleatória com suplemento ligado**: as fichas passam a sair com poderes que antes nunca apareciam. É o comportamento correto, mas é visível para o usuário e provavelmente merece linha no changelog.

## 🎯 Tipo de Mudança

- [x] Bug fix
- [ ] Nova funcionalidade
- [x] Melhoria de código
- [ ] Documentação

## 🧪 Testes

- [x] Testes passando — 223 arquivos, 2843 testes
- [x] Novos testes adicionados — 22 no total
- [x] `npx tsc --noEmit`, `npx eslint --max-warnings=0` e `npm run build` limpos

Cobertura nova:

- `mountPowers.spec.ts` — tipo e cadeia de pré-requisitos dos quatro poderes
- `destinyPowers.spec.ts` — Coração de Dragão: tipo, requisitos no mesmo grupo (E, não OU) e o +2 PV/+2 PM medido na ficha recalculada com e sem o poder, não só inspecionado no dado
- `requirementEvaluation.spec.ts` — concedido satisfaz requisito por nome e por `grantsPowerRequirements`, sem vazar para poder de nome diferente
- `generalPowerCatalogScope.spec.ts` — escopo do catálogo (core por padrão, suplemento quando ativo, `sheet.supplements` como fallback) e ausência de concedidos/poderes de raça no sorteio
- `randomSheetPowerScope.spec.ts` — ponta a ponta: **150 fichas, níveis 1 a 20, todos os suplementos ligados.** Confere que o poder de suplemento chega na ficha atravessando `applyPower` e o recálculo final (~190 poderes fora do core na amostra; antes seriam zero) e que o sorteio nunca entrega concedido. O teste separa o sorteio das concessões explícitas — Arcanista *Linhagem Abençoada* e Minauro *Plurivalente* entregam concedido como poder geral de propósito, via `availablePowers`, e continuam funcionando

## 📱 Screenshots

N/A — mudanças de dados e de regra, sem alteração de interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
