### PR TITLE
fix(armas): margem de crítico sem multiplicador lida como multiplicador

### DIFF
--- a/src/functions/itemEnhancements/core.ts
+++ b/src/functions/itemEnhancements/core.ts
@@ -302,19 +302,33 @@ interface ParsedCritico {
   mult: number;
 }
 
-function parseCritico(c: string): ParsedCritico {
-  const trimmed = (c || '').trim();
-  const slashIdx = trimmed.indexOf('/');
-  if (slashIdx >= 0) {
-    const threat = parseInt(trimmed.substring(0, slashIdx), 10);
-    const multStr = trimmed.substring(slashIdx + 1).replace(/^x/i, '');
+/**
+ * Formatos aceitos (os mesmos de `parseCritical` em `diceRoller`):
+ *   "19/x3" → margem 19, multiplicador 3
+ *   "x3"    → margem 20, multiplicador 3
+ *   "19"    → margem 19, multiplicador 2  (o `x` é obrigatório para multiplicador)
+ * Retorna `null` para strings sem crítico ("-", "**", vazio) ou não
+ * reconhecidas, para que os ajustes devolvam a string original intacta.
+ */
+function parseCritico(c: string): ParsedCritico | null {
+  const trimmed = (c || '').trim().toLowerCase();
+
+  const fullMatch = trimmed.match(/^(\d+)\/x(\d+)$/);
+  if (fullMatch) {
     return {
-      threat: Number.isFinite(threat) ? threat : 20,
-      mult: parseInt(multStr, 10) || 2,
+      threat: parseInt(fullMatch[1], 10),
+      mult: parseInt(fullMatch[2], 10),
     };
   }
-  const multStr = trimmed.replace(/^x/i, '');
-  return { threat: 20, mult: parseInt(multStr, 10) || 2 };
+
+  const multMatch = trimmed.match(/^x(\d+)$/);
+  if (multMatch) return { threat: 20, mult: parseInt(multMatch[1], 10) };
+
+  // Só a margem: "19" é 19/x2, NUNCA multiplicador x19.
+  const threatMatch = trimmed.match(/^(\d+)$/);
+  if (threatMatch) return { threat: parseInt(threatMatch[1], 10), mult: 2 };
+
+  return null;
 }
 
 function formatCritico({ threat, mult }: ParsedCritico): string {
@@ -324,6 +338,7 @@ function formatCritico({ threat, mult }: ParsedCritico): string {
 
 export function adjustCriticoMult(c: string, delta: number): string {
   const parsed = parseCritico(c);
+  if (!parsed) return c;
   return formatCritico({
     ...parsed,
     mult: Math.max(2, parsed.mult + delta),
@@ -336,6 +351,7 @@ export function adjustCriticoMult(c: string, delta: number): string {
  */
 export function adjustCriticoThreat(c: string, delta: number): string {
   const parsed = parseCritico(c);
+  if (!parsed) return c;
   return formatCritico({
     ...parsed,
     threat: Math.min(20, parsed.threat - delta),
@@ -349,6 +365,7 @@ export function adjustCriticoThreat(c: string, delta: number): string {
  */
 export function doubleCriticoThreatMargin(c: string): string {
   const parsed = parseCritico(c);
+  if (!parsed) return c;
   const margin = 21 - parsed.threat;
   const newThreat = Math.max(2, 21 - margin * 2);
   return formatCritico({ ...parsed, threat: newThreat });

--- a/src/functions/modifications/__tests__/applyModifications.spec.ts
+++ b/src/functions/modifications/__tests__/applyModifications.spec.ts
@@ -37,6 +37,16 @@ describe('adjustCriticoMult', () => {
   test('does not drop below x2', () => {
     expect(adjustCriticoMult('x2', -5)).toBe('x2');
   });
+
+  // Regressão: "19" é margem de ameaça com multiplicador x2 implícito (Besta
+  // pesada), não multiplicador x19 — Maciça precisa levá-la a 19/x3.
+  test('treats a bare number as the threat range, not the multiplier', () => {
+    expect(adjustCriticoMult('19', 1)).toBe('19/x3');
+  });
+
+  test('leaves a weapon without critical untouched', () => {
+    expect(adjustCriticoMult('-', 1)).toBe('-');
+  });
 });
 
 describe('adjustCriticoThreat', () => {
@@ -46,6 +56,30 @@ describe('adjustCriticoThreat', () => {
 
   test('widens an explicit threat range', () => {
     expect(adjustCriticoThreat('18/x2', 1)).toBe('17/x2');
+  });
+
+  test('widens a bare threat range', () => {
+    expect(adjustCriticoThreat('19', 1)).toBe('18/x2');
+  });
+
+  test('leaves a weapon without critical untouched', () => {
+    expect(adjustCriticoThreat('-', 1)).toBe('-');
+  });
+});
+
+describe('Maciça + Precisa on a bare-threat weapon', () => {
+  test('Besta pesada (19) becomes 18/x3', () => {
+    const besta: Equipment = {
+      nome: 'Besta pesada',
+      group: 'Arma',
+      dano: '1d12',
+      critico: '19',
+      atkBonus: 0,
+      spaces: 2,
+      modifications: [{ mod: 'Maciça' }, { mod: 'Precisa' }],
+    };
+
+    expect(applyModificationsToEquipment(besta).critico).toBe('18/x3');
   });
 });
 


### PR DESCRIPTION
## Problema

Armas cujo crítico é gravado só como margem — `critico: '19'` (Besta pesada, e mais 23 armas), `'18'`, `'17'` — eram lidas pelo `parseCritico` do pipeline de melhorias como **multiplicador** x19. Resultado: Besta pesada + Maciça + Precisa virava `19/x20` em vez de `18/x3`, e o crítico passava a rolar x20 de verdade.

Reportado por usuário.

## Correção

`parseCritico` ([core.ts](../blob/fix/critico-margem-sem-multiplicador/src/functions/itemEnhancements/core.ts)) agora usa os mesmos três formatos do `parseCritical` do `diceRoller`, que já estava certo:

- `19/x3` → margem 19, x3
- `x3` → margem 20, x3 (o `x` é obrigatório para multiplicador)
- `19` → margem 19, x2 implícito

Strings sem crítico (`-`, `**`, vazio) agora voltam intactas dos ajustes, em vez de virarem `x2`.

Testes de regressão cobrindo o caso relatado. Suíte completa passa (2826 testes).

## Fichas existentes

Se corrigem sozinhas no próximo recálculo, já que o pipeline reaplica a partir do `baseCritico` (capturado corretamente). Exceção: itens com `hasManualEdits`, onde o valor errado ficou congelado — nesses o jogador precisa clicar em "Resetar" no editor.

## Fora do escopo

O gerador de recompensas (`equipmentRewardGenerator.ts`) tem uma implementação paralela com tabela hardcoded que também não conhece o formato `'19'`, mas ali ela apenas não casa e devolve a string intacta — é um no-op, não corrompe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)