### PR TITLE
Crítico de arma: proficiência exigida e marcação de edição manual

### DIFF
--- a/src/components/SheetResult/BackpackModal/ItemEditorDialog.tsx
+++ b/src/components/SheetResult/BackpackModal/ItemEditorDialog.tsx
@@ -49,6 +49,7 @@ import { ItemE, ItemMod } from '../../../interfaces/Rewards';
 import { useContentSupplements } from '../../../hooks/useContentSupplements';
 import { SupplementId } from '../../../types/supplement.types';
 import { applyItemEnhancements } from '../../../functions/itemEnhancements/applyEnhancements';
+import { getManualStatFields } from '../../../functions/manualStats';
 import {
   MaterialContext,
   toAppliedEnchantment,
@@ -187,6 +188,13 @@ const ItemEditorDialog: React.FC<ItemEditorDialogProps> = ({
   const [manualEditedFields, setManualEditedFields] = useState<Set<StatField>>(
     new Set()
   );
+  /**
+   * Campos digitados NESTA abertura do editor. Separado de
+   * `manualEditedFields`, que ao reabrir um item já congelado volta com o grupo
+   * inteiro (para o preview não sobrescrever valor gravado): sem esta segunda
+   * lista, reabrir e salvar transformaria "editei o dano" em "editei os três".
+   */
+  const [touchedFields, setTouchedFields] = useState<Set<StatField>>(new Set());
   const [rollsOpen, setRollsOpen] = useState(false);
   const [modError, setModError] = useState('');
   const [enchError, setEnchError] = useState('');
@@ -214,15 +222,12 @@ const ItemEditorDialog: React.FC<ItemEditorDialogProps> = ({
       setForm(buildInitial(item));
       // Preserve prior manual edits when reopening an item that already had
       // the flag set — otherwise the live-preview effect below would silently
-      // recompute over the user's persisted values.
-      const restored = new Set<StatField>();
-      if (item?.hasManualEdits) {
-        restored.add('dano');
-        restored.add('atkBonus');
-        restored.add('critico');
-        restored.add('defenseBonus');
-        restored.add('armorPenalty');
-      }
+      // recompute over the user's persisted values. `getManualStatFields` já
+      // resolve o item legado (flag sem lista) como "grupo inteiro editado".
+      const restored = new Set<StatField>(
+        item ? [...getManualStatFields(item)] : []
+      );
+      setTouchedFields(new Set());
       // Flag independente: reabrir um item com espaço manual não pode perder o
       // congelamento só porque o jogador não tocou no campo desta vez.
       if (item?.hasManualSpaces) restored.add('spaces');
@@ -333,13 +338,20 @@ const ItemEditorDialog: React.FC<ItemEditorDialogProps> = ({
     manualEditedFields,
   ]);
 
-  const markManualEdit = (field: StatField) =>
+  const markManualEdit = (field: StatField) => {
+    setTouchedFields((s) => {
+      if (s.has(field)) return s;
+      const next = new Set(s);
+      next.add(field);
+      return next;
+    });
     setManualEditedFields((s) => {
       if (s.has(field)) return s;
       const next = new Set(s);
       next.add(field);
       return next;
     });
+  };
 
   // Existe um espaço "automático" para voltar? Ou o pipeline de aprimoramentos
   // já capturou um base, ou é munição (espaço vem das unidades restantes).
@@ -391,6 +403,7 @@ const ItemEditorDialog: React.FC<ItemEditorDialogProps> = ({
   const handleResetToBase = () => {
     if (!baseSnapshot) return;
     setManualEditedFields(new Set());
+    setTouchedFields(new Set());
     setForm((f) => ({
       ...f,
       spacesText:
@@ -445,7 +458,7 @@ const ItemEditorDialog: React.FC<ItemEditorDialogProps> = ({
     // arremesso). Pipeline is idempotent — when all enhancements are cleared it
     // restores stats from `base*` snapshots automatically.
     const finalItem = applyItemEnhancements(
-      buildSavedItem(item, form, manualEditedFields)
+      buildSavedItem(item, form, manualEditedFields, touchedFields)
     );
 
     onSave(finalItem);

--- a/src/components/SheetResult/BackpackModal/ItemEditorDialog.tsx
+++ b/src/components/SheetResult/BackpackModal/ItemEditorDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
+  Alert,
   Box,
   Button,
   Checkbox,
@@ -402,6 +403,25 @@ const ItemEditorDialog: React.FC<ItemEditorDialogProps> = ({
     }));
   };
 
+  /**
+   * As estatísticas travadas por edição manual são invisíveis para o pipeline
+   * de melhorias: `applyItemEnhancements` roda com `preserveManualStats` e o
+   * `applyWeaponBonuses` do recálculo nem toca na arma. Sem este aviso o
+   * jogador aplica Maciça, não vê o crítico mudar e conclui que a melhoria não
+   * funciona — foi exatamente como o problema chegou.
+   */
+  const statsLockedWarning =
+    isWeapon &&
+    (manualEditedFields.has('dano') ||
+      manualEditedFields.has('atkBonus') ||
+      manualEditedFields.has('critico')) ? (
+      <Alert severity='warning' icon={false}>
+        Dano, bônus de ataque e crítico estão travados por edição manual —
+        melhorias, encantos e bônus de poderes não vão alterá-los. Use
+        “Resetar”, na aba Estatísticas, para voltar ao cálculo automático.
+      </Alert>
+    ) : null;
+
   const spacesAreManual = manualEditedFields.has('spaces');
   let spacesHelperText: React.ReactNode;
   if (spacesAreManual && hasAutomaticSpaces) {
@@ -560,6 +580,7 @@ const ItemEditorDialog: React.FC<ItemEditorDialogProps> = ({
 
         {tab === 'stats' && hasStatsTab && (
           <Stack spacing={2}>
+            {statsLockedWarning}
             <Stack
               direction='row'
               sx={{
@@ -1004,6 +1025,7 @@ const ItemEditorDialog: React.FC<ItemEditorDialogProps> = ({
 
         {tab === 'modificacoes' && hasModificationsTab && modItemType && (
           <Stack spacing={2}>
+            {statsLockedWarning}
             <Typography
               variant='caption'
               sx={{
@@ -1042,6 +1064,7 @@ const ItemEditorDialog: React.FC<ItemEditorDialogProps> = ({
 
         {tab === 'encantamentos' && hasEnchantmentsTab && enchItemType && (
           <Stack spacing={2}>
+            {statsLockedWarning}
             <Typography
               variant='caption'
               sx={{

--- a/src/components/SheetResult/BackpackModal/__tests__/itemEditorSave.spec.ts
+++ b/src/components/SheetResult/BackpackModal/__tests__/itemEditorSave.spec.ts
@@ -264,3 +264,87 @@ describe('buildSavedItem — espaços editados à mão', () => {
     expect(result.spaces).toBe(0);
   });
 });
+
+/**
+ * `manualStatFields` diz QUAIS estatísticas o jogador digitou. `hasManualEdits`
+ * continua congelando o grupo inteiro (é o que o motor lê), mas a ficha só
+ * sublinha o campo de fato editado.
+ */
+describe('buildSavedItem — manualStatFields', () => {
+  const espada: Equipment = {
+    nome: 'Espada Longa',
+    group: 'Arma',
+    dano: '1d8',
+    critico: 'x2',
+    atkBonus: 0,
+    spaces: 1,
+  };
+
+  it('grava só o campo digitado', () => {
+    const result = buildSavedItem(
+      espada,
+      mkForm({ danoText: '1d10', criticoText: 'x2', atkBonusText: '0' }),
+      new Set<StatField>(['dano'])
+    );
+
+    expect(result.hasManualEdits).toBe(true);
+    expect(result.manualStatFields).toEqual(['dano']);
+  });
+
+  it('reabrir e salvar não promove o grupo inteiro a manual', () => {
+    // Ao reabrir um item congelado o editor restaura o grupo em
+    // `manualEditedFields` (para o preview não sobrescrever o valor gravado),
+    // mas nada foi digitado desta vez.
+    const jaEditada: Equipment = {
+      ...espada,
+      hasManualEdits: true,
+      manualStatFields: ['dano'],
+    };
+
+    const result = buildSavedItem(
+      jaEditada,
+      mkForm({ danoText: '1d10' }),
+      new Set<StatField>(['dano', 'atkBonus', 'critico']),
+      new Set<StatField>()
+    );
+
+    expect(result.manualStatFields).toEqual(['dano']);
+  });
+
+  it('acumula o campo digitado numa segunda edição', () => {
+    const jaEditada: Equipment = {
+      ...espada,
+      hasManualEdits: true,
+      manualStatFields: ['dano'],
+    };
+
+    const result = buildSavedItem(
+      jaEditada,
+      mkForm({ danoText: '1d10', criticoText: '19/x2' }),
+      new Set<StatField>(['dano', 'atkBonus', 'critico']),
+      new Set<StatField>(['critico'])
+    );
+
+    expect(result.manualStatFields).toEqual(['dano', 'critico']);
+  });
+
+  it('item legado (flag sem lista) conta como grupo inteiro editado', () => {
+    const legado: Equipment = { ...espada, hasManualEdits: true };
+
+    const result = buildSavedItem(
+      legado,
+      mkForm({ danoText: '1d10' }),
+      new Set<StatField>(['dano', 'atkBonus', 'critico']),
+      new Set<StatField>()
+    );
+
+    expect(result.manualStatFields).toEqual(['dano', 'atkBonus', 'critico']);
+  });
+
+  it('sem edição manual nenhuma, o campo some do item', () => {
+    const result = buildSavedItem(espada, mkForm(), new Set<StatField>());
+
+    expect(result.hasManualEdits).toBeUndefined();
+    expect(result.manualStatFields).toBeUndefined();
+  });
+});

--- a/src/components/SheetResult/BackpackModal/itemEditorSave.ts
+++ b/src/components/SheetResult/BackpackModal/itemEditorSave.ts
@@ -1,6 +1,7 @@
 import Equipment, {
   AppliedEnchantment,
   AppliedModification,
+  ManualStatField,
   AttackAttribute,
   DamageAttribute,
   DamageType,
@@ -20,6 +21,7 @@ import {
   withMaterialSnapshot,
 } from '../../../functions/itemEnhancements/snapshot';
 import { isDefenseGroup } from './equipmentCatalog';
+import { getManualStatFields } from '../../../functions/manualStats';
 
 /**
  * Campos que o jogador pode sobrescrever à mão no editor, congelando o
@@ -92,10 +94,30 @@ export interface ItemEditorFormState {
  * flag `hasManualSpaces` (que faz `applyDelta` parar de reescrever o espaço a
  * partir de `baseSpaces`) só é ligada quando o jogador mexeu no campo.
  */
+/**
+ * Lista de estatísticas editadas à mão depois deste save: o que já estava
+ * marcado no item mais o que o jogador digitou agora.
+ */
+function mergeManualStatFields(
+  item: Equipment,
+  group: ManualStatField[],
+  touchedFields: Set<StatField>
+): ManualStatField[] {
+  const previous = getManualStatFields(item);
+  return group.filter(
+    (field) => previous.has(field) || touchedFields.has(field)
+  );
+}
+
 export function buildSavedItem(
   item: Equipment,
   form: ItemEditorFormState,
-  manualEditedFields: Set<StatField>
+  manualEditedFields: Set<StatField>,
+  // Campos digitados nesta sessão do editor. Só eles ENTRAM na lista
+  // `manualStatFields` (o que a ficha marca); `manualEditedFields` inclui o
+  // grupo restaurado ao reabrir um item já congelado. Sem argumento, os dois
+  // são a mesma coisa — é o caso de quem chama fora do editor.
+  touchedFields: Set<StatField> = manualEditedFields
 ): Equipment {
   const isWeapon = item.group === 'Arma';
   const isDefense = isDefenseGroup(item.group);
@@ -204,6 +226,15 @@ export function buildSavedItem(
       });
     }
     next.hasManualEdits = weaponStatTouched ? true : undefined;
+    // A flag congela o grupo inteiro, mas a ficha marca só o campo digitado —
+    // por isso a lista é gravada além dela.
+    next.manualStatFields = weaponStatTouched
+      ? mergeManualStatFields(
+          item,
+          ['dano', 'atkBonus', 'critico'],
+          touchedFields
+        )
+      : undefined;
   }
 
   let finalItem: Equipment = next;
@@ -224,6 +255,13 @@ export function buildSavedItem(
         : armorPenalty;
     }
     defenseNext.hasManualEdits = defenseStatTouched ? true : undefined;
+    defenseNext.manualStatFields = defenseStatTouched
+      ? mergeManualStatFields(
+          item,
+          ['defenseBonus', 'armorPenalty'],
+          touchedFields
+        )
+      : undefined;
     finalItem = defenseNext;
   }
 

--- a/src/components/Weapon.tsx
+++ b/src/components/Weapon.tsx
@@ -455,7 +455,6 @@ const Weapon: React.FC<WeaponProps> = (props) => {
             textUnderlineOffset: '3px',
             cursor: 'help',
           }}
-          onClick={(e) => e.stopPropagation()}
         >
           {content}
         </Box>

--- a/src/components/Weapon.tsx
+++ b/src/components/Weapon.tsx
@@ -18,6 +18,7 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import TuneIcon from '@mui/icons-material/Tune';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
+import EditNoteIcon from '@mui/icons-material/EditNote';
 import Equipment, {
   AmmoType,
   DamageAttribute,
@@ -444,10 +445,32 @@ const Weapon: React.FC<WeaponProps> = (props) => {
     [equipment]
   );
 
+  const manualMarkTitle =
+    'Modificado manualmente — melhorias e bônus automáticos não se aplicam a este valor';
+
+  const MANUAL_FIELD_LABELS: Record<ManualStatField, string> = {
+    atkBonus: 'ataque',
+    dano: 'dano',
+    critico: 'crítico',
+    defenseBonus: 'defesa',
+    armorPenalty: 'penalidade de armadura',
+  };
+
+  // Quais estatísticas a marca cobre, na ordem em que aparecem na linha.
+  const manualFieldNames = (
+    ['atkBonus', 'dano', 'critico'] as ManualStatField[]
+  )
+    .filter((field) => manualStatFields.has(field))
+    .map((field) => MANUAL_FIELD_LABELS[field]);
+
   const withManualMark = (field: ManualStatField, content: React.ReactNode) => {
     if (!manualStatFields.has(field)) return content;
+    // `disableTouchListener`: no toque o tooltip do MUI só abre com long-press e
+    // ele não cancela o clique sintético que vem depois — o gesto abriria a
+    // explicação E rolaria o ataque. No mobile a explicação sai pelo ícone de
+    // lápis, que é afordância própria e pode parar a propagação sem custo.
     return (
-      <Tooltip title='Modificado manualmente — melhorias e bônus automáticos não se aplicam a este valor'>
+      <Tooltip title={manualMarkTitle} disableTouchListener>
         <Box
           component='span'
           sx={{
@@ -812,6 +835,28 @@ const Weapon: React.FC<WeaponProps> = (props) => {
                   color: bonusEffects.hasActiveEffect
                     ? ACTIVE_EFFECT_COLOR
                     : theme.palette.primary.main,
+                  cursor: 'help',
+                }}
+                onClick={(e) => e.stopPropagation()}
+              />
+            </Tooltip>
+          )}
+          {manualFieldNames.length > 0 && (
+            <Tooltip
+              title={`${manualMarkTitle} (${manualFieldNames.join(', ')}).`}
+              arrow
+              enterTouchDelay={0}
+              leaveTouchDelay={4000}
+            >
+              {/* No desktop o sublinhado pontilhado já explica no hover; este
+                  ícone existe pelo mobile, onde não há hover e o long-press
+                  sobre o número rolaria o ataque junto. */}
+              <EditNoteIcon
+                aria-label='Estatísticas modificadas manualmente'
+                sx={{
+                  fontSize: 15,
+                  ml: 0.5,
+                  color: 'text.secondary',
                   cursor: 'help',
                 }}
                 onClick={(e) => e.stopPropagation()}

--- a/src/components/Weapon.tsx
+++ b/src/components/Weapon.tsx
@@ -210,8 +210,17 @@ const Weapon: React.FC<WeaponProps> = (props) => {
         nivel: nivel ?? 1,
         classLevels,
         thrownMode: isThrownAction(action),
+        isProficient: !isNonProficient,
       }),
-    [sheetBonuses, equipment, isThrownAction, atributos, nivel, classLevels]
+    [
+      sheetBonuses,
+      equipment,
+      isThrownAction,
+      atributos,
+      nivel,
+      classLevels,
+      isNonProficient,
+    ]
   );
 
   const liveDamageBonus = useCallback(
@@ -333,6 +342,10 @@ const Weapon: React.FC<WeaponProps> = (props) => {
     hasActiveEffect: boolean;
   }>(() => {
     const lines: string[] = [];
+    // Bônus que casam com a arma mas estão desligados por falta de
+    // proficiência: vão para o fim da lista, marcados, em vez de sumirem — o
+    // jogador precisa saber por que o número não mudou.
+    const inactiveLines: string[] = [];
     let hasActiveEffect = false;
     if (!sheetBonuses) return { lines, hasActiveEffect };
 
@@ -353,16 +366,25 @@ const Weapon: React.FC<WeaponProps> = (props) => {
         targetType !== 'WeaponAttack' &&
         targetType !== 'WeaponDamage' &&
         targetType !== 'WeaponDamageStep' &&
-        targetType !== 'WeaponThreatMargin'
+        targetType !== 'WeaponThreatMargin' &&
+        targetType !== 'WeaponCriticalMultiplier'
       ) {
         return;
       }
       // Casamento estático arma × escopo pela fonte única (weaponMatchesScope) —
       // cobre name/tags/categorias/melee/ranged/thrown/firing/leve-ágil/2-mãos.
-      const scope = b.target as WeaponBonusScope;
+      const scope = b.target as WeaponBonusScope & {
+        proficiencyRequired?: boolean;
+      };
       if (!weaponMatchesScope(equipment, scope)) {
         return;
       }
+      // Bônus que exigem proficiência (Armas da Ambição, Armas da Destruição)
+      // não são aplicados pelo recálculo numa arma em que o personagem não é
+      // proficiente — o caso clássico é a pistola, que é arma de fogo.
+      const requiresMissingProficiency = !!(
+        scope.proficiencyRequired && isNonProficient
+      );
       const value = evaluateSimpleModifier(b.modifier, atributos, nivel ?? 1, {
         classLevels,
         source: b.source,
@@ -380,28 +402,37 @@ const Weapon: React.FC<WeaponProps> = (props) => {
       } else if (equipment.arremesso && scope.meleeOnly) {
         suffix = ' (corpo a corpo)';
       }
+      let line: string | null = null;
       if (targetType === 'WeaponAttack') {
-        lines.push(`${sourceName}: ${signed} no ataque${suffix}`);
+        line = `${sourceName}: ${signed} no ataque${suffix}`;
       } else if (targetType === 'WeaponDamage') {
-        lines.push(`${sourceName}: ${signed} no dano${suffix}`);
+        line = `${sourceName}: ${signed} no dano${suffix}`;
       } else if (targetType === 'WeaponDamageStep') {
-        lines.push(
-          `${sourceName}: ${signed} passo${
-            Math.abs(value) > 1 ? 's' : ''
-          } de dano`
-        );
+        line = `${sourceName}: ${signed} passo${
+          Math.abs(value) > 1 ? 's' : ''
+        } de dano`;
       } else if (targetType === 'WeaponThreatMargin') {
-        lines.push(
+        line =
           b.target.mode === 'set'
             ? `${sourceName}: margem de ameaça ${value}`
-            : `${sourceName}: ${signed} na margem de ameaça`
-        );
+            : `${sourceName}: ${signed} na margem de ameaça`;
+      } else if (targetType === 'WeaponCriticalMultiplier') {
+        line =
+          b.target.mode === 'set'
+            ? `${sourceName}: multiplicador de crítico x${value}`
+            : `${sourceName}: ${signed} no multiplicador de crítico`;
       }
+      if (!line) return;
+      if (requiresMissingProficiency) {
+        inactiveLines.push(`${line} (inativo: sem proficiência)`);
+        return;
+      }
+      lines.push(line);
       hasActiveEffect = hasActiveEffect || isActiveEffect;
     });
 
-    return { lines, hasActiveEffect };
-  }, [sheetBonuses, equipment, atributos, nivel, classLevels]);
+    return { lines: [...lines, ...inactiveLines], hasActiveEffect };
+  }, [sheetBonuses, equipment, atributos, nivel, classLevels, isNonProficient]);
 
   const damage = getWeaponDisplayDamage(
     equipment,

--- a/src/components/Weapon.tsx
+++ b/src/components/Weapon.tsx
@@ -21,9 +21,11 @@ import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import Equipment, {
   AmmoType,
   DamageAttribute,
+  ManualStatField,
   WeaponAction,
   WeaponOverride,
 } from '../interfaces/Equipment';
+import { getManualStatFields } from '../functions/manualStats';
 import type { SheetBonus } from '../interfaces/CharacterSheet';
 import { AMMO_LABELS } from './SheetResult/BackpackModal/ammo';
 import { parseCritical, parseDualModeDamage } from '../functions/diceRoller';
@@ -434,6 +436,33 @@ const Weapon: React.FC<WeaponProps> = (props) => {
     return { lines: [...lines, ...inactiveLines], hasActiveEffect };
   }, [sheetBonuses, equipment, atributos, nivel, classLevels, isNonProficient]);
 
+  // Estatísticas digitadas à mão pelo jogador neste item. Ficam sublinhadas em
+  // pontilhado na linha da arma: nelas o motor não aplica melhorias nem bônus
+  // de poder, e sem a marca o número parece simplesmente errado.
+  const manualStatFields = useMemo(
+    () => getManualStatFields(equipment),
+    [equipment]
+  );
+
+  const withManualMark = (field: ManualStatField, content: React.ReactNode) => {
+    if (!manualStatFields.has(field)) return content;
+    return (
+      <Tooltip title='Modificado manualmente — melhorias e bônus automáticos não se aplicam a este valor'>
+        <Box
+          component='span'
+          sx={{
+            textDecoration: 'underline dotted',
+            textUnderlineOffset: '3px',
+            cursor: 'help',
+          }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {content}
+        </Box>
+      </Tooltip>
+    );
+  };
+
   const damage = getWeaponDisplayDamage(
     equipment,
     atributos,
@@ -835,7 +864,9 @@ const Weapon: React.FC<WeaponProps> = (props) => {
             </Tooltip>
           )}
           {customSkill && ` (${customSkill})`}{' '}
-          {`${baseAtk >= 0 ? '+' : ''}${baseAtk}`} • {damage} • ({critico})
+          {withManualMark('atkBonus', `${baseAtk >= 0 ? '+' : ''}${baseAtk}`)} •{' '}
+          {withManualMark('dano', damage)} • (
+          {withManualMark('critico', critico)})
           {equipment.tipo && equipment.tipo !== '-' && ` • ${equipment.tipo}`}
           {(equipment.extraDamage ?? []).map((extra) => (
             <Box

--- a/src/components/Weapon.tsx
+++ b/src/components/Weapon.tsx
@@ -131,6 +131,13 @@ interface WeaponProps {
   onSemanticsChange?: (next: WeaponOverride) => void;
 }
 
+/** Rótulo da mão na linha da arma. `null` (não empunhada) não rende texto. */
+const WIELDING_LABELS: Record<Exclude<WieldingSlot, null>, string> = {
+  main: '🤚 Principal',
+  off: '✋ Secundária',
+  both: '🤝 Duas mãos',
+};
+
 interface RollContext {
   action?: WeaponAction;
   useTrigger: boolean;
@@ -907,24 +914,68 @@ const Weapon: React.FC<WeaponProps> = (props) => {
               />
             </Tooltip>
           )}
-          {customSkill && ` (${customSkill})`}{' '}
-          {withManualMark('atkBonus', `${baseAtk >= 0 ? '+' : ''}${baseAtk}`)} •{' '}
-          {withManualMark('dano', damage)} • (
-          {withManualMark('critico', critico)})
-          {equipment.tipo && equipment.tipo !== '-' && ` • ${equipment.tipo}`}
-          {(equipment.extraDamage ?? []).map((extra) => (
-            <Box
-              key={extra.id ?? `${extra.dice}-${extra.damageType}`}
-              component='span'
-              sx={{ color: 'text.secondary', fontSize: '0.85em', ml: 0.5 }}
-            >
-              {' '}
-              + {extra.dice} {extra.damageType}
+          {/* As estatísticas moram num único item flex, com cada valor e seus
+              acompanhantes (separador, parênteses) num grupo `nowrap`.
+              O container desta linha é `display: flex`, e num flex container
+              cada TRECHO DE TEXTO contíguo vira um item anônimo: com as marcas
+              de edição manual quebrando o texto em vários elementos, o `(`, o
+              `)` e os `•` viravam itens próprios, encolhiam e quebravam linha
+              cada um por conta — no mobile os parênteses e pontos apareciam
+              soltos e desalinhados dos números. */}
+          <Box
+            component='span'
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'baseline',
+              flexWrap: 'wrap',
+              columnGap: 0.5,
+              ml: 0.5,
+            }}
+          >
+            {customSkill && (
+              <Box component='span' sx={{ whiteSpace: 'nowrap' }}>
+                ({customSkill})
+              </Box>
+            )}
+            <Box component='span' sx={{ whiteSpace: 'nowrap' }}>
+              {withManualMark(
+                'atkBonus',
+                `${baseAtk >= 0 ? '+' : ''}${baseAtk}`
+              )}
             </Box>
-          ))}
-          {wieldingSlot === 'main' && ' · 🤚 Principal'}
-          {wieldingSlot === 'off' && ' · ✋ Secundária'}
-          {wieldingSlot === 'both' && ' · 🤝 Duas mãos'}
+            {/* O separador viaja junto do valor que ele introduz: numa quebra
+                de linha ele desce com o número, em vez de ficar órfão no fim
+                da linha anterior. */}
+            <Box component='span' sx={{ whiteSpace: 'nowrap' }}>
+              • {withManualMark('dano', damage)}
+            </Box>
+            <Box component='span' sx={{ whiteSpace: 'nowrap' }}>
+              • ({withManualMark('critico', critico)})
+            </Box>
+            {equipment.tipo && equipment.tipo !== '-' && (
+              <Box component='span' sx={{ whiteSpace: 'nowrap' }}>
+                • {equipment.tipo}
+              </Box>
+            )}
+            {(equipment.extraDamage ?? []).map((extra) => (
+              <Box
+                key={extra.id ?? `${extra.dice}-${extra.damageType}`}
+                component='span'
+                sx={{
+                  color: 'text.secondary',
+                  fontSize: '0.85em',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                + {extra.dice} {extra.damageType}
+              </Box>
+            ))}
+            {wieldingSlot && WIELDING_LABELS[wieldingSlot] && (
+              <Box component='span' sx={{ whiteSpace: 'nowrap' }}>
+                · {WIELDING_LABELS[wieldingSlot]}
+              </Box>
+            )}
+          </Box>
           {(onWieldingChange || onSemanticsChange) && (
             <Box
               sx={{

--- a/src/components/__tests__/weaponManualStatMark.spec.tsx
+++ b/src/components/__tests__/weaponManualStatMark.spec.tsx
@@ -91,4 +91,44 @@ describe('Weapon — marcação de estatística editada à mão', () => {
 
     expect(onRowClick).toHaveBeenCalled();
   });
+
+  /**
+   * O sublinhado pontilhado é visível no mobile, mas a explicação dele não: sem
+   * hover, o tooltip do MUI só abre com long-press — e como ele não cancela o
+   * clique sintético que vem depois, o gesto rolaria o ataque junto. A
+   * explicação sai por um ícone próprio, que pode parar a propagação.
+   */
+  describe('afordância de toque', () => {
+    it('mostra o ícone com os campos marcados quando há edição manual', () => {
+      renderRow(
+        espada({ hasManualEdits: true, manualStatFields: ['dano'] }),
+        onRowClick
+      );
+
+      expect(
+        screen.getByLabelText('Estatísticas modificadas manualmente')
+      ).toBeInTheDocument();
+    });
+
+    it('não mostra o ícone em arma sem edição manual', () => {
+      renderRow(espada(), onRowClick);
+
+      expect(
+        screen.queryByLabelText('Estatísticas modificadas manualmente')
+      ).not.toBeInTheDocument();
+    });
+
+    it('clicar no ícone não rola o ataque', () => {
+      renderRow(
+        espada({ hasManualEdits: true, manualStatFields: ['dano'] }),
+        onRowClick
+      );
+
+      fireEvent.click(
+        screen.getByLabelText('Estatísticas modificadas manualmente')
+      );
+
+      expect(onRowClick).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/components/__tests__/weaponManualStatMark.spec.tsx
+++ b/src/components/__tests__/weaponManualStatMark.spec.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import _ from 'lodash';
+import Weapon from '../Weapon';
+import { Armas } from '../../data/systems/tormenta20/equipamentos';
+import Equipment from '../../interfaces/Equipment';
+import { CharacterAttributes } from '../../interfaces/Character';
+import { Atributo } from '../../data/systems/tormenta20/atributos';
+
+// O componente só precisa do contexto de rolagem para não explodir no mount:
+// nenhum teste aqui afirma sobre a rolagem em si.
+vi.mock('../../premium/hooks/useDiceRoll', () => ({
+  useDiceRoll: () => ({
+    showDiceResult: vi.fn(),
+    showAttackRoll: vi.fn(),
+    logExternalRoll: vi.fn(),
+  }),
+  default: () => ({
+    showDiceResult: vi.fn(),
+    showAttackRoll: vi.fn(),
+    logExternalRoll: vi.fn(),
+  }),
+}));
+
+/**
+ * A linha inteira da arma é o alvo de clique que rola o ataque. A marcação de
+ * "modificado manualmente" (sublinhado pontilhado + tooltip) não pode consumir
+ * esse gesto: item salvo antes da marcação cai no fallback "grupo inteiro", o
+ * que marcaria ataque, dano e crítico de toda arma já editada à mão — o miolo
+ * da linha (quase a linha toda no celular) viraria zona morta.
+ */
+describe('Weapon — marcação de estatística editada à mão', () => {
+  const atributos = {
+    [Atributo.FORCA]: { name: Atributo.FORCA, value: 2, mod: 2 },
+    [Atributo.DESTREZA]: { name: Atributo.DESTREZA, value: 3, mod: 3 },
+    [Atributo.CONSTITUICAO]: { name: Atributo.CONSTITUICAO, value: 1, mod: 1 },
+    [Atributo.INTELIGENCIA]: { name: Atributo.INTELIGENCIA, value: 0, mod: 0 },
+    [Atributo.SABEDORIA]: { name: Atributo.SABEDORIA, value: 0, mod: 0 },
+    [Atributo.CARISMA]: { name: Atributo.CARISMA, value: 0, mod: 0 },
+  } as unknown as CharacterAttributes;
+
+  const renderRow = (equipment: Equipment, onRowClick: () => void) =>
+    render(
+      <div onClick={onRowClick} role='presentation'>
+        <Weapon
+          equipment={equipment}
+          completeSkills={[]}
+          atributos={atributos}
+          nivel={1}
+        />
+      </div>
+    );
+
+  const espada = (extra: Partial<Equipment> = {}): Equipment => ({
+    ..._.cloneDeep(Armas.ESPADA_LONGA),
+    id: 'espada',
+    ...extra,
+  });
+
+  let onRowClick: () => void;
+  beforeEach(() => {
+    onRowClick = vi.fn();
+  });
+
+  it('arma sem edição manual: clicar no dano propaga para a linha', () => {
+    renderRow(espada(), onRowClick);
+
+    fireEvent.click(screen.getByText(/1d8/));
+
+    expect(onRowClick).toHaveBeenCalled();
+  });
+
+  it('arma com edição manual: clicar na estatística marcada ainda propaga', () => {
+    renderRow(
+      espada({ hasManualEdits: true, manualStatFields: ['dano'] }),
+      onRowClick
+    );
+
+    fireEvent.click(screen.getByText(/1d8/));
+
+    expect(onRowClick).toHaveBeenCalled();
+  });
+
+  it('item salvo antes da marcação (grupo inteiro) não vira zona morta', () => {
+    // Sem `manualStatFields`, `getManualStatFields` devolve o grupo todo —
+    // ataque, dano e crítico ficam marcados na mesma linha.
+    renderRow(espada({ hasManualEdits: true }), onRowClick);
+
+    fireEvent.click(screen.getByText(/1d8/));
+
+    expect(onRowClick).toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/weaponManualStatMark.spec.tsx
+++ b/src/components/__tests__/weaponManualStatMark.spec.tsx
@@ -131,4 +131,47 @@ describe('Weapon — marcação de estatística editada à mão', () => {
       expect(onRowClick).not.toHaveBeenCalled();
     });
   });
+
+  /**
+   * A linha é um flex container, e nele cada trecho de texto contíguo vira um
+   * item anônimo. Com as marcas de edição manual quebrando o texto em vários
+   * elementos, os `•` e os parênteses do crítico viravam itens próprios e
+   * quebravam linha soltos dos números (visível no mobile). Cada valor e seus
+   * acompanhantes precisam viver num mesmo nó `nowrap`.
+   */
+  describe('agrupamento das estatísticas', () => {
+    it('o crítico viaja junto do separador e dos parênteses', () => {
+      const { container } = renderRow(
+        espada({ hasManualEdits: true, manualStatFields: ['critico'] }),
+        onRowClick
+      );
+
+      // Um único nó carrega separador + parênteses + valor, então nenhuma
+      // quebra de linha consegue separá-los.
+      const grupos = Array.from(container.querySelectorAll('span')).filter(
+        (el) => (el.textContent ?? '').trim() === '• (19)'
+      );
+
+      expect(grupos.length).toBeGreaterThan(0);
+    });
+
+    it('nenhum separador vira item flex solto na linha', () => {
+      const { container } = renderRow(
+        espada({ hasManualEdits: true }),
+        onRowClick
+      );
+
+      // A linha é `display: flex`, e nela cada trecho de TEXTO CRU contíguo
+      // vira um item anônimo que encolhe e quebra por conta própria. Era assim
+      // que `•`, `(` e `)` se soltavam dos números. Nenhum filho direto da
+      // linha pode ser um texto solto de separadores.
+      const linha = container.querySelector('p');
+      const textosSoltos = Array.from(linha?.childNodes ?? [])
+        .filter((no) => no.nodeType === Node.TEXT_NODE)
+        .map((no) => (no.textContent ?? '').trim())
+        .filter((texto) => texto.length > 0);
+
+      expect(textosSoltos.filter((t) => /[•()·]/.test(t))).toEqual([]);
+    });
+  });
 });

--- a/src/data/systems/tormenta20/herois-de-arton/variantClasses/duelista.ts
+++ b/src/data/systems/tormenta20/herois-de-arton/variantClasses/duelista.ts
@@ -1,6 +1,7 @@
 import { VariantClassOverrides } from '../../../../../interfaces/Class';
 import Skill from '../../../../../interfaces/Skills';
 import BUCANEIRO from '../../classes/bucaneiro';
+import PROFICIENCIAS from '../../proficiencias';
 
 const insolencia = BUCANEIRO.abilities.find((a) => a.name === 'Insolência')!;
 const esquivaSagaz = BUCANEIRO.abilities.find(
@@ -57,6 +58,20 @@ const DUELISTA: VariantClassOverrides = {
               {
                 name: 'Escola de Tiro',
                 text: 'Você recebe proficiência com armas de fogo leves e de uma mão. Caso receba essa proficiência novamente, com essas armas você pode usar suas habilidades de bucaneiro normalmente usadas com armas corpo a corpo leves ou ágeis.',
+                // "leves e de uma mão" = toda arma de fogo que não é de duas
+                // mãos (Pistola, Garrucha). Sem isto o personagem continuava
+                // com o −5 de não proficiência e perdia os bônus que exigem
+                // proficiência (ex.: Armas da Ambição, de Valkaria).
+                sheetBonuses: [
+                  {
+                    source: { type: 'class', className: 'Duelista' },
+                    target: {
+                      type: 'Proficiency',
+                      proficiency: PROFICIENCIAS.FOGO_UMA_MAO,
+                    },
+                    modifier: { type: 'Fixed', value: 1 },
+                  },
+                ],
               },
             ],
           },

--- a/src/data/systems/tormenta20/proficiencias.ts
+++ b/src/data/systems/tormenta20/proficiencias.ts
@@ -6,6 +6,9 @@ const PROFICIENCIAS = {
   PESADAS: 'Armaduras Pesadas',
   SIMPLES: 'Armas Simples',
   FOGO: 'Armas de Fogo',
+  // Escola de Tiro (Duelista): "armas de fogo leves e de uma mão" — na tabela
+  // de armas, tudo que é de fogo e não é de duas mãos (Pistola, Garrucha).
+  FOGO_UMA_MAO: 'Armas de Fogo de Uma Mão',
   EXOTICAS: 'Armas Exóticas',
 };
 

--- a/src/functions/__tests__/armasDaAmbicao.spec.ts
+++ b/src/functions/__tests__/armasDaAmbicao.spec.ts
@@ -7,6 +7,7 @@ import Bag from '../../interfaces/Bag';
 import Skill from '../../interfaces/Skills';
 import GRANTED_POWERS from '../../data/systems/tormenta20/powers/grantedPowers';
 import VALKARIA from '../../data/systems/tormenta20/divindades/valkaria';
+import { Armas } from '../../data/systems/tormenta20/equipamentos';
 
 /**
  * Cobre o poder concedido "Armas da Ambição" (Valkaria): o +1 em testes de
@@ -120,5 +121,50 @@ describe('Armas da Ambição', () => {
     normalizeSheet(sheet);
 
     expect(sheet.devoto?.poderes[0]).toEqual(homebrewPower);
+  });
+
+  /**
+   * "com armas nas quais é proficiente": numa arma de fogo (Pistola) o +1 de
+   * margem só vale se a ficha tiver a proficiência Armas de Fogo. Relatado como
+   * bug ("Armas da Ambição não muda a margem da pistola") — é a regra, e o
+   * tooltip da arma passou a dizer que o bônus está inativo.
+   */
+  describe('arma de fogo (Pistola)', () => {
+    const mkPistolaSheet = (proficiente: boolean): CharacterSheet => {
+      const sheet = mkDevotoSheet();
+      sheet.bag = new Bag({
+        Arma: [{ ..._.cloneDeep(Armas.PISTOLA), id: WID }],
+      });
+      // Clonar a classe: `createMockCharacterSheet` devolve um objeto de classe
+      // COMPARTILHADO entre os testes — mexer nas proficiências in loco vazaria
+      // a de Armas de Fogo para os casos seguintes.
+      sheet.classe = {
+        ...sheet.classe,
+        proficiencias: [
+          ...(sheet.classe.proficiencias ?? []),
+          ...(proficiente ? ['Armas de Fogo'] : []),
+        ],
+      };
+      return sheet;
+    };
+
+    const criticoOf = (sheet: CharacterSheet) =>
+      recalculateSheet(sheet).bag.equipments.Arma.find((w) => w.id === WID)
+        ?.critico;
+
+    it('sem proficiência em Armas de Fogo, a margem não muda', () => {
+      expect(criticoOf(mkPistolaSheet(false))).toBe('19/x3');
+    });
+
+    it('com proficiência em Armas de Fogo, a margem estreita (19 → 18)', () => {
+      expect(criticoOf(mkPistolaSheet(true))).toBe('18/x3');
+    });
+
+    it('a modificação Maciça sobe o multiplicador, não a margem', () => {
+      const sheet = mkPistolaSheet(false);
+      sheet.bag.equipments.Arma[0].modifications = [{ mod: 'Maciça' }];
+
+      expect(criticoOf(sheet)).toBe('19/x4');
+    });
   });
 });

--- a/src/functions/__tests__/duelistaEscolaDeTiro.spec.ts
+++ b/src/functions/__tests__/duelistaEscolaDeTiro.spec.ts
@@ -1,0 +1,79 @@
+import _ from 'lodash';
+import { recalculateSheet } from '../recalculateSheet';
+import { createMockCharacterSheet } from '../../__mocks__/characterSheet';
+import CharacterSheet from '../../interfaces/CharacterSheet';
+import { ClassDescription } from '../../interfaces/Class';
+import Bag from '../../interfaces/Bag';
+import { dataRegistry } from '../../data/registry';
+import { SupplementId } from '../../types/supplement.types';
+import { Armas } from '../../data/systems/tormenta20/equipamentos';
+import { getSheetProficiencias } from '../proficiencies';
+import PROFICIENCIAS from '../../data/systems/tormenta20/proficiencias';
+import GRANTED_POWERS from '../../data/systems/tormenta20/powers/grantedPowers';
+import VALKARIA from '../../data/systems/tormenta20/divindades/valkaria';
+
+/**
+ * Escola de Tiro (Duelista, 2º nível): "você recebe proficiência com armas de
+ * fogo leves e de uma mão". A escolha era só texto — o personagem seguia com o
+ * −5 de não proficiência na pistola e perdia os bônus que exigem proficiência
+ * (Armas da Ambição, de Valkaria, foi como o problema apareceu).
+ */
+describe('Duelista — Escola de Tiro', () => {
+  const duelista = (): ClassDescription => {
+    const classe = dataRegistry
+      .getClassesBySupplements([
+        SupplementId.TORMENTA20_CORE,
+        SupplementId.TORMENTA20_HEROIS_ARTON,
+      ])
+      .find((c) => c.name === 'Duelista');
+    if (!classe) throw new Error('Duelista não encontrado no registry');
+    return _.cloneDeep(classe);
+  };
+
+  const mkSheet = (escola: string): CharacterSheet => {
+    const sheet = createMockCharacterSheet();
+    sheet.nivel = 5;
+    sheet.classe = duelista();
+    sheet.optionChoices = { escolaDeDuelo: [escola] };
+    sheet.bag = new Bag({
+      Arma: [
+        { ..._.cloneDeep(Armas.PISTOLA), id: 'pistola' },
+        { ..._.cloneDeep(Armas.MOSQUETE), id: 'mosquete' },
+      ],
+    });
+    sheet.sheetBonuses = [];
+    sheet.sheetActionHistory = [];
+    return sheet;
+  };
+
+  it('concede a proficiência com armas de fogo de uma mão', () => {
+    const profs = getSheetProficiencias(
+      recalculateSheet(mkSheet('Escola de Tiro'))
+    );
+
+    expect(profs).toContain(PROFICIENCIAS.FOGO_UMA_MAO);
+  });
+
+  it('outra escola de duelo não concede a proficiência', () => {
+    const profs = getSheetProficiencias(
+      recalculateSheet(mkSheet('Escola Clássica'))
+    );
+
+    expect(profs).not.toContain(PROFICIENCIAS.FOGO_UMA_MAO);
+  });
+
+  it('Armas da Ambição passa a valer na pistola, mas não no mosquete', () => {
+    const sheet = mkSheet('Escola de Tiro');
+    sheet.devoto = {
+      divindade: _.cloneDeep(VALKARIA),
+      poderes: [_.cloneDeep(GRANTED_POWERS.ARMAS_DA_AMBICAO)],
+    };
+
+    const armas = recalculateSheet(sheet).bag.equipments.Arma;
+
+    // Pistola: uma mão → coberta pela Escola de Tiro (19 → 18).
+    expect(armas.find((w) => w.id === 'pistola')?.critico).toBe('18/x3');
+    // Mosquete: duas mãos → segue sem proficiência.
+    expect(armas.find((w) => w.id === 'mosquete')?.critico).toBe('19/x3');
+  });
+});

--- a/src/functions/__tests__/duelistaEscolaDeTiro.spec.ts
+++ b/src/functions/__tests__/duelistaEscolaDeTiro.spec.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import generateRandomSheet from '../general';
 import { recalculateSheet } from '../recalculateSheet';
 import { createMockCharacterSheet } from '../../__mocks__/characterSheet';
 import CharacterSheet from '../../interfaces/CharacterSheet';
@@ -7,7 +8,10 @@ import Bag from '../../interfaces/Bag';
 import { dataRegistry } from '../../data/registry';
 import { SupplementId } from '../../types/supplement.types';
 import { Armas } from '../../data/systems/tormenta20/equipamentos';
-import { getSheetProficiencias } from '../proficiencies';
+import {
+  getSheetProficiencias,
+  isProficientWithWeapon,
+} from '../proficiencies';
 import PROFICIENCIAS from '../../data/systems/tormenta20/proficiencias';
 import GRANTED_POWERS from '../../data/systems/tormenta20/powers/grantedPowers';
 import VALKARIA from '../../data/systems/tormenta20/divindades/valkaria';
@@ -75,5 +79,74 @@ describe('Duelista — Escola de Tiro', () => {
     expect(armas.find((w) => w.id === 'pistola')?.critico).toBe('18/x3');
     // Mosquete: duas mãos → segue sem proficiência.
     expect(armas.find((w) => w.id === 'mosquete')?.critico).toBe('19/x3');
+  });
+
+  it('Mosquete legado (sem `twoHanded` gravado) segue não proficiente', () => {
+    // `twoHanded` só existe no catálogo desde 02/05/2026 e
+    // `refreshBagItemsFromCatalog` não o recarimba: uma cópia antiga na mochila
+    // chega sem o campo e passaria como arma de uma mão. O fallback por nome
+    // fecha isso.
+    const mosqueteLegado = _.cloneDeep(Armas.MOSQUETE);
+    delete (mosqueteLegado as { twoHanded?: boolean }).twoHanded;
+
+    expect(
+      isProficientWithWeapon(mosqueteLegado, [PROFICIENCIAS.FOGO_UMA_MAO])
+    ).toBe(false);
+    // E a pistola legada continua coberta.
+    const pistolaLegada = _.cloneDeep(Armas.PISTOLA);
+    delete (pistolaLegada as { twoHanded?: boolean }).twoHanded;
+    expect(
+      isProficientWithWeapon(pistolaLegada, [PROFICIENCIAS.FOGO_UMA_MAO])
+    ).toBe(true);
+  });
+
+  /**
+   * A ficha aleatória não passa por `recalculateSheet`: `generateRandomSheet`
+   * termina em `applyStatModifiers`, e `chooseFromOptions` empurra o bônus da
+   * escola direto para `sheet.sheetBonuses`. Sem um ramo `Proficiency` lá, o
+   * Duelista sorteado com Escola de Tiro (1 em 3) ficava com o −5 na pistola
+   * até algum recálculo posterior curar a ficha.
+   */
+  describe('caminho de geração aleatória', () => {
+    // O sorteio da escola é aleatório; tenta até sair a que interessa em vez
+    // de fixar semente (a geração não expõe uma).
+    const gerarComEscolaDeTiro = (): CharacterSheet | null => {
+      for (let i = 0; i < 60; i += 1) {
+        const sheet = generateRandomSheet({
+          nivel: 5,
+          raca: 'Humano',
+          classe: 'Duelista',
+          origin: '',
+          devocao: { label: '', value: '' },
+          supplements: [
+            SupplementId.TORMENTA20_CORE,
+            SupplementId.TORMENTA20_HEROIS_ARTON,
+          ],
+        });
+        if (sheet.optionChoices?.escolaDeDuelo?.includes('Escola de Tiro')) {
+          return sheet;
+        }
+      }
+      return null;
+    };
+
+    it('aplica a proficiência sem depender de um recálculo posterior', () => {
+      const sheet = gerarComEscolaDeTiro();
+      // 60 tentativas com 1 em 3 de chance: só um sorteio absurdo chega aqui
+      // nulo, e nesse caso é melhor falhar do que passar sem afirmar nada.
+      expect(sheet).not.toBeNull();
+      if (!sheet) return;
+
+      const profs = getSheetProficiencias(sheet);
+      expect(profs).toContain(PROFICIENCIAS.FOGO_UMA_MAO);
+
+      // E a proficiência de fato cobre a pistola — sem o ramo `Proficiency` em
+      // `applyStatModifiers` a arma seguia com o −5. (O recorte "só uma mão"
+      // é afirmado nos testes determinísticos acima: aqui a ficha é sorteada e
+      // pode ganhar 'Armas de Fogo' por outro caminho.)
+      expect(isProficientWithWeapon(_.cloneDeep(Armas.PISTOLA), profs)).toBe(
+        true
+      );
+    });
   });
 });

--- a/src/functions/__tests__/manualStats.spec.ts
+++ b/src/functions/__tests__/manualStats.spec.ts
@@ -1,0 +1,57 @@
+import Equipment from '../../interfaces/Equipment';
+import { getManualStatFields } from '../manualStats';
+
+/**
+ * Quais estatísticas a ficha marca como "modificado manualmente". A flag
+ * `hasManualEdits` congela o grupo inteiro no motor; a lista é só para a
+ * marcação visual — e precisa degradar bem no item salvo antes dela existir.
+ */
+describe('getManualStatFields', () => {
+  const espada: Equipment = {
+    nome: 'Espada Longa',
+    group: 'Arma',
+    dano: '1d8',
+    critico: 'x2',
+  };
+
+  it('item sem edição manual não marca nada', () => {
+    expect(getManualStatFields(espada).size).toBe(0);
+    // A lista sozinha não vale: quem manda no congelamento é a flag.
+    expect(
+      getManualStatFields({ ...espada, manualStatFields: ['dano'] }).size
+    ).toBe(0);
+  });
+
+  it('marca apenas os campos da lista', () => {
+    const item: Equipment = {
+      ...espada,
+      hasManualEdits: true,
+      manualStatFields: ['critico'],
+    };
+
+    expect([...getManualStatFields(item)]).toEqual(['critico']);
+  });
+
+  it('item legado (flag sem lista) marca o grupo da arma', () => {
+    const item: Equipment = { ...espada, hasManualEdits: true };
+
+    expect([...getManualStatFields(item)]).toEqual([
+      'dano',
+      'atkBonus',
+      'critico',
+    ]);
+  });
+
+  it('item legado de defesa marca o grupo de defesa', () => {
+    const item: Equipment = {
+      nome: 'Brunea',
+      group: 'Armadura',
+      hasManualEdits: true,
+    };
+
+    expect([...getManualStatFields(item)]).toEqual([
+      'defenseBonus',
+      'armorPenalty',
+    ]);
+  });
+});

--- a/src/functions/__tests__/weaponBonusScope.spec.ts
+++ b/src/functions/__tests__/weaponBonusScope.spec.ts
@@ -425,6 +425,39 @@ describe('isLiveWeaponBonus / sumLiveWeaponBonuses', () => {
     );
   });
 
+  it('bônus com proficiencyRequired some quando a ficha não é proficiente', () => {
+    // Armas da Destruição (Arsenal): +1 no dano "com armas nas quais é
+    // proficiente". Numa arma editada manualmente o bônus não é bakeado pelo
+    // recálculo, então quem tinha que respeitar a proficiência era o caminho
+    // vivo — e ele ignorava a flag.
+    const armasDaDestruicao = [
+      mkBonus({ type: 'WeaponDamage', proficiencyRequired: true }, 1, {
+        type: 'activeEffect',
+        powerKey: 'concedido:armas-da-destruicao',
+        name: 'Armas da Destruição',
+      }),
+    ];
+    const editada: Equipment = { ...espadaLonga, hasManualEdits: true };
+
+    expect(
+      sumLiveWeaponBonuses(editada, armasDaDestruicao, 'WeaponDamage', {
+        ...ctx,
+        isProficient: false,
+      })
+    ).toBe(0);
+    expect(
+      sumLiveWeaponBonuses(editada, armasDaDestruicao, 'WeaponDamage', {
+        ...ctx,
+        isProficient: true,
+      })
+    ).toBe(1);
+    // Sem informação de proficiência (caminhos que não a passam), falha segura:
+    // trata como proficiente.
+    expect(
+      sumLiveWeaponBonuses(editada, armasDaDestruicao, 'WeaponDamage', ctx)
+    ).toBe(1);
+  });
+
   it('escopo que não casa com a arma continua fora, mesmo sendo vivo', () => {
     // Estilo de Duas Mãos: `twoHandedOnly` — a Lança não é de duas mãos.
     const estiloDuasMaos = [

--- a/src/functions/general.ts
+++ b/src/functions/general.ts
@@ -5163,6 +5163,17 @@ export const applyStatModifiers = (
         name: subStepName,
         value: `Modifica atributo de ${skillName} para ${attribute}`,
       });
+    } else if (bonus.target.type === 'Proficiency') {
+      // Espelho do ramo de `applyPower` (e do Step 8 do `recalculateSheet`).
+      // Sem isto, proficiência concedida por escolha de habilidade de classe
+      // (ex.: Escola de Tiro do Duelista, que empurra o bônus direto para
+      // `sheet.sheetBonuses` via `chooseFromOptions`) nunca chegava na ficha
+      // aleatória — que não passa por `recalculateSheet` — e a arma seguia
+      // com o -5 de não-proficiência.
+      const { proficiency } = bonus.target;
+      if (proficiency && !sheet.classe.proficiencias.includes(proficiency)) {
+        sheet.classe.proficiencias.push(proficiency);
+      }
     } else {
       // console.warn('bonus não implementado', bonus);
     }

--- a/src/functions/manualStats.ts
+++ b/src/functions/manualStats.ts
@@ -1,0 +1,24 @@
+import Equipment, { ManualStatField } from '../interfaces/Equipment';
+
+const WEAPON_STAT_FIELDS: ManualStatField[] = ['dano', 'atkBonus', 'critico'];
+const DEFENSE_STAT_FIELDS: ManualStatField[] = ['defenseBonus', 'armorPenalty'];
+
+/**
+ * Estatísticas que o jogador digitou à mão neste item.
+ *
+ * Fonte única da marcação "modificado manualmente" na ficha e do estado inicial
+ * do editor de item. Um item gravado ANTES de `manualStatFields` existir só tem
+ * a flag `hasManualEdits` — aí o grupo inteiro (de arma ou de defesa) conta como
+ * editado, que é o comportamento congelado de fato pelo motor.
+ */
+export function getManualStatFields(
+  item: Equipment
+): ReadonlySet<ManualStatField> {
+  if (!item.hasManualEdits) return new Set();
+  if (item.manualStatFields) return new Set(item.manualStatFields);
+  return new Set(
+    item.group === 'Arma' ? WEAPON_STAT_FIELDS : DEFENSE_STAT_FIELDS
+  );
+}
+
+export default getManualStatFields;

--- a/src/functions/proficiencies.ts
+++ b/src/functions/proficiencies.ts
@@ -101,6 +101,34 @@ const WEAPON_CATEGORY_BY_NAME = new Map<string, WeaponCategory>();
   });
 });
 
+// Mesma história do mapa acima, para `twoHanded`: o campo só existe no catálogo
+// desde 02/05/2026 e `refreshBagItemsFromCatalog` não o recarimba, então um
+// Mosquete copiado para a mochila antes disso chega aqui sem ele — e passaria
+// como arma de uma mão para 'Armas de Fogo de Uma Mão'.
+const WEAPON_TWO_HANDED_BY_NAME = new Map<string, boolean>();
+(
+  [
+    ...EQUIPAMENTOS.armasSimples,
+    ...EQUIPAMENTOS.armasMarciais,
+    ...EQUIPAMENTOS.armasExoticas,
+    ...EQUIPAMENTOS.armasDeFogo,
+    ...Object.values(AMEACAS_ARTON_WEAPONS),
+    ...Object.values(HEROIS_ARTON_WEAPONS),
+  ] as Equipment[]
+).forEach((weapon) => {
+  WEAPON_TWO_HANDED_BY_NAME.set(weapon.nome, Boolean(weapon.twoHanded));
+});
+
+/**
+ * `twoHanded` da arma, com fallback pelo catálogo para cópias legadas gravadas
+ * antes do campo existir. Mantém o `false` explícito do item quando ele traz o
+ * campo — override manual do usuário vence o catálogo.
+ */
+function isTwoHandedWeapon(weapon: Equipment): boolean {
+  if (weapon.twoHanded !== undefined) return weapon.twoHanded;
+  return WEAPON_TWO_HANDED_BY_NAME.get(weapon.nome) ?? false;
+}
+
 /** Categoria de catálogo de uma arma pelo nome (core + suplementos). */
 export function getCatalogWeaponCategoryByName(
   nome: string
@@ -177,7 +205,8 @@ export function isProficientWithWeapon(
   // Tiro do Duelista) cobre as que não são de duas mãos.
   if (proficiencias.includes(PROFICIENCIAS.FOGO)) return true;
   return (
-    !weapon.twoHanded && proficiencias.includes(PROFICIENCIAS.FOGO_UMA_MAO)
+    !isTwoHandedWeapon(weapon) &&
+    proficiencias.includes(PROFICIENCIAS.FOGO_UMA_MAO)
   );
 }
 

--- a/src/functions/proficiencies.ts
+++ b/src/functions/proficiencies.ts
@@ -143,7 +143,8 @@ const normalizeProficiencyName = (value: unknown): string =>
  * - Marciais: exigem 'Armas Marciais'; se a arma tem alcance (incluindo
  *   arremesso), 'Armas Marciais de Distância' também satisfaz. A proficiência
  *   é da arma, não do modo de ataque — vale igualmente em Luta e Pontaria.
- * - Exóticas: exigem 'Armas Exóticas'. De fogo: exigem 'Armas de Fogo'.
+ * - Exóticas: exigem 'Armas Exóticas'. De fogo: exigem 'Armas de Fogo' — ou,
+ *   se não forem de duas mãos, 'Armas de Fogo de Uma Mão' (Escola de Tiro).
  * - Sem categoria resolvível (custom/homebrew): proficiente (falha segura).
  *
  * Use `getSheetProficiencias(sheet)` para obter a lista efetiva da ficha.
@@ -172,7 +173,12 @@ export function isProficientWithWeapon(
   }
   if (category === 'exotic')
     return proficiencias.includes(PROFICIENCIAS.EXOTICAS);
-  return proficiencias.includes(PROFICIENCIAS.FOGO);
+  // De fogo: 'Armas de Fogo' cobre todas; 'Armas de Fogo de Uma Mão' (Escola de
+  // Tiro do Duelista) cobre as que não são de duas mãos.
+  if (proficiencias.includes(PROFICIENCIAS.FOGO)) return true;
+  return (
+    !weapon.twoHanded && proficiencias.includes(PROFICIENCIAS.FOGO_UMA_MAO)
+  );
 }
 
 /** Penalidade de não proficiência da arma: 0 ou -5 nos testes de ataque. */

--- a/src/functions/weaponBonusScope.ts
+++ b/src/functions/weaponBonusScope.ts
@@ -245,6 +245,13 @@ export interface LiveWeaponBonusContext {
    * exibição é o modo corpo a corpo, coerente com `getWeaponSkill`.
    */
   thrownMode?: boolean;
+  /**
+   * O personagem é proficiente com esta arma? Bônus marcados com
+   * `proficiencyRequired` (Armas da Ambição, Armas da Destruição) só valem
+   * quando `true`. `undefined` = quem chamou não sabe → trata como proficiente,
+   * mesma falha segura de `isProficientWithWeapon` para arma sem categoria.
+   */
+  isProficient?: boolean;
 }
 
 /**
@@ -268,9 +275,14 @@ export function sumLiveWeaponBonuses(
 
   return bonuses.reduce((sum, bonus) => {
     if (bonus.target.type !== targetType) return sum;
-    const scope = bonus.target as WeaponBonusScope;
+    const scope = bonus.target as WeaponBonusScope & {
+      proficiencyRequired?: boolean;
+    };
     if (!isLiveWeaponBonus(weapon, scope, bonus.source.type)) return sum;
     if (!weaponMatchesScope(weapon, scope)) return sum;
+    // Espelha a checagem de `weaponMatchesBonus` (recalculateSheet): sem ela o
+    // caminho vivo aplicaria um bônus que o baking recusa.
+    if (scope.proficiencyRequired && ctx.isProficient === false) return sum;
 
     if (isModeScopedForWeapon(weapon, scope)) {
       const appliesInMode = thrown

--- a/src/interfaces/Equipment.ts
+++ b/src/interfaces/Equipment.ts
@@ -214,6 +214,18 @@ export interface WeaponActionTrigger {
 
 export type WeaponCategory = 'simple' | 'martial' | 'exotic' | 'firearm';
 
+/**
+ * Estatísticas de combate que o jogador pode sobrescrever no editor de item.
+ * `spaces` fica de fora de propósito: tem a sua própria flag
+ * (`hasManualSpaces`) e não pertence ao grupo congelado por `hasManualEdits`.
+ */
+export type ManualStatField =
+  | 'dano'
+  | 'atkBonus'
+  | 'critico'
+  | 'defenseBonus'
+  | 'armorPenalty';
+
 export interface WeaponAction {
   id: string;
   label: string;
@@ -276,6 +288,17 @@ export default interface Equipment {
   // Flag to indicate if this weapon has manual user edits
   // When true, recalculateSheet will preserve user edits instead of resetting
   hasManualEdits?: boolean;
+
+  /**
+   * QUAIS estatísticas o jogador digitou à mão. `hasManualEdits` congela o
+   * grupo inteiro (é o que o motor precisa saber), mas a ficha marca só o campo
+   * de fato editado — daí a lista.
+   *
+   * Ausente num item com `hasManualEdits` = item gravado antes deste campo
+   * existir: nesse caso todo o grupo é tratado como editado (ver
+   * `getManualStatFields`).
+   */
+  manualStatFields?: ManualStatField[];
 
   /**
    * O jogador editou `spaces` à mão — o pipeline de aprimoramentos para de


### PR DESCRIPTION
## 📋 Descrição
Ver: https://fichasdenimb.com.br/forum/buffs-nao-sendo-aplicados

Relato: nem a melhoria **Maciça** nem **Armas da Ambição** mudavam o crítico de uma pistola. Investigando, o motor de crítico estava certo — eram três causas distintas.

- **Escola de Tiro (Duelista) não concedia proficiência nenhuma** — a opção era só texto, então o personagem seguia com o −5 na pistola e perdia os bônus que exigem proficiência. Nova proficiência `Armas de Fogo de Uma Mão`, que cobre arma de fogo não-duas-mãos (Pistola, Garrucha; não Mosquete/Canhão portátil/Sifão).
- **Tooltip ✨ da arma prometia bônus que não valiam** — bônus com `proficiencyRequired` eram listados mesmo sem proficiência, enquanto o número não mudava. Agora aparecem no fim, marcados `(inativo: sem proficiência)`.
- **`sumLiveWeaponBonuses` ignorava `proficiencyRequired`** — o caminho que soma bônus na hora de exibir (usado em modo de arremesso e efeitos ativos sobre arma editada à mão) não checava proficiência, divergindo do cálculo principal. Passa a receber `isProficient`; sem informação, segue tratando como proficiente.
- **Bônus de multiplicador de crítico passam a aparecer no tooltip** — Armas da Destruição (Arsenal) era invisível na ficha.
- **Aviso no editor de item** quando dano/ataque/crítico estão travados por edição manual: nesse estado melhorias e bônus de poder não mexem nos números, e a única pista era o botão "Resetar" resolver.
- **Marcação por campo na linha da arma** — a estatística editada à mão fica sublinhada em pontilhado, com tooltip "Modificado manualmente". Para isso o item grava `manualStatFields` além de `hasManualEdits`: a flag continua congelando o grupo (é o que o motor lê), a lista diz o que foi digitado. Item salvo antes disso marca o grupo inteiro.

Comportamento do motor de crítico e do baking: inalterado. Maciça continua subindo o multiplicador (`19/x3` → `19/x4`), não a margem — quem mexe na margem é a Precisa.

## 🔁 Depois do review

Os dois bloqueadores do @YuriAlessandro, mais as duas ressalvas técnicas:

- **Clique do ataque voltou nas estatísticas marcadas** (`85b2f2bb`) — o `stopPropagation` da marca manual comia o gesto principal da linha. Como item salvo antes deste PR cai no fallback "grupo inteiro", isso atingia toda arma já editada à mão. Ficou só o sublinhado e o tooltip; o `stopPropagation` continua nos ícones, que são afordâncias auxiliares.
- **Proficiência agora chega na geração aleatória** (`85b2f2bb`) — `applyStatModifiers` ganhou o ramo `Proficiency`, espelhando `applyPower` e o Step 8 do `recalculateSheet`. Sem ele o Duelista sorteado com Escola de Tiro (1 em 3) ficava com o −5 na pistola até um recálculo posterior curar a ficha.
- **`twoHanded` legado resolvido pelo catálogo** (`85b2f2bb`) — cópia de arma gravada antes de o campo existir (e não recarimbada por `refreshBagItemsFromCatalog`) passava como arma de uma mão. Fallback por nome, no mesmo molde do `getEffectiveWeaponCategory`; override explícito do item continua vencendo.
- **`Weapon.tsx` deixou de estar sem teste** — novo `weaponManualStatMark.spec.tsx`.

Duas coisas apareceram ao arrumar a primeira:

- **Explicação da marca acessível no mobile** (`16faad18`) — sem hover, o tooltip do MUI só abre com long-press, e ele não cancela o clique sintético que vem depois: o gesto abriria a explicação **e** rolaria o ataque. O tooltip do sublinhado virou `disableTouchListener` (só hover), e a explicação ganhou um ícone próprio no fim da linha, que para a propagação, abre no primeiro toque e lista quais estatísticas estão marcadas — útil no caso do item legado, em que o grupo inteiro conta como editado.
- **Estatísticas não quebram mais linha soltas** (`c0f54bfb`) — a linha é `display: flex`, e nela cada trecho de texto contíguo vira um item anônimo. Enquanto `+2 • 1d8 • (19)` era um texto só isso não aparecia, mas a marca de edição manual picota o texto em vários elementos, e o `•`, o `(` e o `)` viravam itens próprios que encolhiam e quebravam por conta. No mobile os separadores flutuavam desalinhados dos números. As estatísticas passam a viver num único item flex, com cada valor e seus acompanhantes num grupo `nowrap`, e o separador viajando junto do valor que introduz.

Sobre separar a marcação de edição manual num PR próprio: mantido aqui a pedido, para não reescrever a branch.

## 🎯 Tipo de Mudança

- [x] Bug fix
- [x] Nova funcionalidade
- [ ] Melhoria de código
- [ ] Documentação

## 🧪 Testes

- [x] Testes passando (2847)
- [x] Novos testes adicionados
- [x] Testado manualmente

Novos: `duelistaEscolaDeTiro.spec.ts`, `manualStats.spec.ts`, `weaponManualStatMark.spec.tsx`, casos em `armasDaAmbicao.spec.ts`, `weaponBonusScope.spec.ts` e `itemEditorSave.spec.ts`. `tsc`, `eslint` e `npm run build` limpos.

Cada teste novo dos commits de review foi verificado revertendo o código correspondente: todos falham sem a correção.

⚠️ Limite da verificação: os testes de toque rodam em jsdom, que não simula a sequência `touchstart → 700ms → touchend → click` de um browser real. O comportamento de long-press vem da leitura do fonte do MUI (`Tooltip.js`, `handleTouchStart`/`handleTouchEnd` não chamam `preventDefault`), e o resultado visual do agrupamento das estatísticas não foi conferido em device — vale abrir uma arma editada à mão no celular antes do merge.

## ⚠️ Nota

Fichas de Duelista **salvas antes** deste PR carregam a definição antiga da classe (`abilities` da ficha vence a do registry no rehydrate), então não recebem a proficiência sozinhas — dá para marcar "Armas de Fogo de Uma Mão" no editor de proficiências. Um refresh automático de habilidades de classe stale no `sheetNormalizer` resolveria isso de forma geral; ficou de fora deste PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
